### PR TITLE
Folder creation

### DIFF
--- a/src/bootstrap/ExternalsBootstrap.cpp
+++ b/src/bootstrap/ExternalsBootstrap.cpp
@@ -66,22 +66,13 @@ namespace UKControllerPlugin {
                 ExternalsBootstrap::GetMyDocumentsPath()
             );
 
-            if (!winApi.CreateFolder(documentsPath + "/EuroScope")) {
+            if (!winApi.CreateFolderRecursive(documentsPath + "/EuroScope/ukcp")) {
                 winApi.OpenMessageBox(
-                    L"Unable to find EuroScope documents folder, please contact the VATUK Web Department.",
+                    L"Unable to create the UKCP root folder, please contact the VATUK Web Department.",
                     L"UKCP Fatal Error",
                     MB_OK | MB_ICONSTOP
                 );
-                throw std::runtime_error("Unable to create EuroScope folder");
-            }
-
-            if (!winApi.CreateFolder(documentsPath + "/EuroScope/ukcp")) {
-                winApi.OpenMessageBox(
-                    L"Unable to create ukcp file root, please contact the VATUK Web Department.",
-                    L"UKCP Fatal Error",
-                    MB_OK | MB_ICONSTOP
-                );
-                throw std::runtime_error("Unable to create ukcp root folder");
+                throw std::runtime_error("Unable to create UKCP Root");
             }
         }
 

--- a/src/bootstrap/ExternalsBootstrap.cpp
+++ b/src/bootstrap/ExternalsBootstrap.cpp
@@ -81,11 +81,12 @@ namespace UKControllerPlugin {
         */
         std::wstring ExternalsBootstrap::GetMyDocumentsPath(void)
         {
-            TCHAR myDocumentsPath[MAX_PATH];
-            HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
+            TCHAR * myDocumentsPath = 0;
+            HRESULT result = SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_SIMPLE_IDLIST, NULL, &myDocumentsPath);
 
             std::wstring widePath(myDocumentsPath);
             std::replace(widePath.begin(), widePath.end(), L'\\', L'/');
+            CoTaskMemFree(myDocumentsPath);
             return widePath;
         }
     }  // namespace Bootstrap

--- a/src/bootstrap/ExternalsBootstrap.cpp
+++ b/src/bootstrap/ExternalsBootstrap.cpp
@@ -13,6 +13,7 @@
 using UKControllerPlugin::Curl::CurlApi;
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
 using UKControllerPlugin::Windows::WinApi;
+using UKControllerPlugin::Windows::WinApiInterface;
 using UKControllerPlugin::Windows::GdiplusBrushes;
 using UKControllerPlugin::Windows::GdiGraphicsWrapper;
 using UKControllerPlugin::Euroscope::GeneralSettingsDialog;
@@ -53,13 +54,48 @@ namespace UKControllerPlugin {
         */
         std::wstring ExternalsBootstrap::GetPluginFileRootWide(void)
         {
+            return ExternalsBootstrap::GetMyDocumentsPath() + L"/EuroScope/ukcp";
+        }
+
+        /*
+            Create the required folder hierarchy for UKCP.
+        */
+        void ExternalsBootstrap::SetupUkcpFolderRoot(WinApiInterface & winApi)
+        {
+            std::string documentsPath = HelperFunctions::ConvertToRegularString(
+                ExternalsBootstrap::GetMyDocumentsPath()
+            );
+
+            if (!winApi.CreateFolder(documentsPath + "/EuroScope")) {
+                winApi.OpenMessageBox(
+                    L"Unable to find EuroScope documents folder, please contact the VATUK Web Department.",
+                    L"UKCP Fatal Error",
+                    MB_OK | MB_ICONSTOP
+                );
+                throw std::runtime_error("Unable to create EuroScope folder");
+            }
+
+            if (!winApi.CreateFolder(documentsPath + "/EuroScope/ukcp")) {
+                winApi.OpenMessageBox(
+                    L"Unable to create ukcp file root, please contact the VATUK Web Department.",
+                    L"UKCP Fatal Error",
+                    MB_OK | MB_ICONSTOP
+                );
+                throw std::runtime_error("Unable to create ukcp root folder");
+            }
+        }
+
+        /*
+            Get the My Documents path
+        */
+        std::wstring ExternalsBootstrap::GetMyDocumentsPath(void)
+        {
             TCHAR myDocumentsPath[MAX_PATH];
             HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
 
             std::wstring widePath(myDocumentsPath);
             std::replace(widePath.begin(), widePath.end(), L'\\', L'/');
-
-            return widePath + L"/EuroScope/ukcp";
+            return widePath;
         }
     }  // namespace Bootstrap
 }  // namespace UKControllerPlugin

