### PR TITLE
89 qnh updates on concerned

### DIFF
--- a/src/airfield/ControllerAirfieldOwnershipHandler.cpp
+++ b/src/airfield/ControllerAirfieldOwnershipHandler.cpp
@@ -87,7 +87,6 @@ namespace UKControllerPlugin {
 
             // Perform a match based on frequency and facility to find the canonical position
             ControllerPositionParser parser;
-            std::shared_ptr<ControllerPosition> pos;
             try {
                 this->SetupPosition(controller, this->controllers.FetchPositionByFacilityAndFrequency(
                     parser.ParseFacilityFromCallsign(controller.GetCallsign()),

--- a/src/controller/ControllerPosition.cpp
+++ b/src/controller/ControllerPosition.cpp
@@ -35,6 +35,15 @@ namespace UKControllerPlugin {
             return this->type;
         }
 
+        bool ControllerPosition::HasTopdownAirfield(std::string icao) const
+        {
+            return std::find(
+                this->topdown.cbegin(),
+                this->topdown.cend(),
+                icao
+            ) != this->topdown.cend();
+        }
+
         std::vector<std::string> ControllerPosition::GetTopdown(void) const
         {
             return this->topdown;

--- a/src/controller/ControllerPosition.h
+++ b/src/controller/ControllerPosition.h
@@ -20,6 +20,7 @@ namespace UKControllerPlugin {
                 double GetFrequency(void) const;
                 std::vector<std::string> GetTopdown(void) const;
                 std::string GetType(void) const;
+                bool HasTopdownAirfield(std::string icao) const;
                 bool operator==(const ControllerPosition & position) const;
 
             private:

--- a/src/metar/PressureMonitor.cpp
+++ b/src/metar/PressureMonitor.cpp
@@ -3,18 +3,20 @@
 #include "metar/MetarParsingFunctions.h"
 #include "metar/PressureChangeMessage.h"
 #include "euroscope/GeneralSettingsEntries.h"
+#include "controller/ControllerPosition.h"
 
 using UKControllerPlugin::Euroscope::UserSetting;
 using UKControllerPlugin::Euroscope::GeneralSettingsEntries;
 using UKControllerPlugin::Message::UserMessager;
 using UKControllerPlugin::Metar::PressureChangeMessage;
+using UKControllerPlugin::Controller::ActiveCallsignCollection;
 
 namespace UKControllerPlugin {
     namespace Metar {
 
 
-        PressureMonitor::PressureMonitor(UserMessager & userMessager)
-            : userMessager(userMessager)
+        PressureMonitor::PressureMonitor(UserMessager & userMessager, const ActiveCallsignCollection& activeCallsigns)
+            : userMessager(userMessager), activeCallsigns(activeCallsigns)
         {
 
         }
@@ -62,7 +64,13 @@ namespace UKControllerPlugin {
                 return;
             }
 
-            if (this->notificationsEnabled) {
+            if (
+                this->notificationsEnabled &&
+                this->activeCallsigns.UserHasCallsign() &&
+                this->activeCallsigns.GetUserCallsign().GetNormalisedPosition().HasTopdownAirfield(station)
+            ) {
+
+
                // Send message
                 PressureChangeMessage message(station, this->qnhs.at(station), newQnh);
                 this->userMessager.SendMessageToUser(message);

--- a/src/metar/PressureMonitor.h
+++ b/src/metar/PressureMonitor.h
@@ -3,6 +3,7 @@
 #include "euroscope/UserSetting.h"
 #include "message/UserMessager.h"
 #include "euroscope/UserSettingAwareInterface.h"
+#include "controller/ActiveCallsignCollection.h"
 
 namespace UKControllerPlugin {
     namespace Metar {
@@ -16,8 +17,9 @@ namespace UKControllerPlugin {
         {
             public:
 
-                explicit PressureMonitor(
-                    UKControllerPlugin::Message::UserMessager & userMessager
+                PressureMonitor(
+                    UKControllerPlugin::Message::UserMessager & userMessager,
+                    const UKControllerPlugin::Controller::ActiveCallsignCollection& activeCallsigns
                 );
                 std::string GetStoredQnh(std::string station) const;
                 bool NotificationsEnabled(void) const;
@@ -42,6 +44,9 @@ namespace UKControllerPlugin {
 
                 // Interface with ES for sending messages to the user about pressure changes.
                 UKControllerPlugin::Message::UserMessager & userMessager;
+
+                // All the active controller callsigns
+                const UKControllerPlugin::Controller::ActiveCallsignCollection& activeCallsigns;
         };
     }  // namespace Metar
 }  // namespace UKControllerPlugin

--- a/src/metar/PressureMonitorBootstrap.cpp
+++ b/src/metar/PressureMonitorBootstrap.cpp
@@ -13,7 +13,9 @@ namespace UKControllerPlugin {
         */
         void PressureMonitorBootstrap(const PersistenceContainer & container)
         {
-            std::shared_ptr<PressureMonitor> handler(new PressureMonitor(*container.userMessager));
+            std::shared_ptr<PressureMonitor> handler(
+                new PressureMonitor(*container.userMessager, *container.activeCallsigns)
+            );
 
             container.metarEventHandler->RegisterHandler(handler);
             container.userSettingHandlers->RegisterHandler(handler);

--- a/test/test/controller/ControllerPositionTest.cpp
+++ b/test/test/controller/ControllerPositionTest.cpp
@@ -78,5 +78,18 @@ namespace UKControllerPluginTest {
             ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
             EXPECT_TRUE("EGFF" == controller.GetUnit());
         }
+
+        TEST(ControllerPosition, ItReturnsTrueOnTopdownAirfield)
+        {
+            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
+            EXPECT_TRUE(controller.HasTopdownAirfield("EGFF"));
+            EXPECT_TRUE(controller.HasTopdownAirfield("EGGD"));
+        }
+
+        TEST(ControllerPosition, ItReturnsFalseOnNoTopdownAirfield)
+        {
+            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
+            EXPECT_FALSE(controller.HasTopdownAirfield("EGLL"));
+        }
     }  // namespace Controller
 }  // namespace UKControllerPluginTest


### PR DESCRIPTION
- Only send a QNH update message if the user is concerned (ie, may have topdown responsibility) on the airfield in question.