### PR TITLE
Reset Renderable Objects

### DIFF
--- a/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj
+++ b/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj
@@ -222,6 +222,7 @@
     <ClInclude Include="..\..\src\prenote\PrenoteServiceFactory.h" />
     <ClInclude Include="..\..\src\radarscreen\ConfigurableDisplayCollection.h" />
     <ClInclude Include="..\..\src\radarscreen\ConfigurableDisplayInterface.h" />
+    <ClInclude Include="..\..\src\radarscreen\PositionResetCommand.h" />
     <ClInclude Include="..\..\src\radarscreen\RadarRenderableCollection.h" />
     <ClInclude Include="..\..\src\radarscreen\RadarRenderableInterface.h" />
     <ClInclude Include="..\..\src\radarscreen\RadarScreenFactory.h" />
@@ -432,6 +433,7 @@
     <ClCompile Include="..\..\src\prenote\PrenoteService.cpp" />
     <ClCompile Include="..\..\src\prenote\PrenoteServiceFactory.cpp" />
     <ClCompile Include="..\..\src\radarscreen\ConfigurableDisplayCollection.cpp" />
+    <ClCompile Include="..\..\src\radarscreen\PositionResetCommand.cpp" />
     <ClCompile Include="..\..\src\radarscreen\RadarRenderableCollection.cpp" />
     <ClCompile Include="..\..\src\radarscreen\RadarScreenFactory.cpp" />
     <ClCompile Include="..\..\src\radarscreen\ScreenControls.cpp" />

--- a/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj.filters
+++ b/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj.filters
@@ -858,6 +858,9 @@
     <ClInclude Include="..\..\src\api\ApiConfigurationMenuItem.h">
       <Filter>src\api</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\radarscreen\PositionResetCommand.h">
+      <Filter>src\radarscreen</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\resource\UKControllerPlugin.rc">
@@ -1464,6 +1467,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\api\ApiConfigurationMenuItem.cpp">
       <Filter>src\api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\radarscreen\PositionResetCommand.cpp">
+      <Filter>src\radarscreen</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/msvc/UKControllerPluginTest/UKControllerPluginTest.vcxproj
+++ b/msvc/UKControllerPluginTest/UKControllerPluginTest.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="..\..\test\test\prenote\PrenoteServiceFactoryTest.cpp" />
     <ClCompile Include="..\..\test\test\prenote\PrenoteServiceTest.cpp" />
     <ClCompile Include="..\..\test\test\radarscreen\ConfigurableDisplayCollectionTest.cpp" />
+    <ClCompile Include="..\..\test\test\radarscreen\PositionResetCommandTest.cpp" />
     <ClCompile Include="..\..\test\test\radarscreen\RadarRenderableCollectionTest.cpp" />
     <ClCompile Include="..\..\test\test\radarscreen\ScreenControlsBootstrapTest.cpp" />
     <ClCompile Include="..\..\test\test\radarscreen\ScreenControlsTest.cpp" />

--- a/msvc/UKControllerPluginTest/UKControllerPluginTest.vcxproj.filters
+++ b/msvc/UKControllerPluginTest/UKControllerPluginTest.vcxproj.filters
@@ -668,6 +668,9 @@
     <ClCompile Include="..\..\test\test\log\LoggerBootstrapTest.cpp">
       <Filter>test\log</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\test\test\radarscreen\PositionResetCommandTest.cpp">
+      <Filter>test\radarscreen</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\test\helper\ApiRequestHelperFunctions.h">

--- a/src/countdown/CountdownRenderer.cpp
+++ b/src/countdown/CountdownRenderer.cpp
@@ -334,6 +334,14 @@ namespace UKControllerPlugin {
         }
 
         /*
+            Reset the positon of the display
+        */
+        void CountdownRenderer::ResetPosition(void)
+        {
+            this->Move({ 100, 100, 100, 100 }, "");
+        }
+
+        /*
             Moves all the elements of the display.
         */
         void CountdownRenderer::ShiftAllElements(int topLeftX, int topLeftY)

