### PR TITLE
Fix #27: Menu Has A Random Order

### DIFF
--- a/src/radarscreen/ConfigurableDisplayCollection.cpp
+++ b/src/radarscreen/ConfigurableDisplayCollection.cpp
@@ -19,7 +19,12 @@ namespace UKControllerPlugin {
         void ConfigurableDisplayCollection::RegisterDisplay(
             std::shared_ptr<UKControllerPlugin::RadarScreen::ConfigurableDisplayInterface> radarScreen
         ) {
-            this->displays.insert(radarScreen);
+            if (std::find(this->displays.begin(), this->displays.end(), radarScreen) != this->displays.end()) {
+                LogWarning("Duplicate configurable display added");
+                return;
+            }
+
+            this->displays.push_back(radarScreen);
         }
     }  // namespace RadarScreen
 }  // namespace UKControllerPlugin

--- a/src/radarscreen/ConfigurableDisplayCollection.h
+++ b/src/radarscreen/ConfigurableDisplayCollection.h
@@ -27,14 +27,14 @@ class ConfigurableDisplayCollection
             std::shared_ptr<UKControllerPlugin::RadarScreen::ConfigurableDisplayInterface> radarScreen
         );
 
-        typedef std::set<std::shared_ptr<UKControllerPlugin::RadarScreen::ConfigurableDisplayInterface>> DisplaySet;
+        typedef std::list<std::shared_ptr<UKControllerPlugin::RadarScreen::ConfigurableDisplayInterface>> DisplaySet;
         typedef DisplaySet::iterator iterator;
         typedef DisplaySet::const_iterator const_iterator;
         const_iterator cbegin() const { return displays.cbegin(); }  // namespace UKControllerPlugin
         const_iterator cend() const { return displays.cend(); }  // namespace Euroscope
 
     private:
-        std::set<std::shared_ptr<UKControllerPlugin::RadarScreen::ConfigurableDisplayInterface>> displays;
+        std::list<std::shared_ptr<UKControllerPlugin::RadarScreen::ConfigurableDisplayInterface>> displays;
 };
 
 }  // namespace RadarScreen

--- a/test/test/radarscreen/ConfigurableDisplayCollectionTest.cpp
+++ b/test/test/radarscreen/ConfigurableDisplayCollectionTest.cpp
@@ -25,6 +25,16 @@ namespace UKControllerPluginTest {
             EXPECT_EQ(1, collection.CountDisplays());
         }
 
+        TEST(ConfigurableDisplayCollection, DoesNotAddDuplicates)
+        {
+            ConfigurableDisplayCollection collection;
+            std::shared_ptr<MockConfigurableDisplay> testDisplay = std::make_shared<MockConfigurableDisplay>();
+            collection.RegisterDisplay(testDisplay);
+            EXPECT_EQ(1, collection.CountDisplays());
+            collection.RegisterDisplay(testDisplay);
+            EXPECT_EQ(1, collection.CountDisplays());
+        }
+
         TEST(ConfigurableDisplayCollection, IsIterable)
         {
             ConfigurableDisplayCollection collection;


### PR DESCRIPTION
Change ConfigurableDisplayCollection to use a list underneath, so that
the order of the collection is determined by insertion order (in the
future could change again, if we want!) and not by the memory address
allocated to the pointer.