### PR TITLE
Fix initial controller load

### DIFF
--- a/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj
+++ b/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj
@@ -59,6 +59,7 @@
     <ClInclude Include="..\..\src\controller\ControllerPositionParser.h" />
     <ClInclude Include="..\..\src\controller\ControllerStatusEventHandlerCollection.h" />
     <ClInclude Include="..\..\src\controller\ControllerStatusEventHandlerInterface.h" />
+    <ClInclude Include="..\..\src\controller\TranslateFrequencyAbbreviation.h" />
     <ClInclude Include="..\..\src\countdown\CountdownModule.h" />
     <ClInclude Include="..\..\src\countdown\CountdownRenderer.h" />
     <ClInclude Include="..\..\src\countdown\CountdownTimer.h" />
@@ -253,6 +254,7 @@
     <ClCompile Include="..\..\src\controller\ControllerPositionHierarchyFactory.cpp" />
     <ClCompile Include="..\..\src\controller\ControllerPositionParser.cpp" />
     <ClCompile Include="..\..\src\controller\ControllerStatusEventHandlerCollection.cpp" />
+    <ClCompile Include="..\..\src\controller\TranslateFrequencyAbbreviation.cpp" />
     <ClCompile Include="..\..\src\countdown\CountdownModule.cpp" />
     <ClCompile Include="..\..\src\countdown\CountdownRenderer.cpp" />
     <ClCompile Include="..\..\src\countdown\CountdownTimer.cpp" />

--- a/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj.filters
+++ b/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj.filters
@@ -714,6 +714,9 @@
     <ClInclude Include="..\..\src\squawk\ApiSquawkAllocation.h">
       <Filter>src\squawk</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\controller\TranslateFrequencyAbbreviation.h">
+      <Filter>src\controller</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\resource\UKControllerPlugin.rc">
@@ -1206,6 +1209,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\squawk\ApiSquawkAllocationHandler.cpp">
       <Filter>src\squawk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\controller\TranslateFrequencyAbbreviation.cpp">
+      <Filter>src\controller</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/msvc/UKControllerPluginTest/UKControllerPluginTest.vcxproj
+++ b/msvc/UKControllerPluginTest/UKControllerPluginTest.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="..\..\test\test\controller\ControllerPositionParserTest.cpp" />
     <ClCompile Include="..\..\test\test\controller\ControllerPositionTest.cpp" />
     <ClCompile Include="..\..\test\test\controller\ControllerStatusEventHandlerCollectionTest.cpp" />
+    <ClCompile Include="..\..\test\test\controller\TranslateFrequencyAbbreviationTest.cpp" />
     <ClCompile Include="..\..\test\test\countdown\CountdownModuleTest.cpp" />
     <ClCompile Include="..\..\test\test\countdown\CountdownRendererTest.cpp" />
     <ClCompile Include="..\..\test\test\countdown\CountdownTimerTest.cpp" />

--- a/msvc/UKControllerPluginTest/UKControllerPluginTest.vcxproj.filters
+++ b/msvc/UKControllerPluginTest/UKControllerPluginTest.vcxproj.filters
@@ -533,6 +533,9 @@
     <ClCompile Include="..\..\test\test\squawk\ApiSquawkAllocationTest.cpp">
       <Filter>test\squawk</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\test\test\controller\TranslateFrequencyAbbreviationTest.cpp">
+      <Filter>test\controller</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\test\helper\ApiRequestHelperFunctions.h">

--- a/src/airfield/AirfieldOwnershipManager.cpp
+++ b/src/airfield/AirfieldOwnershipManager.cpp
@@ -118,7 +118,7 @@ namespace UKControllerPlugin {
                 }
 
                 // Only log when positions have changed hands
-                bool needsLog = this->ownershipMap.count(icao) > 0 &&
+                bool needsLog = this->ownershipMap.count(icao) == 0 ||
                     this->ownershipMap.at(icao)->GetCallsign() !=
                     this->activeCallsigns.GetLeadCallsignForPosition(*it).GetCallsign();
 