--- a/src/countdown/CountdownRenderer.h
+++ b/src/countdown/CountdownRenderer.h
@@ -77,6 +77,7 @@ namespace UKControllerPlugin {
                     UKControllerPlugin::Euroscope::EuroscopeRadarLoopbackInterface & radarScreen
                 ) override;
                 void SetVisible(bool visible);
+                void ResetPosition(void) override;
 
                 // The clickspot id for the number buttons and the reset button
                 const int functionsClickspotId;

--- a/src/historytrail/HistoryTrailRenderer.cpp
+++ b/src/historytrail/HistoryTrailRenderer.cpp
@@ -389,6 +389,13 @@ namespace UKControllerPlugin {
         }
 
         /*
+            History Trails cannot have their position reset. Do nothing.
+        */
+        void HistoryTrailRenderer::ResetPosition(void)
+        {
+        }
+
+        /*
             They aren't clickable.
         */
         void HistoryTrailRenderer::RightClick(

--- a/src/historytrail/HistoryTrailRenderer.h
+++ b/src/historytrail/HistoryTrailRenderer.h
@@ -80,6 +80,7 @@ namespace UKControllerPlugin {
                     UKControllerPlugin::Windows::GdiGraphicsInterface & graphics,
                     UKControllerPlugin::Euroscope::EuroscopeRadarLoopbackInterface & radarScreen
                 ) override;
+                void ResetPosition(void) override;
 
                 // The function ID for the toggle callback
                 const int toggleCallbackFunctionId;

--- a/src/hold/HoldRenderer.cpp
+++ b/src/hold/HoldRenderer.cpp
@@ -145,6 +145,20 @@ namespace UKControllerPlugin {
         }
 
         /*
+            Reset the position of each hold display
+        */
+        void HoldRenderer::ResetPosition(void)
+        {
+            for (
+                HoldDisplayManager::const_iterator it = this->displays->cbegin();
+                it != this->displays->cend();
+                ++it
+            ) {
+                (*it)->Move({ 100, 100 });
+            }
+        }
+
+        /*
             Toggle hold visibility
         */
         void HoldRenderer::Configure(int functionId, std::string subject, RECT screenObjectArea)

--- a/src/hold/HoldRenderer.h
+++ b/src/hold/HoldRenderer.h
@@ -42,6 +42,7 @@ namespace UKControllerPlugin {
                     UKControllerPlugin::Euroscope::EuroscopeRadarLoopbackInterface & radarScreen
                 ) override;
                 void SetVisible(bool visible);
+                void ResetPosition(void) override;
 
                 // Inherited via ConfigurableDisplayInterface
                 void Configure(int functionId, std::string subject, RECT screenObjectArea) override;

--- a/src/minstack/MinStackRenderer.cpp
+++ b/src/minstack/MinStackRenderer.cpp
@@ -345,6 +345,16 @@ namespace UKControllerPlugin {
         {
             this->visible = visible;
         }
-
+        
+        /*
+            Reset the position of the renderer
+        */
+        void MinStackRenderer::ResetPosition(void)
+        {
+            this->Move(
+                { 100, 100, 100 + this->leftColumnWidth, 100 + this->rowHeight },
+                ""
+            );
+        }
     }  // namespace MinStack
 }  // namespace UKControllerPlugin

