### PR TITLE
Assign circuit squawks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ dynamically to the plugin.
 
 ### Compiling
 
-There are three build configurations available:
+There are two build configurations available:
 
 - Debug: Compile with all debugging symbols for development. Results in decreased performance and an inflated DLL
 - Release: Compile in release mode

--- a/src/euroscope/EuroScopeCFlightPlanInterface.h
+++ b/src/euroscope/EuroScopeCFlightPlanInterface.h
@@ -23,6 +23,7 @@ namespace UKControllerPlugin {
                 virtual std::string GetFlightRules(void) const = 0;
                 virtual std::string GetGroundState(void) const = 0;
                 virtual const std::string GetOrigin(void) const = 0;
+                virtual std::string GetRawRouteString(void) const = 0;
                 virtual const std::string GetSidName(void) const = 0;
                 virtual std::string GetAssignedSquawk(void) const = 0;
                 virtual std::string GetAircraftType(void) const = 0;
@@ -36,6 +37,7 @@ namespace UKControllerPlugin {
                 virtual const bool IsTracked(void) const = 0;
                 virtual const bool IsTrackedByUser(void) const = 0;
                 virtual bool IsValid(void) const = 0;
+                virtual bool IsVfr(void) const = 0;
         };
     }  // namespace Euroscope
 }  // namespace UKControllerPlugin

--- a/src/euroscope/EuroScopeCFlightPlanWrapper.cpp
+++ b/src/euroscope/EuroScopeCFlightPlanWrapper.cpp
@@ -75,6 +75,11 @@ namespace UKControllerPlugin {
             return this->originalData.GetFlightPlanData().GetOrigin();
         }
 
+        std::string EuroScopeCFlightPlanWrapper::GetRawRouteString(void) const
+        {
+            return this->originalData.GetFlightPlanData().GetRoute();
+        }
+
         const std::string EuroScopeCFlightPlanWrapper::GetSidName(void) const
         {
             return this->originalData.GetFlightPlanData().GetSidName();
@@ -146,6 +151,14 @@ namespace UKControllerPlugin {
         bool EuroScopeCFlightPlanWrapper::IsValid(void) const
         {
             return this->originalData.IsValid();
+        }
+
+        /*
+            Returns true if the flightplan is VFR
+        */
+        bool EuroScopeCFlightPlanWrapper::IsVfr(void) const
+        {
+            return strcmp(this->originalData.GetFlightPlanData().GetPlanType(), "V") == 0;
         }
     }  // namespace Euroscope
 }  // namespace UKControllerPlugin