--- a/src/controller/ControllerPositionCollection.cpp
+++ b/src/controller/ControllerPositionCollection.cpp
@@ -74,7 +74,7 @@ namespace UKControllerPlugin {
         */
         bool ControllerPositionCollection::IsPossibleAirfieldPosition(std::string facility) const
         {
-            return facility == "ESSEX" || facility == "THAMES" || facility == "SOLENT" || 
+            return facility == "ESSEX" || facility == "THAMES" || facility == "SOLENT" ||
                 facility.size() == 4 && facility.substr(0, 2) == "EG";
         }
 

--- a/src/controller/ControllerPositionCollection.cpp
+++ b/src/controller/ControllerPositionCollection.cpp
@@ -1,6 +1,7 @@
 #include "pch/stdafx.h"
 #include "controller/ControllerPositionCollection.h"
 #include "controller/ControllerPosition.h"
+#include "controller/TranslateFrequencyAbbreviation.h"
 
 using UKControllerPlugin::Controller::ControllerPosition;
 
@@ -35,6 +36,9 @@ namespace UKControllerPlugin {
             std::string facility,
             double frequency
         ) const {
+
+            facility = TranslateFrequencyAbbreviation(facility);
+
             // If there's no chance of finding anything, save us the iteration.
             if (!this->IsPossibleAreaPosition(facility) && !this->IsPossibleAirfieldPosition(facility)) {
                 throw std::out_of_range("Position not found.");
@@ -70,7 +74,8 @@ namespace UKControllerPlugin {
         */
         bool ControllerPositionCollection::IsPossibleAirfieldPosition(std::string facility) const
         {
-            return facility.size() == 4 && facility.substr(0, 2) == "EG";
+            return facility == "ESSEX" || facility == "THAMES" || facility == "SOLENT" || 
+                facility.size() == 4 && facility.substr(0, 2) == "EG";
         }
 
         /*

--- a/src/controller/TranslateFrequencyAbbreviation.cpp
+++ b/src/controller/TranslateFrequencyAbbreviation.cpp
@@ -1,0 +1,23 @@
+#include "pch/stdafx.h"
+#include "controller/TranslateFrequencyAbbreviation.h"
+
+namespace UKControllerPlugin {
+    namespace Controller {
+
+        std::map <std::string, std::string> translations = {
+            {"ESX", "ESSEX"},
+            {"SOL", "SOLENT"},
+            {"THA", "THAMES"},
+            {"TMS", "THAMES"}
+        };
+
+        /*
+            Given a recognised abbreviation for a facility, translate
+            it to the full facility for use in matching controller positions.
+        */
+        std::string TranslateFrequencyAbbreviation(std::string facility)
+        {
+            return translations.count(facility) ? translations.at(facility) : facility;
+        }
+    }  // namespace Controller 
+}  // namespace UKControllerPlugin

--- a/src/controller/TranslateFrequencyAbbreviation.cpp
+++ b/src/controller/TranslateFrequencyAbbreviation.cpp
@@ -19,5 +19,5 @@ namespace UKControllerPlugin {
         {
             return translations.count(facility) ? translations.at(facility) : facility;
         }
-    }  // namespace Controller 
+    }  // namespace Controller
 }  // namespace UKControllerPlugin

--- a/src/controller/TranslateFrequencyAbbreviation.h
+++ b/src/controller/TranslateFrequencyAbbreviation.h
@@ -4,5 +4,5 @@ namespace UKControllerPlugin {
     namespace Controller {
 
         std::string TranslateFrequencyAbbreviation(std::string facility);
-    }  // namespace Controller 
+    }  // namespace Controller
 }  // namespace UKControllerPlugin

--- a/src/controller/TranslateFrequencyAbbreviation.h
+++ b/src/controller/TranslateFrequencyAbbreviation.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace UKControllerPlugin {
+    namespace Controller {
+
+        std::string TranslateFrequencyAbbreviation(std::string facility);
+    }  // namespace Controller 
+}  // namespace UKControllerPlugin