--- a/src/minstack/MinStackRenderer.cpp
+++ b/src/minstack/MinStackRenderer.cpp
@@ -345,7 +345,7 @@ namespace UKControllerPlugin {
         {
             this->visible = visible;
         }
-        
+
         /*
             Reset the position of the renderer
         */

--- a/src/minstack/MinStackRenderer.h
+++ b/src/minstack/MinStackRenderer.h
@@ -70,6 +70,7 @@ namespace UKControllerPlugin {
                     UKControllerPlugin::Euroscope::EuroscopeRadarLoopbackInterface & radarScreen
                 );
                 void SetVisible(bool visible);
+                void ResetPosition(void) override;
 
                 // The EuroScope ID for the close button.
                 const int hideClickspotId;

--- a/src/radarscreen/PositionResetCommand.cpp
+++ b/src/radarscreen/PositionResetCommand.cpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "pch/stdafx.h"
+#include "radarscreen/PositionResetCommand.h"
+
+namespace UKControllerPlugin {
+    namespace RadarScreen {
+
+        PositionResetCommand::PositionResetCommand(const RadarRenderableCollection & renderables)
+            : renderables(renderables)
+        {
+
+        }
+
+        /*
+            Process commands
+        */
+        bool PositionResetCommand::ProcessCommand(std::string command)
+        {
+            if (command != this->resetCommand) {
+                return false;
+            }
+
+            this->renderables.ResetPosition();
+            return true;
+        }
+    }  // namespace RadarScreen
+}  // namespace UKControllerPlugin

--- a/src/radarscreen/PositionResetCommand.h
+++ b/src/radarscreen/PositionResetCommand.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "command/CommandHandlerInterface.h"
+#include "RadarScreen/RadarRenderableCollection.h"
+
+namespace UKControllerPlugin {
+    namespace RadarScreen {
+
+        /*
+            Processes commands to reset the position of renderables
+        */
+        class PositionResetCommand : public UKControllerPlugin::Command::CommandHandlerInterface
+        {
+            public:
+                PositionResetCommand(const UKControllerPlugin::RadarScreen::RadarRenderableCollection & renderables);
+
+                // Inherited via CommandHandlerInterface
+                bool ProcessCommand(std::string command) override;
+
+                // Command for resetting the visuals
+                const std::string resetCommand = ".ukcp resetvisuals";
+
+            private:
+                
+                // Radar renderables
+                const UKControllerPlugin::RadarScreen::RadarRenderableCollection & renderables;
+        };
+    }  // namespace RadarScreen
+}  // namespace UKControllerPlugin

--- a/src/radarscreen/PositionResetCommand.h
+++ b/src/radarscreen/PositionResetCommand.h
@@ -11,7 +11,9 @@ namespace UKControllerPlugin {
         class PositionResetCommand : public UKControllerPlugin::Command::CommandHandlerInterface
         {
             public:
-                PositionResetCommand(const UKControllerPlugin::RadarScreen::RadarRenderableCollection & renderables);
+                explicit PositionResetCommand(
+                    const UKControllerPlugin::RadarScreen::RadarRenderableCollection & renderables
+                );
 
                 // Inherited via CommandHandlerInterface
                 bool ProcessCommand(std::string command) override;
@@ -20,7 +22,7 @@ namespace UKControllerPlugin {
                 const std::string resetCommand = ".ukcp resetvisuals";
 
             private:
-                
+
                 // Radar renderables
                 const UKControllerPlugin::RadarScreen::RadarRenderableCollection & renderables;
         };

--- a/src/radarscreen/RadarRenderableCollection.cpp
+++ b/src/radarscreen/RadarRenderableCollection.cpp
@@ -190,5 +190,20 @@ namespace UKControllerPlugin {
                 }
             }
         }
+
+        /*
+            Process the command and see if its the reset visuals command.
+        */
+        void RadarRenderableCollection::ResetPosition(void) const
+        {
+            for (
+                std::map<int, std::shared_ptr<RadarRenderableInterface>>::const_iterator it
+                    = this->allRenderers.cbegin();
+                it != this->allRenderers.cend();
+                ++it
+            ) {
+                it->second->ResetPosition();
+            }
+        }
     }  // namespace RadarScreen
 }  // namespace UKControllerPlugin

--- a/src/radarscreen/RadarRenderableCollection.h
+++ b/src/radarscreen/RadarRenderableCollection.h
@@ -54,6 +54,7 @@ namespace UKControllerPlugin {
                     std::string objectDescription,
                     UKControllerPlugin::Euroscope::EuroscopeRadarLoopbackInterface & radarScreen
                 ) const;
