### PR TITLE
Always Download Dependency If Not On Filesystem

### DIFF
--- a/src/dependency/UpdateDependencies.cpp
+++ b/src/dependency/UpdateDependencies.cpp
@@ -81,14 +81,18 @@ namespace UKControllerPlugin {
                 it != newDependencies.cend();
                 ++it
             ) {
-                if (!NeedsDownload(existingDependencies, newDependencies, it->first)) {
+                std::wstring widePath = HelperFunctions::ConvertToWideString(it->second.at("local_file"));
+
+                if (
+                    filesystem.FileExists(L"dependencies/" + widePath) &&
+                    !NeedsDownload(existingDependencies, newDependencies, it->first)
+                ) {
                     LogInfo("Dependency " + it->first + " is up to date, skipping download");
                     continue;
                 }
 
                 try {
                     LogInfo("Dependency " + it->first + " has a new version available, downloading");
-                    std::wstring widePath = HelperFunctions::ConvertToWideString(it->second.at("local_file"));
                     filesystem.WriteToFile(
                         L"dependencies/" + widePath,
                         api.GetUri(it->second.at("uri").get<std::string>()).dump(),


### PR DESCRIPTION
- At the moment, if we don't have a dependency on the file-system but its contained in the list file (e.g. a download failed in the past), we don't try to redownload it.
- This change downloads any missing files regardless.