### PR TITLE
[DRAFT] Audio for vatsim

### DIFF
--- a/src/airfield/ControllerAirfieldOwnershipHandler.cpp
+++ b/src/airfield/ControllerAirfieldOwnershipHandler.cpp
@@ -69,6 +69,11 @@ namespace UKControllerPlugin {
             bool callsignActive = this->activeCallsigns.CallsignActive(controller.GetCallsign());
             bool frequencyActive = controller.HasActiveFrequency();
 
+            // If the controller isn't vatsim recognised as a controller, then they don't count.
+            if (!controller.IsVatsimRecognisedController()) {
+                return;
+            }
+
             // If it's already an active callsign with an active frequency, do nothing.
             if (callsignActive && frequencyActive) {
                 return;

--- a/src/euroscope/EuroScopeCControllerWrapper.cpp
+++ b/src/euroscope/EuroScopeCControllerWrapper.cpp
@@ -15,7 +15,8 @@ namespace UKControllerPlugin {
 
         bool EuroScopeCControllerWrapper::IsVatsimRecognisedController(void) const
         {
-            return this->originalData.IsController();
+            return this->originalData.IsController() &&
+                std::string(this->originalData.GetCallsign()).at(0) != '*';
         }
 
         const std::string EuroScopeCControllerWrapper::GetCallsign(void) const

--- a/test/test/controller/ControllerAirfieldOwnershipHandlerTest.cpp
+++ b/test/test/controller/ControllerAirfieldOwnershipHandlerTest.cpp
@@ -326,6 +326,10 @@ namespace UKControllerPluginTest {
         {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
 
+            EXPECT_CALL(euroscopeMock, IsVatsimRecognisedController())
+                .Times(1)
+                .WillOnce(Return(true));
+
             EXPECT_CALL(euroscopeMock, GetCallsign())
                 .Times(4)
                 .WillRepeatedly(Return("EGKK_TWR"));
@@ -343,6 +347,10 @@ namespace UKControllerPluginTest {
         TEST_F(ControllerAirfieldOwnershipHandlerTest, ControllerUpdateEventAddsActiveCallsign)
         {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
+
+            EXPECT_CALL(euroscopeMock, IsVatsimRecognisedController())
+                .Times(1)
+                .WillOnce(Return(true));
 
             EXPECT_CALL(euroscopeMock, GetCallsign())
                 .Times(4)
@@ -373,6 +381,10 @@ namespace UKControllerPluginTest {
         {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
 
+            EXPECT_CALL(euroscopeMock, IsVatsimRecognisedController())
+                .Times(1)
+                .WillOnce(Return(true));
+
             EXPECT_CALL(euroscopeMock, GetCallsign())
                 .Times(4)
                 .WillRepeatedly(Return("EGKK_DEL"));
@@ -400,6 +412,10 @@ namespace UKControllerPluginTest {
         TEST_F(ControllerAirfieldOwnershipHandlerTest, ControllerUpdateEventUpdatesTopDownMultiple)
         {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
+
+            EXPECT_CALL(euroscopeMock, IsVatsimRecognisedController())
+                .Times(1)
+                .WillOnce(Return(true));
 
             EXPECT_CALL(euroscopeMock, GetCallsign())
                 .Times(4)
@@ -434,6 +450,10 @@ namespace UKControllerPluginTest {
         {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
 
+            EXPECT_CALL(euroscopeMock, IsVatsimRecognisedController())
+                .Times(1)
+                .WillOnce(Return(true));
+
             EXPECT_CALL(euroscopeMock, GetCallsign())
                 .Times(4)
                 .WillRepeatedly(Return("EGKK_1-DEL"));
@@ -465,6 +485,7 @@ namespace UKControllerPluginTest {
             // Do some dummy flightplan setups.
             NiceMock<MockEuroScopeCRadarTargetInterface> mockRadarTarget;
             NiceMock<MockEuroScopeCFlightPlanInterface> mockFlightplan;
+
             ON_CALL(mockFlightplan, GetCallsign())
                 .WillByDefault(Return("BAW123"));
 
@@ -479,6 +500,10 @@ namespace UKControllerPluginTest {
 
             // Create the controller mock
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
+
+            EXPECT_CALL(euroscopeMock, IsVatsimRecognisedController())
+                .Times(1)
+                .WillOnce(Return(true));
 
             ON_CALL(euroscopeMock, GetCallsign())
                 .WillByDefault(Return("EGKK_DEL"));


### PR DESCRIPTION
Close #71 

- Adds a check for pseudopositions that are used by AFV, denoted by an asterisk at the start of the callsign. Ignores these positions when determining which callsigns are "Active".