+                void ResetPosition(void) const;
 
                 // Constant dictating that rendering should take place in the initial bitmap
                 const int initialPhase = 0;

--- a/src/radarscreen/RadarRenderableInterface.h
+++ b/src/radarscreen/RadarRenderableInterface.h
@@ -61,6 +61,11 @@ namespace UKControllerPlugin {
                     UKControllerPlugin::Windows::GdiGraphicsInterface & graphics,
                     UKControllerPlugin::Euroscope::EuroscopeRadarLoopbackInterface & radarScreen
                 ) = 0;
+
+                /*
+                    Reset the position of the object to default
+                */
+                virtual void ResetPosition() = 0;
         };
     }  // namespace RadarScreen
 }  // namespace UKControllerPlugin

--- a/src/radarscreen/RadarScreenFactory.cpp
+++ b/src/radarscreen/RadarScreenFactory.cpp
@@ -9,6 +9,7 @@
 #include "historytrail/HistoryTrailModule.h"
 #include "radarscreen/ConfigurableDisplayCollection.h"
 #include "radarscreen/ScreenControlsBootstrap.h"
+#include "radarscreen/PositionResetCommand.h"
 #include "command/CommandHandlerCollection.h"
 #include "euroscope/GeneralSettingsConfigurationBootstrap.h"
 #include "hold/HoldModule.h"
@@ -40,7 +41,8 @@ namespace UKControllerPlugin {
         UKControllerPlugin::UKRadarScreen * RadarScreenFactory::Create(void) const
         {
             // Create the collections
-            RadarRenderableCollection renderers;
+            this->renderableCollections.push_back(std::make_shared<RadarRenderableCollection>());
+            RadarRenderableCollection & renderers = *renderableCollections.back();
             AsrEventHandlerCollection userSettingHandlers;
             ConfigurableDisplayCollection configurableDisplays;
             CommandHandlerCollection commandHandlers;
@@ -93,6 +95,11 @@ namespace UKControllerPlugin {
                 userSettingHandlers,
                 commandHandlers,
                 this->persistence
+            );
+
+            // Register command for position resets
+            this->persistence.commandHandlers->RegisterHandler(
+                std::make_shared<PositionResetCommand>(renderers)
             );
 
             // Last thing we do is ScreenControls

--- a/src/radarscreen/RadarScreenFactory.h
+++ b/src/radarscreen/RadarScreenFactory.h
@@ -23,12 +23,12 @@ namespace UKControllerPlugin {
                 UKControllerPlugin::UKRadarScreen * Create(void) const;
 
             private:
-                
+
                 // Container of all the things
                 const UKControllerPlugin::Bootstrap::PersistenceContainer & persistence;
 
                 // Stores the renderables
-                mutable std::vector<std::shared_ptr<UKControllerPlugin::RadarScreen::RadarRenderableCollection>> 
+                mutable std::vector<std::shared_ptr<UKControllerPlugin::RadarScreen::RadarRenderableCollection>>
                     renderableCollections;
         };
     }  // namespace RadarScreen

--- a/src/radarscreen/RadarScreenFactory.h
+++ b/src/radarscreen/RadarScreenFactory.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "radarscreen/RadarRenderableCollection.h"
 
 // Forward declarations
 namespace UKControllerPlugin {
@@ -22,7 +23,13 @@ namespace UKControllerPlugin {
                 UKControllerPlugin::UKRadarScreen * Create(void) const;
 
             private:
+                
+                // Container of all the things
                 const UKControllerPlugin::Bootstrap::PersistenceContainer & persistence;
+
+                // Stores the renderables
+                mutable std::vector<std::shared_ptr<UKControllerPlugin::RadarScreen::RadarRenderableCollection>> 
+                    renderableCollections;
         };
     }  // namespace RadarScreen
 }  // namespace UKControllerPlugin

--- a/src/radarscreen/ScreenControls.cpp
+++ b/src/radarscreen/ScreenControls.cpp
@@ -109,7 +109,7 @@ namespace UKControllerPlugin {
                 false
             );
         }