--- a/src/euroscope/EuroScopeCFlightPlanWrapper.h
+++ b/src/euroscope/EuroScopeCFlightPlanWrapper.h
@@ -24,6 +24,7 @@ namespace UKControllerPlugin {
                 std::string GetGroundState(void) const;
                 std::string GetIcaoWakeCategory(void) const override;
                 const std::string GetOrigin(void) const;
+                std::string GetRawRouteString(void) const override;
                 const std::string GetSidName(void) const;
                 bool HasAssignedSquawk(void) const;
                 const bool HasControllerClearedAltitude(void) const;
@@ -32,6 +33,7 @@ namespace UKControllerPlugin {
                 const bool IsTracked(void) const;
                 const bool IsTrackedByUser(void) const;
                 bool IsValid(void) const;
+                bool IsVfr(void) const override;
                 void SetClearedAltitude(int cleared);
                 void SetSquawk(std::string squawk);
 

--- a/src/squawk/SquawkAssignment.cpp
+++ b/src/squawk/SquawkAssignment.cpp
@@ -39,14 +39,18 @@ namespace UKControllerPlugin {
         /*
             Returns whether or not the aircraft is believed to be doing VFR circuits
         */
-        bool SquawkAssignment::CircuitAssignmentNeeded(EuroScopeCFlightPlanInterface & flightplan) const
+        bool SquawkAssignment::CircuitAssignmentNeeded(
+            EuroScopeCFlightPlanInterface & flightplan,
+            EuroScopeCRadarTargetInterface & radarTarget
+        ) const
         {
             return flightplan.IsVfr() &&
                 !flightplan.HasAssignedSquawk() &&
                 std::regex_search(
                     flightplan.GetRawRouteString(),
                     std::regex("^(?:VFR )?CIRCUIT(?:S)?", std::regex::icase)
-                );
+                ) &&
+                this->GeneralAssignmentNeeded(flightplan, radarTarget);
         }
 
         /*

--- a/src/squawk/SquawkAssignment.cpp
+++ b/src/squawk/SquawkAssignment.cpp
@@ -41,7 +41,8 @@ namespace UKControllerPlugin {
         */
         bool SquawkAssignment::CircuitAssignmentNeeded(EuroScopeCFlightPlanInterface & flightplan) const
         {
-            return flightplan.IsVfr() && 
+            return flightplan.IsVfr() &&
+                !flightplan.HasAssignedSquawk() &&
                 std::regex_search(
                     flightplan.GetRawRouteString(),
                     std::regex("^(?:VFR )?CIRCUIT(?:S)?", std::regex::icase)

--- a/src/squawk/SquawkAssignment.cpp
+++ b/src/squawk/SquawkAssignment.cpp
@@ -39,7 +39,7 @@ namespace UKControllerPlugin {
         /*
             Returns whether or not the aircraft is believed to be doing VFR circuits
         */
-        bool SquawkAssignment::CircuitAssignmentNeeded(EuroScopeCFlightPlanInterface & flightplan)
+        bool SquawkAssignment::CircuitAssignmentNeeded(EuroScopeCFlightPlanInterface & flightplan) const
         {
             return flightplan.IsVfr() && 
                 std::regex_search(

--- a/src/squawk/SquawkAssignment.cpp
+++ b/src/squawk/SquawkAssignment.cpp
@@ -37,6 +37,18 @@ namespace UKControllerPlugin {
         }
 
         /*
+            Returns whether or not the aircraft is believed to be doing VFR circuits
+        */
+        bool SquawkAssignment::CircuitAssignmentNeeded(EuroScopeCFlightPlanInterface & flightplan)
+        {
+            return flightplan.IsVfr() && 
+                std::regex_search(
+                    flightplan.GetRawRouteString(),
+                    std::regex("^(?:VFR )?CIRCUIT(?:S)?", std::regex::icase)
+                );
+        }
+
+        /*
             Returns whether or not the controller is in a position that they may force squawk assignment.
         */
         bool SquawkAssignment::ForceAssignmentAllowed(EuroScopeCFlightPlanInterface & flightplan) const

--- a/src/squawk/SquawkAssignment.h
+++ b/src/squawk/SquawkAssignment.h
@@ -34,6 +34,9 @@ namespace UKControllerPlugin {
                     const UKControllerPlugin::Controller::ActiveCallsignCollection & activeCallsigns,
                     const bool disabled
                 );
+                bool CircuitAssignmentNeeded(
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan
+                );
                 bool ForceAssignmentAllowed(
                     UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan
                 ) const;

--- a/src/squawk/SquawkAssignment.h
+++ b/src/squawk/SquawkAssignment.h
@@ -35,7 +35,8 @@ namespace UKControllerPlugin {
                     const bool disabled
                 );
                 bool CircuitAssignmentNeeded(
-                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan,
+                    UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface & radarTarget
                 ) const;
                 bool ForceAssignmentAllowed(
                     UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan

--- a/src/squawk/SquawkAssignment.h
+++ b/src/squawk/SquawkAssignment.h
@@ -36,7 +36,7 @@ namespace UKControllerPlugin {
                 );
                 bool CircuitAssignmentNeeded(
                     UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan
-                );
+                ) const;
                 bool ForceAssignmentAllowed(
                     UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan
                 ) const;

--- a/src/squawk/SquawkEventHandler.cpp
+++ b/src/squawk/SquawkEventHandler.cpp
@@ -77,7 +77,8 @@ namespace UKControllerPlugin {
                 return;
             }
 
-            this->generator.ReassignPreviousSquawkToAircraft(flightplan, radarTarget) ||
+            this->generator.AssignCircuitSquawkForAircraft(flightplan, radarTarget) ||
+                this->generator.ReassignPreviousSquawkToAircraft(flightplan, radarTarget) ||
                 this->generator.RequestLocalSquawkForAircraft(flightplan, radarTarget) ||
                 this->generator.RequestGeneralSquawkForAircraft(flightplan, radarTarget);
         }

--- a/src/squawk/SquawkGenerator.cpp
+++ b/src/squawk/SquawkGenerator.cpp
@@ -43,6 +43,22 @@ namespace UKControllerPlugin {
         }
 
         /*
+            Assigns circuit squawks where appropriate.
+        */
+        bool SquawkGenerator::AssignCircuitSquawkForAircraft(
+            EuroScopeCFlightPlanInterface & flightplan,
+            EuroScopeCRadarTargetInterface & radarTarget
+        ) const
+        {
+            if (this->assignmentRules.disabled || !assignmentRules.CircuitAssignmentNeeded(flightplan)) {
+                return false;
+            }
+
+            flightplan.SetSquawk("7010");
+            return true;
+        }
+
+        /*
             Forces a squawk to be assigned for the given aircraft
         */
         bool SquawkGenerator::ForceGeneralSquawkForAircraft(

--- a/src/squawk/SquawkGenerator.cpp
+++ b/src/squawk/SquawkGenerator.cpp
@@ -54,6 +54,7 @@ namespace UKControllerPlugin {
                 return false;
             }
 
+            LogInfo("Assigned circuit squawk to " + flightplan.GetCallsign());
             flightplan.SetSquawk("7010");
             return true;
         }

--- a/src/squawk/SquawkGenerator.cpp
+++ b/src/squawk/SquawkGenerator.cpp
@@ -240,7 +240,7 @@ namespace UKControllerPlugin {
                 std::string squawk = this->api.GetAssignedSquawk(callsign);
                 this->plugin->GetFlightplanForCallsign(callsign)
                     ->SetSquawk(squawk);
-                LogInfo("Assigned squawk " + squawk + " to " + callsign);
+                LogInfo("Assigned existing squawk " + squawk + " to " + callsign);
                 return true;
             }
             catch (ApiNotFoundException exception) {

--- a/src/squawk/SquawkGenerator.cpp
+++ b/src/squawk/SquawkGenerator.cpp
@@ -50,7 +50,7 @@ namespace UKControllerPlugin {
             EuroScopeCRadarTargetInterface & radarTarget
         ) const
         {
-            if (this->assignmentRules.disabled || !assignmentRules.CircuitAssignmentNeeded(flightplan)) {
+            if (this->assignmentRules.disabled || !assignmentRules.CircuitAssignmentNeeded(flightplan, radarTarget)) {
                 return false;
             }
 

--- a/src/squawk/SquawkGenerator.h
+++ b/src/squawk/SquawkGenerator.h
@@ -40,6 +40,10 @@ namespace UKControllerPlugin {
                     const UKControllerPlugin::Controller::ActiveCallsignCollection & callsigns,
                     const UKControllerPlugin::Flightplan::StoredFlightplanCollection & storedFlightplans
                 );
+                bool AssignCircuitSquawkForAircraft(
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan,
+                    UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface & radarTarget
+                ) const;
                 bool ForceGeneralSquawkForAircraft(
                     UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface & flightplan,
                     UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface & radarTarget

--- a/test/mock/MockEuroScopeCFlightplanInterface.h
+++ b/test/mock/MockEuroScopeCFlightplanInterface.h
@@ -23,6 +23,7 @@ namespace UKControllerPluginTest {
                 MOCK_CONST_METHOD0(GetGroundState, std::string(void));
                 MOCK_CONST_METHOD0(GetIcaoWakeCategory, std::string(void));
                 MOCK_CONST_METHOD0(GetOrigin, const std::string(void));
+                MOCK_CONST_METHOD0(GetRawRouteString, std::string(void));
                 MOCK_CONST_METHOD0(GetSidName, const std::string(void));
                 MOCK_CONST_METHOD0(GetAssignedSquawk, std::string(void));
                 MOCK_CONST_METHOD0(HasControllerClearedAltitude, const bool(void));
@@ -32,6 +33,7 @@ namespace UKControllerPluginTest {
                 MOCK_CONST_METHOD0(IsTracked, const bool(void));
                 MOCK_CONST_METHOD0(IsTrackedByUser, const bool(void));
                 MOCK_CONST_METHOD0(IsValid, bool(void));
+                MOCK_CONST_METHOD0(IsVfr, bool(void));
                 MOCK_METHOD1(SetClearedAltitude, void(int));
                 MOCK_METHOD1(SetSquawk, void(std::string));
         };

--- a/test/test/squawk/SquawkAssignmentTest.cpp
+++ b/test/test/squawk/SquawkAssignmentTest.cpp
@@ -726,6 +726,23 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, IsVfr())
                 .WillByDefault(Return(false));
 
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(false));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("CIRCUITS"));
+
+            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+        }
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsIfSquawkAlreadyAssigned)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CIRCUITS"));
 
@@ -736,6 +753,9 @@ namespace UKControllerPluginTest {
         {
             ON_CALL(*this->mockFlightplan, IsVfr())
                 .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(false));
 
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CIRCUITS"));
@@ -748,6 +768,9 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, IsVfr())
                 .WillByDefault(Return(true));
 
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(false));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CIRCUIT"));
 
@@ -758,6 +781,9 @@ namespace UKControllerPluginTest {
         {
             ON_CALL(*this->mockFlightplan, IsVfr())
                 .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(false));
 
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("VFR CIRCUIT"));
@@ -770,6 +796,9 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, IsVfr())
                 .WillByDefault(Return(true));
 
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(false));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("VFR CIRCUITS"));
 
@@ -781,6 +810,9 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, IsVfr())
                 .WillByDefault(Return(true));
 
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(false));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("vfr circuits"));
 
