### PR TITLE
Fix #80: Aircraft Not Removed From Holds On Disconnect

### DIFF
--- a/src/hold/HoldManager.cpp
+++ b/src/hold/HoldManager.cpp
@@ -107,7 +107,6 @@ namespace UKControllerPlugin {
         {
             auto aircraft = this->holdingAircraft.find(callsign);
             if (aircraft == this->holdingAircraft.cend()) {
-                LogWarning("Tried to remove " + callsign + " from holds, it isnt holding");
                 return;
             }
 

--- a/src/plugin/UKPlugin.cpp
+++ b/src/plugin/UKPlugin.cpp
@@ -360,10 +360,6 @@ namespace UKControllerPlugin {
     */
     void UKPlugin::OnFlightPlanDisconnect(EuroScopePlugIn::CFlightPlan flightPlan)
     {
-        if (!flightPlan.IsValid() || flightPlan.GetSimulated()) {
-            return;
-        }
-
         EuroScopeCFlightPlanWrapper flightplanWrapper(flightPlan);
         this->flightplanEventHandler.FlightPlanDisconnectEvent(
             flightplanWrapper


### PR DESCRIPTION
Flightplan disconnect events were being supressed.