-        
+
         /*
             This is always the bottom left of the screen, dont move.
         */

--- a/src/radarscreen/ScreenControls.cpp
+++ b/src/radarscreen/ScreenControls.cpp
@@ -109,5 +109,12 @@ namespace UKControllerPlugin {
                 false
             );
         }
+        
+        /*
+            This is always the bottom left of the screen, dont move.
+        */
+        void ScreenControls::ResetPosition(void)
+        {
+        }
     }  // namespace RadarScreen
 }  // namespace UKControllerPlugin

--- a/src/radarscreen/ScreenControls.h
+++ b/src/radarscreen/ScreenControls.h
@@ -52,6 +52,7 @@ namespace UKControllerPlugin {
                     UKControllerPlugin::Windows::GdiGraphicsInterface & graphics,
                     UKControllerPlugin::Euroscope::EuroscopeRadarLoopbackInterface & radarScreen
                 ) override;
+                void ResetPosition(void) override;
 
                 // The id for the togglebox
                 const int toggleboxIdEuroscope;

--- a/src/radarscreen/UKRadarScreen.cpp
+++ b/src/radarscreen/UKRadarScreen.cpp
@@ -12,7 +12,7 @@ namespace UKControllerPlugin {
 
     UKRadarScreen::UKRadarScreen(
         const UKControllerPlugin::Euroscope::AsrEventHandlerCollection userSettingEventHandler,
-        const UKControllerPlugin::RadarScreen::RadarRenderableCollection renderers,
+        const UKControllerPlugin::RadarScreen::RadarRenderableCollection & renderers,
         const UKControllerPlugin::Command::CommandHandlerCollection commandHandlers,
         UKControllerPlugin::Windows::GdiGraphicsInterface & graphics
     )

--- a/src/radarscreen/UKRadarScreen.h
+++ b/src/radarscreen/UKRadarScreen.h
@@ -39,7 +39,7 @@ namespace UKControllerPlugin {
         public:
             UKRadarScreen(
                 const UKControllerPlugin::Euroscope::AsrEventHandlerCollection userSettingEventHandler,
-                const UKControllerPlugin::RadarScreen::RadarRenderableCollection renderers,
+                const UKControllerPlugin::RadarScreen::RadarRenderableCollection & renderers,
                 const UKControllerPlugin::Command::CommandHandlerCollection commandHandlers,
                 UKControllerPlugin::Windows::GdiGraphicsInterface & graphics
             );
@@ -87,7 +87,7 @@ namespace UKControllerPlugin {
             const UKControllerPlugin::Euroscope::AsrEventHandlerCollection userSettingEventHandler;
 
             // All the things that render things to the screen
-            const UKControllerPlugin::RadarScreen::RadarRenderableCollection renderers;
+            const UKControllerPlugin::RadarScreen::RadarRenderableCollection & renderers;
 
             // Processes Euroscope dot commands
             const UKControllerPlugin::Command::CommandHandlerCollection commandHandlers;

--- a/test/mock/MockRadarRendererableInterface.h
+++ b/test/mock/MockRadarRendererableInterface.h
@@ -26,6 +26,7 @@ namespace UKControllerPluginTest {
                         UKControllerPlugin::Euroscope::EuroscopeRadarLoopbackInterface &
                     )
                 );
+                MOCK_METHOD0(ResetPosition, void(void));
         };
     }  // namespace RadarScreen
 }  // namespace UKControllerPluginTest

--- a/test/test/countdown/CountdownRendererTest.cpp
+++ b/test/test/countdown/CountdownRendererTest.cpp
@@ -486,5 +486,17 @@ namespace UKControllerPluginTest {
             renderer.LeftClick(renderer.functionsClickspotId, "R", mockRadarScreen);
             EXPECT_EQ(0, timer.GetSecondsRemaining());
         }