@@ -791,6 +823,9 @@ namespace UKControllerPluginTest {
         {
             ON_CALL(*this->mockFlightplan, IsVfr())
                 .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(false));
 
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CHEW VALLEY FROME VFR CIRCUITS"));

--- a/test/test/squawk/SquawkAssignmentTest.cpp
+++ b/test/test/squawk/SquawkAssignmentTest.cpp
@@ -729,10 +729,13 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
                 .WillByDefault(Return(false));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CIRCUITS"));
 
-            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
         }
 
         TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsIfSquawkAlreadyAssigned)
@@ -743,10 +746,13 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
                 .WillByDefault(Return(true));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CIRCUITS"));
 
-            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
         }
 
         TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsTrueOnCircuits)
@@ -757,10 +763,13 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
                 .WillByDefault(Return(false));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CIRCUITS"));
 
-            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
         }
 
         TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsTrueOnCircuit)
@@ -771,10 +780,13 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
                 .WillByDefault(Return(false));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CIRCUIT"));
 
-            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
         }
 
         TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsTrueOnVfrCircuit)
@@ -785,10 +797,13 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
                 .WillByDefault(Return(false));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("VFR CIRCUIT"));
 
-            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
         }
 
         TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsTrueOnVfrCircuits)
@@ -799,10 +814,13 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
                 .WillByDefault(Return(false));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("VFR CIRCUITS"));
 