--- a/src/plugin/UKPlugin.cpp
+++ b/src/plugin/UKPlugin.cpp
@@ -118,6 +118,13 @@ namespace UKControllerPlugin {
     void UKPlugin::DoInitialControllerLoad(void)
     {
         LogInfo("Initial controller load started");
+
+        EuroScopePlugIn::CController me = this->ControllerMyself();
+        if (me.IsValid()) {
+            this->OnControllerPositionUpdate(me);
+            LogInfo("Loaded myself, on " + std::string(me.GetCallsign()));
+        }
+
         EuroScopePlugIn::CController current = this->ControllerSelectFirst();
 
         // If there's nobody online, stop.

--- a/src/update/PluginVersion.cpp
+++ b/src/update/PluginVersion.cpp
@@ -3,7 +3,7 @@
 
 namespace UKControllerPlugin {
     namespace Plugin {
-        const char * const PluginVersion::version = "1.1.0";
+        const char * const PluginVersion::version = "1.1.1";
         const char * const PluginVersion::title = "UK Controller Plugin";
         const char * const PluginVersion::author = "VATSIM UK";
         const char * const PluginVersion::copyright = "VATSIM United Kingdom Division";

--- a/src/update/PluginVersion.cpp
+++ b/src/update/PluginVersion.cpp
@@ -3,7 +3,7 @@
 
 namespace UKControllerPlugin {
     namespace Plugin {
-        const char * const PluginVersion::version = "1.1.1";
+        const char * const PluginVersion::version = "1.1.2";
         const char * const PluginVersion::title = "UK Controller Plugin";
         const char * const PluginVersion::author = "VATSIM UK";
         const char * const PluginVersion::copyright = "VATSIM United Kingdom Division";

--- a/src/update/PluginVersion.h
+++ b/src/update/PluginVersion.h
@@ -2,6 +2,12 @@
 
 namespace UKControllerPlugin {
     namespace Plugin {
+
+        /*
+            Contains the version details of the plugin
+            that get passed to ES and are also used in update
+            checks.
+        */
         typedef struct PluginVersion {
             static const char * const version;
             static const char * const title;

--- a/test/test/controller/ControllerPositionCollectionTest.cpp
+++ b/test/test/controller/ControllerPositionCollectionTest.cpp
@@ -111,5 +111,53 @@ namespace UKControllerPluginTest {
             collection.AddPosition(std::move(controller));
             EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("EGFF", 125.8514));
         }
+
+        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyWillWorkForEssex)
+        {
+            ControllerPositionCollection collection;
+            std::unique_ptr<ControllerPosition> controller(
+                new ControllerPosition("ESSEX_APP", 120.620, "APP", std::vector<std::string> {"EGSS, EGGW, EGSC"})
+            );
+
+            ControllerPosition * controllerRaw = controller.get();
+            collection.AddPosition(std::move(controller));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("ESSEX", 120.620));
+        }
+
+        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyWillWorkForThames)
+        {
+            ControllerPositionCollection collection;
+            std::unique_ptr<ControllerPosition> controller(
+                new ControllerPosition("THAMES", 132.700, "APP", std::vector<std::string> {"EGLC, EGKB"})
+            );
+
+            ControllerPosition * controllerRaw = controller.get();
+            collection.AddPosition(std::move(controller));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("THAMES", 132.700));
+        }
+
+        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyWillWorkForSolent)
+        {
+            ControllerPositionCollection collection;
+            std::unique_ptr<ControllerPosition> controller(
+                new ControllerPosition("SOLENT", 120.220, "APP", std::vector<std::string> {"EGLC, EGKB"})
+            );
+
+            ControllerPosition * controllerRaw = controller.get();
+            collection.AddPosition(std::move(controller));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("SOLENT", 120.220));
+        }
+
+        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyWillWorkForAbbreviations)
+        {
+            ControllerPositionCollection collection;
+            std::unique_ptr<ControllerPosition> controller(
+                new ControllerPosition("ESSEX_APP", 120.620, "APP", std::vector<std::string> {"EGSS, EGGW, EGSC"})
+            );
+
+            ControllerPosition * controllerRaw = controller.get();
+            collection.AddPosition(std::move(controller));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("ESX", 120.620));
+        }
     }  // namespace Controller
 }  // namespace UKControllerPluginTest

--- a/test/test/controller/TranslateFrequencyAbbreviationTest.cpp
+++ b/test/test/controller/TranslateFrequencyAbbreviationTest.cpp
@@ -5,7 +5,7 @@ using UKControllerPlugin::Controller::TranslateFrequencyAbbreviation;
 
 namespace UKControllerPluginTest {
     namespace Controller {
-        
+
         TEST(TranslateFrequencyAbbreviation, ItTranslatesEssexAbbreviation)
         {
             EXPECT_EQ("ESSEX", TranslateFrequencyAbbreviation("ESX"));

--- a/test/test/controller/TranslateFrequencyAbbreviationTest.cpp
+++ b/test/test/controller/TranslateFrequencyAbbreviationTest.cpp
@@ -1,0 +1,34 @@
+#include "pch/pch.h"
+#include "controller/TranslateFrequencyAbbreviation.h"
+
+using UKControllerPlugin::Controller::TranslateFrequencyAbbreviation;
+
+namespace UKControllerPluginTest {
+    namespace Controller {
+        
+        TEST(TranslateFrequencyAbbreviation, ItTranslatesEssexAbbreviation)
+        {
+            EXPECT_EQ("ESSEX", TranslateFrequencyAbbreviation("ESX"));
+        }
+
+        TEST(TranslateFrequencyAbbreviation, ItTranslatesSolentAbbreviation)
+        {
+            EXPECT_EQ("SOLENT", TranslateFrequencyAbbreviation("SOL"));
+        }
+
+        TEST(TranslateFrequencyAbbreviation, ItTranslatesThamesAbbreviation)
+        {
+            EXPECT_EQ("THAMES", TranslateFrequencyAbbreviation("THA"));
+        }
+
+        TEST(TranslateFrequencyAbbreviation, ItTranslatesThamesAbbreviation2)
+        {
+            EXPECT_EQ("THAMES", TranslateFrequencyAbbreviation("TMS"));
+        }
+
+        TEST(TranslateFrequencyAbbreviation, ItReturnsFacilityIfNoTranslation)
+        {
+            EXPECT_EQ("EGKK", TranslateFrequencyAbbreviation("EGKK"));
+        }
+    }  // namespace Controller
+}  // namespace UKControllerPluginTest


### PR DESCRIPTION
Fix #38
Fix #23 

- Update initial controller load to explicitly load the users controller
- Recognise special positions such as ESSEX and also reasonable abbreviations (e.g. ESX)