--- a/src/bootstrap/ExternalsBootstrap.h
+++ b/src/bootstrap/ExternalsBootstrap.h
@@ -5,6 +5,9 @@ namespace UKControllerPlugin {
     namespace Bootstrap {
         struct PersistenceContainer;
     }  // namespace Bootstrap
+    namespace Windows {
+        class WinApiInterface;
+    }  // namespace Windows
 }  // namespace UKControllerPlugin
 // END
 
@@ -26,6 +29,10 @@ namespace UKControllerPlugin {
 
                 static std::string GetPluginFileRoot(void);
                 static std::wstring GetPluginFileRootWide(void);
+                static void SetupUkcpFolderRoot(UKControllerPlugin::Windows::WinApiInterface & winApi);
+
+            private:
+                static std::wstring GetMyDocumentsPath(void);
         };
     }  // namespace Bootstrap
 }  // namespace UKControllerPlugin

--- a/src/bootstrap/InitialisePlugin.cpp
+++ b/src/bootstrap/InitialisePlugin.cpp
@@ -152,6 +152,7 @@ namespace UKControllerPlugin {
         PluginUserSettingBootstrap::BootstrapPlugin(*this->container);
 
         ExternalsBootstrap::Bootstrap(*this->container, dllInstance);
+        ExternalsBootstrap::SetupUkcpFolderRoot(*this->container->windows);
         LoggerBootstrap::Bootstrap(*this->container, this->duplicatePlugin->Duplicate());
 
         // API

--- a/src/bootstrap/PostInit.cpp
+++ b/src/bootstrap/PostInit.cpp
@@ -2,6 +2,9 @@
 #include "bootstrap/PostInit.h"
 #include "bootstrap/PersistenceContainer.h"
 #include "euroscope/LoadDefaultUserSettings.h"
+#include "update/PluginVersion.h"
+
+using UKControllerPlugin::Plugin::PluginVersion;
 
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
 namespace UKControllerPlugin {
@@ -17,6 +20,19 @@ namespace UKControllerPlugin {
             container.plugin->PostInit();
             UKControllerPlugin::Euroscope::LoadDefaultUserSettings(*container.pluginUserSettingHandler);
             container.userSettingHandlers->UserSettingsUpdateEvent(*container.pluginUserSettingHandler);
+
+            std::string versionMessage = "UK Controller Plugin Loaded Successfully: Version " +
+                std::string(PluginVersion::version);
+            container.plugin->DisplayUserMessage(
+                "message",
+                "UKCP",
+                versionMessage.c_str(),
+                false,
+                false,
+                false,
+                false,
+                false
+            );
         }
     }  // namespace Bootstrap
 }  // namespace UKControllerPlugin

--- a/src/log/LoggerBootstrap.cpp
+++ b/src/log/LoggerBootstrap.cpp
@@ -13,23 +13,21 @@ namespace UKControllerPlugin {
         void LoggerBootstrap::Bootstrap(PersistenceContainer & persistence, bool nullLogger)
         {
             if (nullLogger) {
-                SetLoggerInstance(
-                    std::make_shared<spdlog::logger>(
-                        "null_logger",
-                        std::make_shared<spdlog::sinks::null_sink_mt>()
-                    )
-                );
+                LoggerBootstrap::CreateNullLogger();
                 return;
             }
 
             // Create us a logger, for now we log everything that happens.
             if (!persistence.windows->CreateLocalFolderRecursive("logs")) {
+                std::wstring msg = L"Unable to create logs folder, please contact the VATSIM UK Web Department.\n\n";
+                msg += L"Plugin events will not be logged.";
                 persistence.windows->OpenMessageBox(
-                    L"Unable to create the logs folder, please contact the VATSIM UK Web Department.",
+                    msg.c_str(),
                     L"UKCP Error",
                     MB_OK | MB_ICONSTOP
                 );
-                throw std::runtime_error("Could not create the logs folder.");
+                LoggerBootstrap::CreateNullLogger();
+                return;
             }
 
             std::shared_ptr<spdlog::sinks::rotating_file_sink_mt> rotatingSink =
@@ -52,6 +50,19 @@ namespace UKControllerPlugin {
 
             SetLoggerInstance(logger);
             LogInfo("Log opened");
+        }
+
+        /*
+            Sets the logger instance to be a null logger.
+        */
+        void LoggerBootstrap::CreateNullLogger(void)
+        {
+            SetLoggerInstance(
+                std::make_shared<spdlog::logger>(
+                "null_logger",
+                std::make_shared<spdlog::sinks::null_sink_mt>()
+            )
+            );
         }
     }  // namespace Log
 }  // namespace UKControllerPlugin