-            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
         }
 
         TEST_F(SquawkAssignmentTest, CircuitAssignmentHandlesCaseInsensitive)
@@ -813,10 +831,13 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
                 .WillByDefault(Return(false));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("vfr circuits"));
 
-            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
         }
 
         TEST_F(SquawkAssignmentTest, CircuitAssignmentDoesntAcceptCircuitsThatArentStartOfFlightplan)
@@ -827,10 +848,32 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
                 .WillByDefault(Return(false));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("CHEW VALLEY FROME VFR CIRCUITS"));
 
-            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
         }
+
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsFalseIfDoesntMeetGeneralAssignmentRules)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, HasAssignedSquawk())
+                .WillByDefault(Return(false));
+
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(false));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("VFR CIRCUITS"));
+
+            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan, *this->mockRadarTarget));
+        }
+
     }  // namespace Squawk
 }  // namespace UKControllerPluginTest

--- a/test/test/squawk/SquawkAssignmentTest.cpp
+++ b/test/test/squawk/SquawkAssignmentTest.cpp
@@ -720,5 +720,82 @@ namespace UKControllerPluginTest {
         {
             EXPECT_FALSE(this->assignment.disabled);
         }
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsFalseOnNotVfr)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(false));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("CIRCUITS"));
+
+            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+        }
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsTrueOnCircuits)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("CIRCUITS"));
+
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+        }
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsTrueOnCircuit)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("CIRCUIT"));
+
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+        }
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsTrueOnVfrCircuit)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("VFR CIRCUIT"));
+
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+        }
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentReturnsTrueOnVfrCircuits)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("VFR CIRCUITS"));
+
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+        }
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentHandlesCaseInsensitive)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("vfr circuits"));
+
+            EXPECT_TRUE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+        }
+
+        TEST_F(SquawkAssignmentTest, CircuitAssignmentDoesntAcceptCircuitsThatArentStartOfFlightplan)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("CHEW VALLEY FROME VFR CIRCUITS"));
+
+            EXPECT_FALSE(this->assignment.CircuitAssignmentNeeded(*this->mockFlightplan));
+        }
     }  // namespace Squawk
 }  // namespace UKControllerPluginTest