+
+        TEST(CountdownRenderer, ResetPositionSetsPosition)
+        {
+            StrictMock<MockWinApi> mockWindows;
+            CountdownTimer timer(mockWindows);
+            GdiplusBrushes brushes;
+            CountdownRenderer renderer(timer, 1, 2, 3, 4, brushes);
+
+            renderer.ResetPosition();
+            EXPECT_EQ(100, renderer.GetTimeDisplayArea().left);
+            EXPECT_EQ(100, renderer.GetTimeDisplayArea().top);
+        }
     }  // namespace Countdown
 }  // namespace UKControllerPluginTest

--- a/test/test/hold/HoldRendererTest.cpp
+++ b/test/test/hold/HoldRendererTest.cpp
@@ -42,6 +42,7 @@ namespace UKControllerPluginTest {
                     this->holdManager.AddHold(ManagedHold({ 1, "WILLO", "WILLO", 8000, 15000, 209, "left", {} }));
                     this->holdManager.AddHold(ManagedHold({ 2, "TIMBA", "TIMBA", 8000, 15000, 209, "left", {} }));
                     this->profileManager.AddProfile({ 1, "Test Profile", {1, 2} });
+
                     displayManager->AsrLoadedEvent(this->userSetting);
                     displayManager->LoadProfile(1);
                 }
@@ -140,6 +141,21 @@ namespace UKControllerPluginTest {
 
             EXPECT_EQ(0, this->displayManager->GetDisplay(1).GetLevelsSkipped());
             EXPECT_EQ(0, this->displayManager->GetDisplay(2).GetLevelsSkipped());
+        }
+
+        TEST_F(HoldRendererTest, ItResetsDisplayPositions)
+        {
+            POINT expectedDisplay1 = { 100, 100 };
+            POINT expectedDisplay2 = { 100, 100 };
+
+            this->renderer.Move({ 200, 200, 200, 200 }, "1");
+            this->renderer.Move({ 200, 200, 200, 200 }, "2");
+
+            this->renderer.ResetPosition();
+            EXPECT_EQ(expectedDisplay1.x, this->displayManager->GetDisplay(1).GetDisplayPos().x);
+            EXPECT_EQ(expectedDisplay1.y, this->displayManager->GetDisplay(1).GetDisplayPos().y);
+            EXPECT_EQ(expectedDisplay2.x, this->displayManager->GetDisplay(2).GetDisplayPos().x);
+            EXPECT_EQ(expectedDisplay2.y, this->displayManager->GetDisplay(2).GetDisplayPos().y);
         }
     }  // namespace Hold
 }  // namespace UKControllerPluginTest

--- a/test/test/minstack/MinStackRendererTest.cpp
+++ b/test/test/minstack/MinStackRendererTest.cpp
@@ -390,5 +390,18 @@ namespace UKControllerPluginTest {
             renderer.RightClick(renderer.hideClickspotId, "", mockRadarScreen);
             EXPECT_FALSE(renderer.IsVisible());
         }
+
+        TEST(MinStackRenderer, ResetPositionResetsPosition)
+        {
+            MinStackManager manager;
+            GdiplusBrushes brushes;
+            MinStackRenderer renderer(manager, 1, 2, 3, 4, brushes);
+            StrictMock<MockEuroscopeRadarScreenLoopbackInterface> mockRadarScreen;
+
+
+            renderer.ResetPosition();
+            EXPECT_EQ(100, renderer.GetTopBarArea().left);
+            EXPECT_EQ(100, renderer.GetTopBarArea().top);
+        }
     }  // namespace MinStack
 }  // namespace UKControllerPluginTest