--- a/src/log/LoggerBootstrap.h
+++ b/src/log/LoggerBootstrap.h
@@ -24,6 +24,10 @@ namespace UKControllerPlugin {
                     UKControllerPlugin::Bootstrap::PersistenceContainer & persistence,
                     bool nullLogger
                 );
+
+            private:
+
+                static void CreateNullLogger(void);
         };
     }  // namespace Log
 }  // namespace UKControllerPlugin

--- a/src/pch/stdafx.h
+++ b/src/pch/stdafx.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <mutex>
 #include <vector>
+#include <KnownFolders.h>
 #include <iterator>
 #include <sstream>
 #include <queue>

--- a/src/pch/stdafx.h
+++ b/src/pch/stdafx.h
@@ -19,6 +19,7 @@
 #include <CommCtrl.h>
 #include <CommDlg.h>
 #include <shtypes.h>
+#include <filesystem>
 #include <cctype>
 #include <ctime>
 #include <string>

--- a/src/pch/stdafx.h
+++ b/src/pch/stdafx.h
@@ -19,7 +19,7 @@
 #include <CommCtrl.h>
 #include <CommDlg.h>
 #include <shtypes.h>
-#include <filesystem>
+#include <experimental/filesystem>
 #include <cctype>
 #include <ctime>
 #include <string>