--- a/test/test/squawk/SquawkGeneratorTest.cpp
+++ b/test/test/squawk/SquawkGeneratorTest.cpp
@@ -764,6 +764,9 @@ namespace UKControllerPluginTest {
             ON_CALL(*this->mockFlightplan, GetRawRouteString())
                 .WillByDefault(Return("VFR CIRCUIT"));
 
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
             EXPECT_TRUE(
                 this->generator->AssignCircuitSquawkForAircraft(*this->mockFlightplan, *this->mockRadarTarget)
             );

--- a/test/test/squawk/SquawkGeneratorTest.cpp
+++ b/test/test/squawk/SquawkGeneratorTest.cpp
@@ -724,5 +724,49 @@ namespace UKControllerPluginTest {
 
             EXPECT_FALSE(newGenerator.RequestLocalSquawkForAircraft(*this->mockFlightplan, *this->mockRadarTarget));
         }
+
+        TEST_F(SquawkGeneratorTest, AssignCircuitSquawkForAircraftStopsIfSquawksDisabled)
+        {
+            SquawkAssignment disabledRules(
+                this->flightplans,
+                this->pluginLoopback,
+                *this->airfieldOwnership,
+                this->activeCallsigns,
+                true
+            );
+            SquawkGenerator newGenerator(
+                this->api,
+                &this->taskRunner,
+                &this->pluginLoopback,
+                disabledRules,
+                this->activeCallsigns,
+                this->flightplans
+            );
+
+            EXPECT_FALSE(newGenerator.AssignCircuitSquawkForAircraft(*this->mockFlightplan, *this->mockRadarTarget));
+        }
+
+        TEST_F(SquawkGeneratorTest, AssignCircuitSquawkStopsIfAssignmentNotRequired)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(false));
+
+            EXPECT_FALSE(
+                this->generator->AssignCircuitSquawkForAircraft(*this->mockFlightplan, *this->mockRadarTarget)
+            );
+        }
+
+        TEST_F(SquawkGeneratorTest, AssignCircuitSquawkAssignsIfRequired)
+        {
+            ON_CALL(*this->mockFlightplan, IsVfr())
+                .WillByDefault(Return(true));
+
+            ON_CALL(*this->mockFlightplan, GetRawRouteString())
+                .WillByDefault(Return("VFR CIRCUIT"));
+
+            EXPECT_TRUE(
+                this->generator->AssignCircuitSquawkForAircraft(*this->mockFlightplan, *this->mockRadarTarget)
+            );
+        }
     }  // namespace Squawk
 }  // namespace UKControllerPluginTest


### PR DESCRIPTION
- Automatically assign 7010 to aircraft that are deemed to be doing VFR circuits.