--- a/test/test/radarscreen/PositionResetCommandTest.cpp
+++ b/test/test/radarscreen/PositionResetCommandTest.cpp
@@ -1,0 +1,52 @@
+#include "pch/pch.h"
+#include "radarscreen/PositionResetCommand.h"
+#include "radarscreen/RadarRenderableCollection.h"
+#include "mock/MockRadarRendererableInterface.h"
+
+using UKControllerPlugin::RadarScreen::PositionResetCommand;
+using UKControllerPlugin::RadarScreen::RadarRenderableCollection;
+using UKControllerPluginTest::RadarScreen::MockRadarRenderableInterface;
+using testing::Test;
+using testing::NiceMock;
+
+namespace UKControllerPluginTest {
+    namespace RadarScreen {
+
+        class PositionResetCommandTest : public Test
+        {
+            public:
+                PositionResetCommandTest()
+                    : command(collection)
+                {
+                    mockRenderable.reset(new NiceMock<MockRadarRenderableInterface>);
+                    this->collection.RegisterRenderer(
+                        1,
+                        mockRenderable,
+                        this->collection.afterLists
+                    );
+                }
+
+                std::shared_ptr <NiceMock<MockRadarRenderableInterface>> mockRenderable;
+                RadarRenderableCollection collection;
+                PositionResetCommand command;
+        };
+
+        TEST_F(PositionResetCommandTest, ProcessCommandReturnsFalseInvalidCommand)
+        {
+            EXPECT_FALSE(this->command.ProcessCommand("notacommand"));
+        }
+
+        TEST_F(PositionResetCommandTest, ProcessCommandReturnsTrueOnProcessedCommand)
+        {
+            EXPECT_TRUE(this->command.ProcessCommand(this->command.resetCommand));
+        }
+
+        TEST_F(PositionResetCommandTest, ProcessCommandResetsPositions)
+        {
+            EXPECT_CALL(*this->mockRenderable, ResetPosition())
+                .Times(1);
+            
+            this->command.ProcessCommand(this->command.resetCommand);
+        }
+    }  // namespace RadarScreen
+}  // namespace UKControllerPluginTest

--- a/test/test/radarscreen/PositionResetCommandTest.cpp
+++ b/test/test/radarscreen/PositionResetCommandTest.cpp
@@ -45,7 +45,7 @@ namespace UKControllerPluginTest {
         {
             EXPECT_CALL(*this->mockRenderable, ResetPosition())
                 .Times(1);
-            
+
             this->command.ProcessCommand(this->command.resetCommand);
         }
     }  // namespace RadarScreen

--- a/test/test/radarscreen/RadarRenderableCollectionTest.cpp
+++ b/test/test/radarscreen/RadarRenderableCollectionTest.cpp
@@ -367,5 +367,31 @@ namespace UKControllerPluginTest {
 
             collection.Render(collection.initialPhase, mockGraphics, mockRadarScreen);
         }
+
+        TEST(RadarRenderableCollection, ResetPositionResetsPositionOfAllRenderers)
+        {
+            RadarRenderableCollection collection;
+            std::shared_ptr<StrictMock<MockRadarRenderableInterface>> renderer1 =
+                std::make_shared<StrictMock<MockRadarRenderableInterface>>();
+            std::shared_ptr<StrictMock<MockRadarRenderableInterface>> renderer2 =
+                std::make_shared<StrictMock<MockRadarRenderableInterface>>();
+            std::shared_ptr<StrictMock<MockRadarRenderableInterface>> renderer3 =
+                std::make_shared<StrictMock<MockRadarRenderableInterface>>();
+
+            collection.RegisterRenderer(collection.ReserveRendererIdentifier(), renderer1, collection.initialPhase);
+            collection.RegisterRenderer(collection.ReserveRendererIdentifier(), renderer2, collection.beforeTags);
+            collection.RegisterRenderer(collection.ReserveRendererIdentifier(), renderer3, collection.afterTags);
+
+            EXPECT_CALL(*renderer1, ResetPosition())
+                .Times(1);
+
+            EXPECT_CALL(*renderer2, ResetPosition())
+                .Times(1);
+
+            EXPECT_CALL(*renderer3, ResetPosition())
+                .Times(1);
+
+            collection.ResetPosition();
+        }
     }  // namespace RadarScreen
 }  // namespace UKControllerPluginTest


### PR DESCRIPTION
Close #21 

- Adds command `.ukcp resetvisuals` to reset the screen position of all RadarRenderables, primarily useful for when things are off screen.