--- a/src/plugin/UKPlugin.cpp
+++ b/src/plugin/UKPlugin.cpp
@@ -64,16 +64,6 @@ namespace UKControllerPlugin {
         functionCallHandler(functionCallHandler),
         commandHandlers(commandHandlers)
     {
-        this->DisplayUserMessage(
-            "message",
-            "UKCP",
-            "UK Controller Plugin Loaded Successfully",
-            false,
-            false,
-            false,
-            false,
-            false
-        );
     }
 
     /*

--- a/src/windows/WinApi.cpp
+++ b/src/windows/WinApi.cpp
@@ -40,15 +40,17 @@ namespace UKControllerPlugin {
         }
 
         /*
-            Create a folder from the root, recursively
+            Create a folder from the UK file root, recursively
         */
         bool WinApi::CreateLocalFolderRecursive(std::string folder)
         {
             std::vector<std::string> tokens = HelperFunctions::TokeniseString(
                 '/',
-                this->GetFullPathToLocalFile(folder)
+                folder
             );
-            std::string currentPath;
+
+            // Start from the UKCP root
+            std::string currentPath = this->filesDirectory + "/";
             for (std::vector<std::string>::iterator it = tokens.begin(); it != tokens.end(); ++it) {
                 if (!this->CreateFolder(currentPath + *it)) {
                     return false;

--- a/src/windows/WinApi.cpp
+++ b/src/windows/WinApi.cpp
@@ -34,31 +34,38 @@ namespace UKControllerPlugin {
         */
         bool WinApi::CreateFolder(std::string folder)
         {
-            std::wstring folderWide(folder.length(), L' ');
-            std::copy(folder.begin(), folder.end(), folderWide.begin());
-            return (CreateDirectory(folderWide.c_str(), NULL) || ERROR_ALREADY_EXISTS == GetLastError()) ? true : false;
+            try {
+                std::filesystem::create_directory(folder);
+                return true;
+            } catch (std::filesystem::filesystem_error) {
+                return false;
+            }
         }
 
         /*
-            Create a folder from the UK file root, recursively
+            Creates a folder and all those before it.
+        */
+        bool WinApi::CreateFolderRecursive(std::string folder)
+        {
+            try {
+                std::filesystem::create_directories(folder);
+                return true;
+            } catch (std::filesystem::filesystem_error) {
+                return false;
+            }
+        }
+
+        /*
+            Create a folder from the UK file root, recursively.
         */
         bool WinApi::CreateLocalFolderRecursive(std::string folder)
         {
-            std::vector<std::string> tokens = HelperFunctions::TokeniseString(
-                '/',
-                folder
-            );
-
-            // Start from the UKCP root
-            std::string currentPath = this->filesDirectory + "/";
-            for (std::vector<std::string>::iterator it = tokens.begin(); it != tokens.end(); ++it) {
-                if (!this->CreateFolder(currentPath + *it)) {
-                    return false;
-                }
-                currentPath += *it + "/";
+            try {
+                std::filesystem::create_directories(this->filesDirectory + "/" + folder);
+                return true;
+            } catch (std::filesystem::filesystem_error) {
+                return false;
             }
-
-            return true;
         }
 
         /*
@@ -77,19 +84,11 @@ namespace UKControllerPlugin {
         */
         bool WinApi::FileExists(std::string filename)
         {
-            std::string newFilename = this->GetFullPathToLocalFile(filename);
-            std::wstring filenameWide(newFilename.length(), L' ');
-            std::copy(newFilename.begin(), newFilename.end(), filenameWide.begin());
-
-            WIN32_FIND_DATA findData;
-            HANDLE hFind = FindFirstFile(filenameWide.c_str(), &findData);
-
-            if (hFind == INVALID_HANDLE_VALUE) {
+            try {
+                return std::filesystem::exists(this->GetFullPathToLocalFile(filename));
+            } catch (std::filesystem::filesystem_error) {
                 return false;
             }
-
-            FindClose(hFind);
-            return true;
         }
 
         /*
@@ -200,16 +199,10 @@ namespace UKControllerPlugin {
         */
         void WinApi::CreateMissingDirectories(std::string endFile)
         {
-            std::vector<std::string> tokens = HelperFunctions::TokeniseString('/', endFile);
-            std::string currentPath;
-            for (std::vector<std::string>::iterator it = tokens.begin(); it != tokens.end(); ++it) {
-                // We don't want to include the last item, as that's the file.
-                if (*it == tokens.back()) {
-                    break;
-                }
-
-                this->CreateFolder(currentPath + *it);
-                currentPath += *it + "/";
+            try {
+                std::filesystem::create_directories(endFile.substr(0, endFile.find_last_of('/')));
+            } catch (std::filesystem::filesystem_error) {
+                // Do nothing
             }
         }
 

--- a/src/windows/WinApi.cpp
+++ b/src/windows/WinApi.cpp
@@ -35,9 +35,9 @@ namespace UKControllerPlugin {
         bool WinApi::CreateFolder(std::string folder)
         {
             try {
-                std::filesystem::create_directory(folder);
+                std::experimental::filesystem::create_directory(folder);
                 return true;
-            } catch (std::filesystem::filesystem_error) {
+            } catch (std::experimental::filesystem::filesystem_error) {
                 return false;
             }
         }
@@ -48,9 +48,9 @@ namespace UKControllerPlugin {
         bool WinApi::CreateFolderRecursive(std::string folder)
         {
             try {
-                std::filesystem::create_directories(folder);
+                std::experimental::filesystem::create_directories(folder);
                 return true;
-            } catch (std::filesystem::filesystem_error) {
+            } catch (std::experimental::filesystem::filesystem_error) {
                 return false;
             }
         }
@@ -61,9 +61,9 @@ namespace UKControllerPlugin {
         bool WinApi::CreateLocalFolderRecursive(std::string folder)
         {
             try {
-                std::filesystem::create_directories(this->filesDirectory + "/" + folder);
+                std::experimental::filesystem::create_directories(this->filesDirectory + "/" + folder);
                 return true;
-            } catch (std::filesystem::filesystem_error) {
+            } catch (std::experimental::filesystem::filesystem_error) {
                 return false;
             }
         }
@@ -85,8 +85,8 @@ namespace UKControllerPlugin {
         bool WinApi::FileExists(std::string filename)
         {
             try {
-                return std::filesystem::exists(this->GetFullPathToLocalFile(filename));
-            } catch (std::filesystem::filesystem_error) {
+                return std::experimental::filesystem::exists(this->GetFullPathToLocalFile(filename));
+            } catch (std::experimental::filesystem::filesystem_error) {
                 return false;
             }
         }
@@ -200,8 +200,8 @@ namespace UKControllerPlugin {
         void WinApi::CreateMissingDirectories(std::string endFile)
         {
             try {
-                std::filesystem::create_directories(endFile.substr(0, endFile.find_last_of('/')));
-            } catch (std::filesystem::filesystem_error) {
+                std::experimental::filesystem::create_directories(endFile.substr(0, endFile.find_last_of('/')));
+            } catch (std::experimental::filesystem::filesystem_error) {
                 // Do nothing
             }
         }

--- a/src/windows/WinApi.h
+++ b/src/windows/WinApi.h
@@ -19,6 +19,7 @@ namespace UKControllerPlugin {
                     std::wstring filesDirectoryW
                 );
                 bool CreateFolder(std::string folder);
+                bool CreateFolderRecursive(std::string folder) override;
                 bool CreateLocalFolderRecursive(std::string folder) override;
                 bool DeleteGivenFile(std::string filename);
                 bool FileExists(std::string filename);

--- a/src/windows/WinApiInterface.h
+++ b/src/windows/WinApiInterface.h
@@ -20,6 +20,7 @@ namespace UKControllerPlugin {
             };
             virtual ~WinApiInterface(void) {}  // namespace Windows
             virtual bool CreateFolder(std::string folder) = 0;
+            virtual bool CreateFolderRecursive(std::string folder) = 0;
             virtual bool CreateLocalFolderRecursive(std::string folder) = 0;
             virtual bool DeleteGivenFile(std::string filename) = 0;
             virtual bool FileExists(std::string filename) = 0;

--- a/test/mock/MockWinApi.h
+++ b/test/mock/MockWinApi.h
@@ -23,6 +23,7 @@ namespace UKControllerPluginTest {
             MOCK_METHOD2(ReadFromFileMock, std::string(std::wstring, bool));
             MOCK_METHOD1(FileExists, bool(std::string ));
             MOCK_METHOD1(CreateFolder, bool(std::string folder));
+            MOCK_METHOD1(CreateFolderRecursive, bool(std::string folder));
             MOCK_METHOD1(CreateLocalFolderRecursive, bool(std::string folder));
             MOCK_METHOD1(DeleteGivenFile, bool(std::string filename));
             MOCK_CONST_METHOD1(GetFullPathToLocalFile, std::string(std::string));

--- a/test/test/bootstrap/ExternalsBootstrapTest.cpp
+++ b/test/test/bootstrap/ExternalsBootstrapTest.cpp
@@ -119,7 +119,7 @@ namespace UKControllerPluginTest {
                 .WillByDefault(Return(false));
 
 
-            EXPECT_THROW(ExternalsBootstrap::SetupUkcpFolderRoot(this->winApiMock),std::runtime_error);
+            EXPECT_THROW(ExternalsBootstrap::SetupUkcpFolderRoot(this->winApiMock), std::runtime_error);
         }
 
         TEST_F(ExternalsBootstrapTest, SetupUkcpFolderRootThrowsExceptionOnFailedCreatingUkcpFolder)

--- a/test/test/bootstrap/ExternalsBootstrapTest.cpp
+++ b/test/test/bootstrap/ExternalsBootstrapTest.cpp
@@ -137,14 +137,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(ExternalsBootstrapTest, SetupUkcpFolderRootCreatesFolders)
         {
-            std::string expected1 = this->GetMyDocumentsPathNarrow() + "/EuroScope";
-            std::string expected2 = this->GetMyDocumentsPathNarrow() + "/EuroScope/ukcp";
-
-            EXPECT_CALL(this->winApiMock, CreateFolder(expected1))
-                .Times(1)
-                .WillOnce(Return(true));
-
-            EXPECT_CALL(this->winApiMock, CreateFolder(expected2))
+            EXPECT_CALL(this->winApiMock, CreateFolderRecursive(this->GetMyDocumentsPathNarrow() + "/EuroScope/ukcp"))
                 .Times(1)
                 .WillOnce(Return(true));
 

--- a/test/test/bootstrap/ExternalsBootstrapTest.cpp
+++ b/test/test/bootstrap/ExternalsBootstrapTest.cpp
@@ -2,17 +2,53 @@
 #include "bootstrap/ExternalsBootstrap.h"
 #include "bootstrap/PersistenceContainer.h"
 #include "curl/CurlRequest.h"
+#include "helper/HelperFunctions.h"
+#include "mock/MockWinApi.h"
 
 using UKControllerPlugin::Bootstrap::ExternalsBootstrap;
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
 using UKControllerPlugin::Curl::CurlRequest;
+using UKControllerPlugin::HelperFunctions;
+using UKControllerPluginTest::Windows::MockWinApi;
+
+using testing::NiceMock;
+using testing::Return;
+using testing::_;
 
 namespace UKControllerPluginTest {
     namespace Bootstrap {
 
         class ExternalsBootstrapTest : public ::testing::Test {
+            public:
+                /*
+                    Get the My Documents path
+                */
+                std::wstring GetMyDocumentsPath(void)
+                {
+                    TCHAR myDocumentsPath[MAX_PATH];
+                    HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
 
+                    std::wstring widePath(myDocumentsPath);
+                    std::replace(widePath.begin(), widePath.end(), L'\\', L'/');
+                    return widePath;
+                }
+
+                /*
+                    Get the My Documents path
+                */
+                std::string GetMyDocumentsPathNarrow(void)
+                {
+                    TCHAR myDocumentsPath[MAX_PATH];
+                    HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
+
+                    std::wstring widePath(myDocumentsPath);
+                    std::replace(widePath.begin(), widePath.end(), L'\\', L'/');
+                    return HelperFunctions::ConvertToRegularString(widePath);
+                }
+
+                NiceMock<MockWinApi> winApiMock;
         };
+
 
         TEST_F(ExternalsBootstrapTest, BootstrapCreatesCurlApi)
         {
@@ -65,24 +101,54 @@ namespace UKControllerPluginTest {
 
         TEST_F(ExternalsBootstrapTest, GetPluginFileRootWideReturnsMyDocumentsEuroscopeFolder)
         {
-            TCHAR myDocumentsPath[MAX_PATH];
-            HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
-            std::wstring expected = myDocumentsPath + std::wstring(L"/EuroScope/ukcp");
-            std::replace(expected.begin(), expected.end(), L'\\', L'/');
-
+            std::wstring expected = this->GetMyDocumentsPath() + std::wstring(L"/EuroScope/ukcp");
             EXPECT_EQ(expected, ExternalsBootstrap::GetPluginFileRootWide());
         }
 
         TEST_F(ExternalsBootstrapTest, GetPluginFileRootReturnsMyDocumentsEuroscopeFolder)
         {
-            TCHAR myDocumentsPath[MAX_PATH];
-            HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
-            std::wstring widePath(myDocumentsPath);
-            std::replace(widePath.begin(), widePath.end(), L'\\', L'/');
-
-            std::string expected = std::string(widePath.cbegin(), widePath.cend()) + "/EuroScope/ukcp";
-
+            std::string expected = this->GetMyDocumentsPathNarrow() + "/EuroScope/ukcp";
             EXPECT_EQ(expected, ExternalsBootstrap::GetPluginFileRoot());
+        }
+
+        TEST_F(ExternalsBootstrapTest, SetupUkcpFolderRootThrowsExceptionOnFailedCreatingEuroscopeFolder)
+        {
+            std::string expected = this->GetMyDocumentsPathNarrow() + "/EuroScope";
+
+            ON_CALL(this->winApiMock, CreateFolder(expected))
+                .WillByDefault(Return(false));
+
+
+            EXPECT_THROW(ExternalsBootstrap::SetupUkcpFolderRoot(this->winApiMock),std::runtime_error);
+        }
+
+        TEST_F(ExternalsBootstrapTest, SetupUkcpFolderRootThrowsExceptionOnFailedCreatingUkcpFolder)
+        {
+            std::string expected = this->GetMyDocumentsPathNarrow() + "/EuroScope/ukcp";
+
+            ON_CALL(this->winApiMock, CreateFolder(_))
+                .WillByDefault(Return(true));
+
+            ON_CALL(this->winApiMock, CreateFolder(expected))
+                .WillByDefault(Return(false));
+
+            EXPECT_THROW(ExternalsBootstrap::SetupUkcpFolderRoot(this->winApiMock), std::runtime_error);
+        }
+
+        TEST_F(ExternalsBootstrapTest, SetupUkcpFolderRootCreatesFolders)
+        {
+            std::string expected1 = this->GetMyDocumentsPathNarrow() + "/EuroScope";
+            std::string expected2 = this->GetMyDocumentsPathNarrow() + "/EuroScope/ukcp";
+
+            EXPECT_CALL(this->winApiMock, CreateFolder(expected1))
+                .Times(1)
+                .WillOnce(Return(true));
+
+            EXPECT_CALL(this->winApiMock, CreateFolder(expected2))
+                .Times(1)
+                .WillOnce(Return(true));
+
+            EXPECT_NO_THROW(ExternalsBootstrap::SetupUkcpFolderRoot(this->winApiMock));
         }
     }  // namespace Bootstrap
 }  // namespace UKControllerPluginTest

--- a/test/test/bootstrap/ExternalsBootstrapTest.cpp
+++ b/test/test/bootstrap/ExternalsBootstrapTest.cpp
@@ -25,11 +25,17 @@ namespace UKControllerPluginTest {
                 */
                 std::wstring GetMyDocumentsPath(void)
                 {
-                    TCHAR myDocumentsPath[MAX_PATH];
-                    HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
+                    TCHAR * myDocumentsPath = 0;
+                    HRESULT result = SHGetKnownFolderPath(
+                        FOLDERID_Documents,
+                        KF_FLAG_SIMPLE_IDLIST,
+                        NULL,
+                        &myDocumentsPath
+                    );
 
                     std::wstring widePath(myDocumentsPath);
                     std::replace(widePath.begin(), widePath.end(), L'\\', L'/');
+                    CoTaskMemFree(myDocumentsPath);
                     return widePath;
                 }
 
@@ -38,12 +44,7 @@ namespace UKControllerPluginTest {
                 */
                 std::string GetMyDocumentsPathNarrow(void)
                 {
-                    TCHAR myDocumentsPath[MAX_PATH];
-                    HRESULT result = SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, myDocumentsPath);
-
-                    std::wstring widePath(myDocumentsPath);
-                    std::replace(widePath.begin(), widePath.end(), L'\\', L'/');
-                    return HelperFunctions::ConvertToRegularString(widePath);
+                    return HelperFunctions::ConvertToRegularString(this->GetMyDocumentsPath());
                 }
 
                 NiceMock<MockWinApi> winApiMock;

--- a/test/test/log/LoggerBootstrapTest.cpp
+++ b/test/test/log/LoggerBootstrapTest.cpp
@@ -8,7 +8,9 @@ using UKControllerPlugin::Bootstrap::PersistenceContainer;
 using UKControllerPlugin::Log::LoggerBootstrap;
 using testing::Test;
 using testing::NiceMock;
+using testing::StrEq;
 using testing::Return;
+using testing::_;
 
 namespace UKControllerPluginTest {
     namespace Log {
@@ -19,16 +21,22 @@ namespace UKControllerPluginTest {
                 PersistenceContainer container;
         };
 
-        TEST_F(LoggerBootstrapTest, ItThrowsExceptionIfItCannotCreateMockFolder)
+        TEST_F(LoggerBootstrapTest, ItNotifiesTheUserIfLogsFolderCannotBeCreated)
         {
             std::unique_ptr<NiceMock<MockWinApi>> mockWindows(new NiceMock<MockWinApi>);
 
+            std::wstring expected = L"Unable to create logs folder, please contact the VATSIM UK Web Department.\n\n";
+            expected += L"Plugin events will not be logged.";
+
             ON_CALL(*mockWindows, CreateLocalFolderRecursive)
                 .WillByDefault(Return(false));
+            
+            EXPECT_CALL(*mockWindows, OpenMessageBox(StrEq(expected.c_str()), _, _))
+                .Times(1);
 
             container.windows = std::move(mockWindows);
 
-            EXPECT_THROW(LoggerBootstrap::Bootstrap(container, false), std::runtime_error);
+            LoggerBootstrap::Bootstrap(container, false);
         }
 
     }  // namespace Log

--- a/test/test/log/LoggerBootstrapTest.cpp
+++ b/test/test/log/LoggerBootstrapTest.cpp
@@ -30,7 +30,7 @@ namespace UKControllerPluginTest {
 
             ON_CALL(*mockWindows, CreateLocalFolderRecursive)
                 .WillByDefault(Return(false));
-            
+
             EXPECT_CALL(*mockWindows, OpenMessageBox(StrEq(expected.c_str()), _, _))
                 .Times(1);
 


### PR DESCRIPTION
Close #66 

- Add code to ExternalsBootstrap that creates the `EuroScope/ukcp` folder without iterating from the absolute root.
- Update WinApi to work using `std::filesystem` rather than the basic API functions.