### PR TITLE
Fix #81: ES Crash When Changing Primaries

### DIFF
--- a/src/controller/ActiveCallsignCollection.cpp
+++ b/src/controller/ActiveCallsignCollection.cpp
@@ -37,8 +37,12 @@ namespace UKControllerPlugin {
         */
         void ActiveCallsignCollection::AddUserCallsign(ActiveCallsign controller)
         {
-            if (this->userActive || this->CallsignActive(controller.GetCallsign())) {
+            if (this->CallsignActive(controller.GetCallsign())) {
                 throw std::invalid_argument("Callsign is already active.");
+            }
+
+            if (this->userActive) {
+                this->RemoveCallsign(*this->userCallsign);
             }
 
             this->userCallsign = this->activePositions[controller.GetNormalisedPosition().GetCallsign()]

--- a/test/test/controller/ActiveCallsignCollectionTest.cpp
+++ b/test/test/controller/ActiveCallsignCollectionTest.cpp
@@ -132,6 +132,18 @@ namespace UKControllerPluginTest {
             EXPECT_EQ(collection.GetUserCallsign(), callsign);
         }
 
+        TEST(ActiveCallsignCollection, AddingExtraUserCallsignRemovesTheFirst)
+        {
+            ActiveCallsignCollection collection;
+            ControllerPosition pos("LON_S_CTR", 129.420, "CTR", { "EGKK", "EGLL", "EGLC" });
+            ActiveCallsign callsign("LON_S_CTR", "Testy McTest", pos);
+            ActiveCallsign callsign2("LON_S1_CTR", "Testy McTest", pos);
+            collection.AddUserCallsign(callsign);
+            collection.AddUserCallsign(callsign2);
+            EXPECT_EQ(collection.GetUserCallsign(), callsign2);
+            EXPECT_FALSE(collection.CallsignActive("LON_S_CTR"));
+        }
+
         TEST(ActiveCallsignCollection, UserHasCallsignReturnsFalseIfNoneSet)
         {
             ActiveCallsignCollection collection;


### PR DESCRIPTION
When a controller changes primary frequencies, we don't get a disconnect
event if it's the user. Therefore, just remove the current user callsign
from the currently active array.