### PR TITLE
Flightplan Wrapper Gets The Parsed Aircraft Type

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,4 +47,4 @@ into the development environment.
 
 ### Contributing
 
-To contribute to the project, please have a look through our [Contributing Guide](CONTRIBUTING.md).
+To contribute to the project, please have a look at the [Contributing Guide](CONTRIBUTING.md).

--- a/src/euroscope/EuroScopeCFlightPlanWrapper.cpp
+++ b/src/euroscope/EuroScopeCFlightPlanWrapper.cpp
@@ -12,7 +12,7 @@ namespace UKControllerPlugin {
 
         std::string EuroScopeCFlightPlanWrapper::GetAircraftType(void) const
         {
-            return this->originalData.GetFlightPlanData().GetAircraftInfo();
+            return this->originalData.GetFlightPlanData().GetAircraftFPType();
         }
 
         const std::string EuroScopeCFlightPlanWrapper::GetCallsign(void) const


### PR DESCRIPTION
The previous method got the un-parsed string, we now get just the type ignoring any pilot-entered wake categories or type information.