### PR TITLE
Fix #164: Incorrect Departure Frequency

### DIFF
--- a/src/controller/ActiveCallsignMonitor.cpp
+++ b/src/controller/ActiveCallsignMonitor.cpp
@@ -37,7 +37,7 @@ namespace UKControllerPlugin {
             }
 
             ActiveCallsign active = this->activeCallsigns.GetCallsign(controller.GetCallsign());
-            LogInfo(controller.GetCallsign() + " has disconnected or unset their primary frequency");
+            LogInfo(controller.GetCallsign() + " has disconnected or has unset or changed their primary frequency");
             this->activeCallsigns.RemoveCallsign(active);
         }
 
@@ -49,9 +49,16 @@ namespace UKControllerPlugin {
             bool callsignActive = this->activeCallsigns.CallsignActive(controller.GetCallsign());
             bool frequencyActive = controller.HasActiveFrequency();
 
-            // If it's already an active callsign with an active frequency, do nothing.
+            // If it's already an active callsign with an active frequency, do nothing unless frequency has changed.
             if (callsignActive && frequencyActive) {
-                return;
+                double normalisedFrequency = this->activeCallsigns.GetCallsign(controller.GetCallsign())
+                    .GetNormalisedPosition()
+                    .GetFrequency();
+                if (fabs(controller.GetFrequency() - normalisedFrequency) < 0.001) {
+                    return;
+                }
+
+                this->ControllerDisconnectEvent(controller);
             }
 
             // If they're a registered callsign, but they've not got an active frequency, they must have unset primary.

--- a/test/test/controller/ActiveCallsignMonitorTest.cpp
+++ b/test/test/controller/ActiveCallsignMonitorTest.cpp
@@ -65,6 +65,11 @@ namespace UKControllerPluginTest {
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
+                        new ControllerPosition("EGKK_2_TWR", 199.997, "TWR", { "EGKK" })
+                    )
+                    );
+                    this->controllerCollection.AddPosition(
+                        std::unique_ptr<ControllerPosition>(
                             new ControllerPosition("EGKK_APP", 199.990, "APP", { "EGKK" })
                         )
                     );
@@ -92,6 +97,9 @@ namespace UKControllerPluginTest {
                     // Add the active callsigns
                     this->kkTwr = std::unique_ptr<ControllerPosition>(
                         new ControllerPosition("EGKK_TWR", 199.999, "TWR", { "EGKK" })
+                    );
+                    this->kkTwr2 = std::unique_ptr<ControllerPosition>(
+                        new ControllerPosition("EGKK_2_TWR", 199.997, "TWR", { "EGKK" })
                     );
                     this->kkApp = std::unique_ptr<ControllerPosition>(
                         new ControllerPosition("EGKK_APP", 199.990, "APP", { "EGKK" })
@@ -121,6 +129,7 @@ namespace UKControllerPluginTest {
 
                 // Controllers
                 std::unique_ptr<ControllerPosition> kkTwr;
+                std::unique_ptr<ControllerPosition> kkTwr2;
                 std::unique_ptr<ControllerPosition> kkApp;
                 std::unique_ptr<ControllerPosition> llTwr;
                 std::unique_ptr<ControllerPosition> llApp;
@@ -169,6 +178,44 @@ namespace UKControllerPluginTest {
             this->handler.ControllerUpdateEvent(euroscopeMock);
             EXPECT_FALSE(this->activeCallsigns.CallsignActive("EGKK_TWR"));
             EXPECT_FALSE(this->activeCallsigns.PositionActive("EGKK_TWR"));
+        }
+
+        TEST_F(ActiveCallsignMonitorTest, ControllerUpdateEventHandlesFrequencyChanges)
+        {
+            NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
+
+            EXPECT_CALL(euroscopeMock, GetCallsign())
+                .WillRepeatedly(Return("EGKK_TWR"));
+
+            EXPECT_CALL(euroscopeMock, GetFrequency())
+                .WillRepeatedly(Return(199.997));
+
+            EXPECT_CALL(euroscopeMock, HasActiveFrequency())
+                .Times(1)
+                .WillOnce(Return(true));
+
+            this->handler.ControllerUpdateEvent(euroscopeMock);
+            EXPECT_TRUE(this->activeCallsigns.CallsignActive("EGKK_TWR"));
+            EXPECT_EQ(*this->kkTwr2, this->activeCallsigns.GetCallsign("EGKK_TWR").GetNormalisedPosition());
+        }
+
+        TEST_F(ActiveCallsignMonitorTest, ControllerUpdateEventDoesNothingOnFrequencyChanges)
+        {
+            NiceMock<MockEuroScopeCControllerInterface> euroscopeMock;
+
+            EXPECT_CALL(euroscopeMock, GetCallsign())
+                .WillRepeatedly(Return("EGKK_TWR"));
+
+            EXPECT_CALL(euroscopeMock, GetFrequency())
+                .WillRepeatedly(Return(199.999));
+
+            EXPECT_CALL(euroscopeMock, HasActiveFrequency())
+                .Times(1)
+                .WillOnce(Return(true));
+
+            this->handler.ControllerUpdateEvent(euroscopeMock);
+            EXPECT_TRUE(this->activeCallsigns.CallsignActive("EGKK_TWR"));
+            EXPECT_EQ(*this->kkTwr, this->activeCallsigns.GetCallsign("EGKK_TWR").GetNormalisedPosition());
         }
 
         TEST_F(ActiveCallsignMonitorTest, ControllerUpdateEventAddsActiveCallsign)


### PR DESCRIPTION
- Changes ActiveCallsignMonitor to check that frequencies haven't changed in controller updates