### PR TITLE
Controller Position Fixes

### DIFF
--- a/src/controller/ActiveCallsignMonitor.cpp
+++ b/src/controller/ActiveCallsignMonitor.cpp
@@ -68,8 +68,9 @@ namespace UKControllerPlugin {
             // Perform a match based on frequency and facility to find the canonical position
             ControllerPositionParser parser;
             try {
-                this->SetupPosition(controller, this->controllers.FetchPositionByFacilityAndFrequency(
+                this->SetupPosition(controller, this->controllers.FetchPositionByFacilityTypeAndFrequency(
                     parser.ParseFacilityFromCallsign(controller.GetCallsign()),
+                    parser.ParseTypeFromCallsign(controller.GetCallsign()),
                     controller.GetFrequency()
                 ));
             }

--- a/src/controller/ControllerPositionCollection.cpp
+++ b/src/controller/ControllerPositionCollection.cpp
@@ -32,8 +32,9 @@ namespace UKControllerPlugin {
         /*
             Retrieves a position based on it's facility (EGXX, LON, LTC, SCO etc) and frequency.
         */
-        const ControllerPosition & ControllerPositionCollection::FetchPositionByFacilityAndFrequency(
+        const ControllerPosition & ControllerPositionCollection::FetchPositionByFacilityTypeAndFrequency(
             std::string facility,
+            std::string type,
             double frequency
         ) const {
 
@@ -41,12 +42,13 @@ namespace UKControllerPlugin {
 
             // Iterate through the positions and try to match.
             auto position = std::find_if(this->positions.begin(), this->positions.end(),
-                [facility, frequency]
+                [facility, frequency, type]
                 (std::pair<std::string, const std::unique_ptr<ControllerPosition> &> position) -> bool {
 
                 // Frequency matching is done to 4dp, because floating points.
                 return fabs(frequency - position.second->GetFrequency()) < 0.001 &&
-                    position.first.substr(0, position.first.find('_')).compare(facility) == 0;
+                    position.second->GetUnit() == facility &&
+                    position.second->GetType() == type;
             });
 
             if (position == this->positions.end()) {

--- a/src/controller/ControllerPositionCollection.cpp
+++ b/src/controller/ControllerPositionCollection.cpp
@@ -39,11 +39,6 @@ namespace UKControllerPlugin {
 
             facility = TranslateFrequencyAbbreviation(facility);
 
-            // If there's no chance of finding anything, save us the iteration.
-            if (!this->IsPossibleAreaPosition(facility) && !this->IsPossibleAirfieldPosition(facility)) {
-                throw std::out_of_range("Position not found.");
-            }
-
             // Iterate through the positions and try to match.
             auto position = std::find_if(this->positions.begin(), this->positions.end(),
                 [facility, frequency]
@@ -72,24 +67,6 @@ namespace UKControllerPlugin {
         bool ControllerPositionCollection::HasPosition(std::string callsign) const
         {
             return this->positions.find(callsign) != this->positions.cend();
-        }
-
-        /*
-            Returns true if the facility is possible for an airfield.
-        */
-        bool ControllerPositionCollection::IsPossibleAirfieldPosition(std::string facility) const
-        {
-            return facility == "ESSEX" || facility == "THAMES" || facility == "SOLENT" ||
-                facility.size() == 4 && facility.substr(0, 2) == "EG";
-        }
-
-        /*
-            Returns true if the facility is possible for an area postion.
-        */
-        bool ControllerPositionCollection::IsPossibleAreaPosition(std::string facility) const
-        {
-            return facility == "LON" || facility == "LTC" ||
-                facility == "SCO" || facility == "STC" || facility == "MAN";
         }
     }  // namespace Controller
 }  // namespace UKControllerPlugin

--- a/src/controller/ControllerPositionCollection.h
+++ b/src/controller/ControllerPositionCollection.h
@@ -16,8 +16,9 @@ namespace UKControllerPlugin {
         public:
             bool AddPosition(std::unique_ptr<ControllerPosition> position);
             const ControllerPosition & FetchPositionByCallsign(std::string callsign) const;
-            const ControllerPosition & FetchPositionByFacilityAndFrequency(
+            const ControllerPosition & FetchPositionByFacilityTypeAndFrequency(
                 std::string facility,
+                std::string type,
                 double frequency
             ) const;
             size_t GetSize(void) const;

--- a/src/controller/ControllerPositionParser.cpp
+++ b/src/controller/ControllerPositionParser.cpp
@@ -27,6 +27,12 @@ namespace UKControllerPlugin {
             return normalise.substr(0, normalise.find('_'));
         }
 
+        std::string ControllerPositionParser::ParseTypeFromCallsign(std::string callsign) const
+        {
+            std::string normalise = this->NormaliseCallsign(callsign);
+            return normalise.substr(normalise.find_last_of('_') + 1);
+        }
+
         /*
             Returns whether the position is a mentors, trainees or non-mentoring
             position.

--- a/src/controller/ControllerPositionParser.h
+++ b/src/controller/ControllerPositionParser.h
@@ -9,6 +9,7 @@ namespace UKControllerPlugin {
                 ControllerPositionParser();
                 std::string NormaliseCallsign(std::string callsign) const;
                 std::string ParseFacilityFromCallsign(std::string callsign) const;
+                std::string ParseTypeFromCallsign(std::string callsign) const;
                 int IsMentoringPosition(std::string callsign) const;
 
                 // Represents a position that is not affiliated with training

--- a/test/test/controller/ActiveCallsignMonitorTest.cpp
+++ b/test/test/controller/ActiveCallsignMonitorTest.cpp
@@ -138,7 +138,6 @@ namespace UKControllerPluginTest {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
 
             EXPECT_CALL(euroscopeMock, GetCallsign())
-                .Times(3)
                 .WillRepeatedly(Return("EGKK_TWR"));
 
             this->handler.ControllerDisconnectEvent(euroscopeMock);
@@ -151,7 +150,6 @@ namespace UKControllerPluginTest {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
 
             EXPECT_CALL(euroscopeMock, GetCallsign())
-                .Times(1)
                 .WillOnce(Return("NOTAREALCALLSIGN"));
 
             this->handler.ControllerDisconnectEvent(euroscopeMock);
@@ -162,7 +160,6 @@ namespace UKControllerPluginTest {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
 
             EXPECT_CALL(euroscopeMock, GetCallsign())
-                .Times(4)
                 .WillRepeatedly(Return("EGKK_TWR"));
 
             EXPECT_CALL(euroscopeMock, HasActiveFrequency())
@@ -179,7 +176,6 @@ namespace UKControllerPluginTest {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
 
             EXPECT_CALL(euroscopeMock, GetCallsign())
-                .Times(4)
                 .WillRepeatedly(Return("EGKK_DEL"));
 
             EXPECT_CALL(euroscopeMock, HasActiveFrequency())
@@ -208,7 +204,6 @@ namespace UKControllerPluginTest {
             NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
 
             EXPECT_CALL(euroscopeMock, GetCallsign())
-                .Times(4)
                 .WillRepeatedly(Return("EGKK_1-DEL"));
 
             EXPECT_CALL(euroscopeMock, HasActiveFrequency())

--- a/test/test/controller/ControllerPositionCollectionTest.cpp
+++ b/test/test/controller/ControllerPositionCollectionTest.cpp
@@ -56,33 +56,43 @@ namespace UKControllerPluginTest {
             EXPECT_THROW(collection.FetchPositionByCallsign("EGFF_APP"), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyThrowsExceptionIfPositionNotFound)
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfPositionNotFound)
         {
             ControllerPositionCollection collection;
-            EXPECT_THROW(collection.FetchPositionByFacilityAndFrequency("EGBB", 121.200), std::out_of_range);
+            EXPECT_THROW(collection.FetchPositionByFacilityTypeAndFrequency("EGBB", "APP", 121.200), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyThrowsExceptionIfNoFrequencyMatch)
-        {
-            ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-            collection.AddPosition(std::move(controller));
-            EXPECT_THROW(collection.FetchPositionByFacilityAndFrequency("EGFF", 121.200), std::out_of_range);
-        }
-
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyThrowsExceptionIfNoFacilityMatch)
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoFrequencyMatch)
         {
             ControllerPositionCollection collection;
             std::unique_ptr<ControllerPosition> controller(
                 new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
             );
             collection.AddPosition(std::move(controller));
-            EXPECT_THROW(collection.FetchPositionByFacilityAndFrequency("EGHI", 125.850), std::out_of_range);
+            EXPECT_THROW(collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "APP", 121.200), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyReturnsOnMatch)
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoTypeMatch)
+        {
+            ControllerPositionCollection collection;
+            std::unique_ptr<ControllerPosition> controller(
+                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
+            );
+            collection.AddPosition(std::move(controller));
+            EXPECT_THROW(collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "TWR", 125.850), std::out_of_range);
+        }
+
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoFacilityMatch)
+        {
+            ControllerPositionCollection collection;
+            std::unique_ptr<ControllerPosition> controller(
+                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
+            );
+            collection.AddPosition(std::move(controller));
+            EXPECT_THROW(collection.FetchPositionByFacilityTypeAndFrequency("EGHI", "APP", 125.850), std::out_of_range);
+        }
+
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyReturnsOnMatch)
         {
             ControllerPositionCollection collection;
             std::unique_ptr<ControllerPosition> controller(
@@ -91,10 +101,10 @@ namespace UKControllerPluginTest {
 
             ControllerPosition * controllerRaw = controller.get();
             collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("EGFF", 125.850));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "APP", 125.850));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyReturnsOnMatchFrequencyDelta)
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyReturnsOnMatchFrequencyDelta)
         {
             ControllerPositionCollection collection;
             std::unique_ptr<ControllerPosition> controller(
@@ -103,10 +113,10 @@ namespace UKControllerPluginTest {
 
             ControllerPosition * controllerRaw = controller.get();
             collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("EGFF", 125.8514));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "APP", 125.8514));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyWillWorkForEssex)
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyWillWorkForEssex)
         {
             ControllerPositionCollection collection;
             std::unique_ptr<ControllerPosition> controller(
@@ -115,10 +125,10 @@ namespace UKControllerPluginTest {
 
             ControllerPosition * controllerRaw = controller.get();
             collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("ESSEX", 120.620));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("ESSEX", "APP", 120.620));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyWillWorkForThames)
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyWillWorkForThames)
         {
             ControllerPositionCollection collection;
             std::unique_ptr<ControllerPosition> controller(
@@ -127,10 +137,10 @@ namespace UKControllerPluginTest {
 
             ControllerPosition * controllerRaw = controller.get();
             collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("THAMES", 132.700));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("THAMES", "APP", 132.700));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyWillWorkForSolent)
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyWillWorkForSolent)
         {
             ControllerPositionCollection collection;
             std::unique_ptr<ControllerPosition> controller(
@@ -139,10 +149,10 @@ namespace UKControllerPluginTest {
 
             ControllerPosition * controllerRaw = controller.get();
             collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("SOLENT", 120.220));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("SOLENT", "APP", 120.220));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyWillWorkForAbbreviations)
+        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyWillWorkForAbbreviations)
         {
             ControllerPositionCollection collection;
             std::unique_ptr<ControllerPosition> controller(
@@ -151,7 +161,7 @@ namespace UKControllerPluginTest {
 
             ControllerPosition * controllerRaw = controller.get();
             collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityAndFrequency("ESX", 120.620));
+            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("ESX", "APP", 120.620));
         }
 
         TEST(ControllerPositionCollection, HasPositionReturnsFalseIfDoesntExist)

--- a/test/test/controller/ControllerPositionCollectionTest.cpp
+++ b/test/test/controller/ControllerPositionCollectionTest.cpp
@@ -56,12 +56,6 @@ namespace UKControllerPluginTest {
             EXPECT_THROW(collection.FetchPositionByCallsign("EGFF_APP"), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyThrowsExceptionIfNotPossible)
-        {
-            ControllerPositionCollection collection;
-            EXPECT_THROW(collection.FetchPositionByFacilityAndFrequency("EIDW", 121.200), std::out_of_range);
-        }
-
         TEST(ControllerPositionCollection, FetchPositionByFacilityAndFrequencyThrowsExceptionIfPositionNotFound)
         {
             ControllerPositionCollection collection;

--- a/test/test/controller/ControllerPositionParserTest.cpp
+++ b/test/test/controller/ControllerPositionParserTest.cpp
@@ -84,6 +84,84 @@ namespace UKControllerPluginTest {
             EXPECT_EQ(0, parser.ParseFacilityFromCallsign(callsign).compare("LON"));
         }
 
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksForDelivery)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "EGKK_DEL";
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("DEL"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCalsignGracefullyHandlesNonCallsigns)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "GATWICK";
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("GATWICK"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksForGround)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "EGKK_GND";
+
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("GND"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksForTower)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "EGKK_TWR";
+
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("TWR"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksForApp)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "EGKK_APP";
+
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("APP"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksForArea)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "LTC_S_CTR";
+
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("CTR"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksForFss)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "LTC_S_CTR";
+
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("CTR"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksHyphenatedCallsigns)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "LON-S_CTR";
+
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("CTR"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksHyphenatedCallsignsLast)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "LON_S-CTR";
+
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("CTR"));
+        }
+
+        TEST(ControllerPositionParser, ParseTypeFromCallsignWorksReliefCallsigns)
+        {
+            ControllerPositionParser parser;
+            std::string callsign = "LON_1_CTR";
+
+            EXPECT_EQ(0, parser.ParseTypeFromCallsign(callsign).compare("CTR"));
+        }
+
         TEST(ControllerPositionParser, IsMentoringPositionReturnsNonMentorIfNotTraining)
         {
             ControllerPositionParser parser;


### PR DESCRIPTION
- Remove restrictions on dependency controller position callsign formats, so we can facilitate positions such as Blackdog and Hotspur.
- Use the facility type when doing ActiveCallsign calculations, to allow us to differentiate when APP and TWR positions share a frequency.