### PR TITLE
Stand assignment textbox

### DIFF
--- a/docs/TAG_FUNCTIONS.md
+++ b/docs/TAG_FUNCTIONS.md
@@ -8,3 +8,4 @@
 9005 - Open Enroute Release Type Menu
 9006 - Open Enroute Release Point Edit Box
 9007 - Open Stand Assignment Selection Menu
+9008 - Open Stand Assignment Edit Box

--- a/src/euroscope/EuroScopeCFlightPlanInterface.h
+++ b/src/euroscope/EuroScopeCFlightPlanInterface.h
@@ -11,6 +11,7 @@ namespace UKControllerPlugin {
         {
             public:
                 virtual ~EuroScopeCFlightPlanInterface(void) {}
+                virtual void AnnotateFlightStrip(int index, std::string data) const = 0;
                 virtual const std::string GetCallsign(void) const = 0;
                 virtual const int GetClearedAltitude(void) const = 0;
                 virtual const int GetCruiseLevel(void) const = 0;

--- a/src/euroscope/EuroScopeCFlightPlanInterface.h
+++ b/src/euroscope/EuroScopeCFlightPlanInterface.h
@@ -12,6 +12,7 @@ namespace UKControllerPlugin {
             public:
                 virtual ~EuroScopeCFlightPlanInterface(void) {}
                 virtual void AnnotateFlightStrip(int index, std::string data) const = 0;
+                virtual std::string GetAnnotation(int index) const = 0;
                 virtual const std::string GetCallsign(void) const = 0;
                 virtual const int GetClearedAltitude(void) const = 0;
                 virtual const int GetCruiseLevel(void) const = 0;

--- a/src/euroscope/EuroScopeCFlightPlanWrapper.cpp
+++ b/src/euroscope/EuroScopeCFlightPlanWrapper.cpp
@@ -21,6 +21,11 @@ namespace UKControllerPlugin {
             this->originalData.GetControllerAssignedData().SetFlightStripAnnotation(index, data.c_str());
         }
 
+        std::string EuroScopeCFlightPlanWrapper::GetAnnotation(int index) const
+        {
+            return this->originalData.GetControllerAssignedData().GetFlightStripAnnotation(index);
+        }
+
         std::string EuroScopeCFlightPlanWrapper::GetAircraftType(void) const
         {
             return this->originalData.GetFlightPlanData().GetAircraftFPType();

--- a/src/euroscope/EuroScopeCFlightPlanWrapper.cpp
+++ b/src/euroscope/EuroScopeCFlightPlanWrapper.cpp
@@ -13,6 +13,14 @@ namespace UKControllerPlugin {
             this->originalData = originalData;
         }
 
+        /*
+            Note indexes begin from 0
+        */
+        void EuroScopeCFlightPlanWrapper::AnnotateFlightStrip(int index, std::string data) const
+        {
+            this->originalData.GetControllerAssignedData().SetFlightStripAnnotation(index, data.c_str());
+        }
+
         std::string EuroScopeCFlightPlanWrapper::GetAircraftType(void) const
         {
             return this->originalData.GetFlightPlanData().GetAircraftFPType();

--- a/src/euroscope/EuroScopeCFlightPlanWrapper.h
+++ b/src/euroscope/EuroScopeCFlightPlanWrapper.h
@@ -13,6 +13,7 @@ namespace UKControllerPlugin {
             public:
                 explicit EuroScopeCFlightPlanWrapper(EuroScopePlugIn::CFlightPlan originalData);
                 void AnnotateFlightStrip(int index, std::string data) const override;
+                std::string GetAnnotation(int index) const override;
                 std::string GetAircraftType(void) const override;
                 std::string GetAssignedSquawk(void) const;
                 const std::string GetCallsign(void) const;

--- a/src/euroscope/EuroScopeCFlightPlanWrapper.h
+++ b/src/euroscope/EuroScopeCFlightPlanWrapper.h
@@ -12,6 +12,7 @@ namespace UKControllerPlugin {
         {
             public:
                 explicit EuroScopeCFlightPlanWrapper(EuroScopePlugIn::CFlightPlan originalData);
+                void AnnotateFlightStrip(int index, std::string data) const override;
                 std::string GetAircraftType(void) const override;
                 std::string GetAssignedSquawk(void) const;
                 const std::string GetCallsign(void) const;

--- a/src/stands/StandEventHandler.cpp
+++ b/src/stands/StandEventHandler.cpp
@@ -274,6 +274,9 @@ namespace UKControllerPlugin {
                             return;
                         }
 
+                        // Delete all existing assignments
+                        this->standAssignments.clear();
+
                         for (
                             auto assignment = standAssignments.cbegin();
                             assignment != standAssignments.cend();

--- a/src/stands/StandEventHandler.cpp
+++ b/src/stands/StandEventHandler.cpp
@@ -114,6 +114,17 @@ namespace UKControllerPlugin {
 
         void StandEventHandler::StandSelected(int functionId, std::string context, RECT)
         {
+            /*
+                EuroScope has a weird bug when using edit boxes where it duplicates up the OnFunctionCall
+                event as a result of the box being filled in. This check makes sure we only process one event
+                per menu-load or edit-box completion.
+            */
+            if (this->lastAirfieldUsed == "") {
+                return;
+            }
+            std::string airfield = this->lastAirfieldUsed;
+            this->lastAirfieldUsed = "";
+
             // Only allow this action if they're tracking the flightplan or its untracked
             std::shared_ptr<EuroScopeCFlightPlanInterface> fp = this->plugin.GetSelectedFlightplan();
 
@@ -146,8 +157,8 @@ namespace UKControllerPlugin {
                 auto stand = std::find_if(
                     this->stands.cbegin(),
                     this->stands.cend(),
-                    [this, context](const Stand& stand) -> bool {
-                        return stand.identifier == context && stand.airfieldCode == this->lastAirfieldUsed;
+                    [airfield, context](const Stand& stand) -> bool {
+                        return stand.identifier == context && stand.airfieldCode == airfield;
                     }
                 );
 
@@ -198,7 +209,6 @@ namespace UKControllerPlugin {
                 this->standSelectedCallbackId,
                 startingText
             );
-
         }
 
         /*

--- a/src/stands/StandEventHandler.cpp
+++ b/src/stands/StandEventHandler.cpp
@@ -128,8 +128,11 @@ namespace UKControllerPlugin {
             }
 
             std::string callsign = fp->GetCallsign();
-            // If no stand is selected, delete the current assisnment if there is one
-            if (context == this->noStandMenuItem && this->standAssignments.count(callsign)) {
+            // If no stand is selected, delete the current assignment if there is one
+            if (
+                (context == this->noStandMenuItem || context == this->noStandEditBoxItem) &&
+                this->standAssignments.count(callsign)
+            ) {
                 this->taskRunner.QueueAsynchronousTask([this, callsign]() {
                     this->standAssignments.erase(callsign);
                     try {

--- a/src/stands/StandEventHandler.h
+++ b/src/stands/StandEventHandler.h
@@ -66,6 +66,7 @@ namespace UKControllerPlugin {
             private:
 
                 bool AssignmentMessageValid(const nlohmann::json& message) const;
+                bool CanAssignStand(UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightplan) const;
                 bool UnassignmentMessageValid(const nlohmann::json & message) const;
                 std::string GetAirfieldForStandAssignment(
                     UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightplan

--- a/src/stands/StandEventHandler.h
+++ b/src/stands/StandEventHandler.h
@@ -24,6 +24,8 @@ namespace UKControllerPlugin {
                     int standSelectedCallbackId
                 );
 
+                void AnnotateFlightStrip(std::string callsign, int standId) const;
+
                 size_t CountStands(void) const;
                 size_t CountStandAssignments(void) const;
                 void DisplayStandSelectionMenu(
@@ -34,6 +36,7 @@ namespace UKControllerPlugin {
                 );
                 int GetAssignedStandForCallsign(std::string callsign) const;
                 std::string GetLastAirfield(void) const;
+                void RemoveFlightStripAnnotation(std::string callsign) const;
                 void SetAssignedStand(std::string callsign, int standId);
                 void StandSelected(int functionId, std::string context, RECT);
                 void DisplayStandAssignmentEditBox(
@@ -65,6 +68,9 @@ namespace UKControllerPlugin {
 
                 // The text we get if no stand is specified in the edit box
                 const std::string noStandEditBoxItem = "";
+
+                // Annotation box 4
+                const int annotationIndex = 3;
 
             private:
 

--- a/src/stands/StandEventHandler.h
+++ b/src/stands/StandEventHandler.h
@@ -35,6 +35,12 @@ namespace UKControllerPlugin {
                 int GetAssignedStandForCallsign(std::string callsign) const;
                 void SetAssignedStand(std::string callsign, int standId);
                 void StandSelected(int functionId, std::string context, RECT);
+                void DisplayStandAssignmentEditBox(
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightplan,
+                    UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface& radarTarget,
+                    std::string context,
+                    const POINT& mousePos
+                );
 
                 // Inherited via WebsocketEventProcessorInterface
                 void ProcessWebsocketMessage(const UKControllerPlugin::Websocket::WebsocketMessage& message) override;

--- a/src/stands/StandEventHandler.h
+++ b/src/stands/StandEventHandler.h
@@ -33,6 +33,7 @@ namespace UKControllerPlugin {
                     const POINT& mousePos
                 );
                 int GetAssignedStandForCallsign(std::string callsign) const;
+                std::string GetLastAirfield(void) const;
                 void SetAssignedStand(std::string callsign, int standId);
                 void StandSelected(int functionId, std::string context, RECT);
                 void DisplayStandAssignmentEditBox(
@@ -66,9 +67,12 @@ namespace UKControllerPlugin {
 
                 bool AssignmentMessageValid(const nlohmann::json& message) const;
                 bool UnassignmentMessageValid(const nlohmann::json & message) const;
+                std::string GetAirfieldForStandAssignment(
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightplan
+                );
 
                 // The last airfield that was used to populate the stand menu
-                std::string lastAirfieldUsed;
+                std::string lastAirfieldUsed = "";
 
                 // The API for making requests in relation to stands
                 const UKControllerPlugin::Api::ApiInterface& api;

--- a/src/stands/StandEventHandler.h
+++ b/src/stands/StandEventHandler.h
@@ -63,6 +63,9 @@ namespace UKControllerPlugin {
                 // The menu item to display for no assigned stand
                 const std::string noStandMenuItem = "--";
 
+                // The text we get if no stand is specified in the edit box
+                const std::string noStandEditBoxItem = "";
+
             private:
 
                 bool AssignmentMessageValid(const nlohmann::json& message) const;

--- a/src/stands/StandEventHandler.h
+++ b/src/stands/StandEventHandler.h
@@ -6,6 +6,7 @@
 #include "task/TaskRunnerInterface.h"
 #include "websocket/WebsocketEventProcessorInterface.h"
 #include "euroscope/EuroscopePluginLoopbackInterface.h"
+#include "flightplan/FlightPlanEventHandlerInterface.h"
 
 namespace UKControllerPlugin {
     namespace Stands {
@@ -13,7 +14,8 @@ namespace UKControllerPlugin {
             A new class
         */
         class StandEventHandler: public UKControllerPlugin::Tag::TagItemInterface,
-            public UKControllerPlugin::Websocket::WebsocketEventProcessorInterface
+            public UKControllerPlugin::Websocket::WebsocketEventProcessorInterface,
+            public UKControllerPlugin::Flightplan::FlightPlanEventHandlerInterface
         {
             public:
                 StandEventHandler(
@@ -53,6 +55,19 @@ namespace UKControllerPlugin {
                 // Inherited via TagItemInterface
                 std::string GetTagItemDescription(int tagItemId) const override;
                 void SetTagItemData(UKControllerPlugin::Tag::TagData& tagData) override;
+
+                // Inherited via FlightPlanEventHandlerInterface
+                void FlightPlanEvent(
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightPlan,
+                    UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface& radarTarget
+                ) override;
+                void FlightPlanDisconnectEvent(
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightPlan
+                ) override;
+                void ControllerFlightPlanDataEvent(
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightPlan,
+                    int dataType
+                ) override;
 
                 // No stand has been assigned to the aircraft
                 const int noStandAssigned = -1;

--- a/src/stands/StandEventHandler.h
+++ b/src/stands/StandEventHandler.h
@@ -75,7 +75,7 @@ namespace UKControllerPlugin {
                     UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightplan
                 );
 
-                // The last airfield that was used to populate the stand menu
+                // The last airfield that was used to populate the stand menu, used when we receive the callback
                 std::string lastAirfieldUsed = "";
 
                 // The API for making requests in relation to stands

--- a/src/stands/StandModule.cpp
+++ b/src/stands/StandModule.cpp
@@ -87,6 +87,7 @@ namespace UKControllerPlugin {
             container.pluginFunctionHandlers->RegisterFunctionCall(openStandAssignmentEditBox);
 
             // Assign to handlers
+            container.flightplanHandler->RegisterHandler(eventHandler);
             container.tagHandler->RegisterTagItem(assignedStandTagItemId, eventHandler);
             container.websocketProcessors->AddProcessor(eventHandler);
         }

--- a/src/stands/StandModule.cpp
+++ b/src/stands/StandModule.cpp
@@ -74,7 +74,7 @@ namespace UKControllerPlugin {
             // TAG function to trigger the stand assignment edit box, uses existing callback
             TagFunction openStandAssignmentEditBox(
                 openStandAssignmentEditBoxTagFunctionId,
-                "Edit Enroute Release Point",
+                "Open Stand Assignment Edit Box",
                 std::bind(
                     &StandEventHandler::DisplayStandAssignmentEditBox,
                     eventHandler,

--- a/src/stands/StandModule.cpp
+++ b/src/stands/StandModule.cpp
@@ -21,6 +21,7 @@ namespace UKControllerPlugin {
         // The tag item id for assigned stand
         const int assignedStandTagItemId = 110;
         const int openStandAssignmentPopupTagFunctionId = 9007;
+        const int openStandAssignmentEditBoxTagFunctionId = 9008;
 
         const std::string standDependency = "DEPENDENCY_STANDS";
 
@@ -57,9 +58,9 @@ namespace UKControllerPlugin {
             );
             container.pluginFunctionHandlers->RegisterFunctionCall(openStandAssignmentPopupMenu);
 
-            CallbackFunction releaseTypeSelectedCallback(
+            CallbackFunction standSelectedCallback(
                 eventHandler->standSelectedCallbackId,
-                "Release Type Selected",
+                "Stand Selected",
                 std::bind(
                     &StandEventHandler::StandSelected,
                     eventHandler,
@@ -68,7 +69,22 @@ namespace UKControllerPlugin {
                     std::placeholders::_3
                 )
             );
-            container.pluginFunctionHandlers->RegisterFunctionCall(releaseTypeSelectedCallback);
+            container.pluginFunctionHandlers->RegisterFunctionCall(standSelectedCallback);
+
+            // TAG function to trigger the stand assignment edit box, uses existing callback
+            TagFunction openStandAssignmentEditBox(
+                openStandAssignmentEditBoxTagFunctionId,
+                "Edit Enroute Release Point",
+                std::bind(
+                    &StandEventHandler::DisplayStandAssignmentEditBox,
+                    eventHandler,
+                    std::placeholders::_1,
+                    std::placeholders::_2,
+                    std::placeholders::_3,
+                    std::placeholders::_4
+                )
+            );
+            container.pluginFunctionHandlers->RegisterFunctionCall(openStandAssignmentEditBox);
 
             // Assign to handlers
             container.tagHandler->RegisterTagItem(assignedStandTagItemId, eventHandler);

--- a/test/mock/MockEuroScopeCFlightplanInterface.h
+++ b/test/mock/MockEuroScopeCFlightplanInterface.h
@@ -8,6 +8,7 @@ namespace UKControllerPluginTest {
         class MockEuroScopeCFlightPlanInterface : public UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface
         {
             public:
+                MOCK_CONST_METHOD2(AnnotateFlightStrip, void(int, std::string));
                 MOCK_CONST_METHOD0(GetAircraftType, std::string(void));
                 MOCK_CONST_METHOD0(GetCallsign, const std::string(void));
                 MOCK_CONST_METHOD0(GetClearedAltitude, const int(void));

--- a/test/mock/MockEuroScopeCFlightplanInterface.h
+++ b/test/mock/MockEuroScopeCFlightplanInterface.h
@@ -9,6 +9,7 @@ namespace UKControllerPluginTest {
         {
             public:
                 MOCK_CONST_METHOD2(AnnotateFlightStrip, void(int, std::string));
+                MOCK_CONST_METHOD1(GetAnnotation, std::string(int));
                 MOCK_CONST_METHOD0(GetAircraftType, std::string(void));
                 MOCK_CONST_METHOD0(GetCallsign, const std::string(void));
                 MOCK_CONST_METHOD0(GetClearedAltitude, const int(void));

--- a/test/test/stands/StandEventHandlerTest.cpp
+++ b/test/test/stands/StandEventHandlerTest.cpp
@@ -633,6 +633,116 @@ namespace UKControllerPluginTest {
             this->handler.DisplayStandSelectionMenu(this->flightplan, this->radarTarget, "", { 0, 0 });
         }
 
+        TEST_F(StandEventHandlerTest, ItTriggersTheStandEditBoxWithDepartureAirportIfWithinLimit)
+        {
+            // Tracked by user
+            ON_CALL(this->flightplan, IsTracked())
+                .WillByDefault(Return(true));
+
+            ON_CALL(this->flightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
+            ON_CALL(this->flightplan, GetCallsign())
+                .WillByDefault(Return("BAW123"));
+
+            ON_CALL(this->flightplan, GetOrigin())
+                .WillByDefault(Return("EGKK"));
+
+            ON_CALL(this->flightplan, GetDistanceFromOrigin())
+                .WillByDefault(Return(4));
+
+            RECT expectedArea = { 0, 0, 80, 25 };
+            EXPECT_CALL(this->plugin, ShowTextEditPopup(RectEq(expectedArea), 1, ""))
+                .Times(1);
+
+            this->handler.DisplayStandAssignmentEditBox(this->flightplan, this->radarTarget, "", { 0, 0 });
+            EXPECT_EQ("EGKK", this->handler.GetLastAirfield());
+        }
+
+        TEST_F(StandEventHandlerTest, ItTriggersTheStandEditBoxWithArrivalAirportIfNotCloseToDeparture)
+        {
+            // Not tracked by anyone
+            ON_CALL(this->flightplan, IsTracked())
+                .WillByDefault(Return(false));
+
+            ON_CALL(this->flightplan, IsTrackedByUser())
+                .WillByDefault(Return(false));
+
+            ON_CALL(this->flightplan, GetCallsign())
+                .WillByDefault(Return("BAW123"));
+
+            ON_CALL(this->flightplan, GetOrigin())
+                .WillByDefault(Return("EGKK"));
+
+            ON_CALL(this->flightplan, GetDestination())
+                .WillByDefault(Return("EGLL"));
+
+            ON_CALL(this->flightplan, GetDistanceFromOrigin())
+                .WillByDefault(Return(8));
+
+            RECT expectedArea = { 0, 0, 80, 25 };
+            EXPECT_CALL(this->plugin, ShowTextEditPopup(RectEq(expectedArea), 1, ""))
+                .Times(1);
+
+            this->handler.DisplayStandAssignmentEditBox(this->flightplan, this->radarTarget, "", { 0, 0 });
+            EXPECT_EQ("EGLL", this->handler.GetLastAirfield());
+        }
+
+        TEST_F(StandEventHandlerTest, ItDoesntTriggerTheEditBoxIfFlightplanTrackedBySomeoneElse)
+        {
+            // Not tracked by user
+            ON_CALL(this->flightplan, IsTracked())
+                .WillByDefault(Return(true));
+
+            ON_CALL(this->flightplan, IsTrackedByUser())
+                .WillByDefault(Return(false));
+
+            ON_CALL(this->flightplan, GetCallsign())
+                .WillByDefault(Return("BAW123"));
+
+            ON_CALL(this->flightplan, GetOrigin())
+                .WillByDefault(Return("EGKK"));
+
+            ON_CALL(this->flightplan, GetDistanceFromOrigin())
+                .WillByDefault(Return(4));
+
+            EXPECT_CALL(this->plugin, ShowTextEditPopup(_, _, _))
+                .Times(0);
+
+            this->handler.DisplayStandAssignmentEditBox(this->flightplan, this->radarTarget, "", { 0, 0 });
+            EXPECT_EQ("", this->handler.GetLastAirfield());
+        }
+
+        TEST_F(StandEventHandlerTest, ItTriggersTheStandEditBoxWithCurrentStandIfOneAssigned)
+        {
+            this->handler.SetAssignedStand("BAW123", 1);
+
+            // Not tracked by anyone
+            ON_CALL(this->flightplan, IsTracked())
+                .WillByDefault(Return(false));
+
+            ON_CALL(this->flightplan, IsTrackedByUser())
+                .WillByDefault(Return(false));
+
+            ON_CALL(this->flightplan, GetCallsign())
+                .WillByDefault(Return("BAW123"));
+
+            ON_CALL(this->flightplan, GetOrigin())
+                .WillByDefault(Return("EGKK"));
+
+            ON_CALL(this->flightplan, GetDestination())
+                .WillByDefault(Return("EGLL"));
+
+            ON_CALL(this->flightplan, GetDistanceFromOrigin())
+                .WillByDefault(Return(8));
+
+            RECT expectedArea = { 0, 0, 80, 25 };
+            EXPECT_CALL(this->plugin, ShowTextEditPopup(RectEq(expectedArea), 1, "1L"))
+                .Times(1);
+
+            this->handler.DisplayStandAssignmentEditBox(this->flightplan, this->radarTarget, "", { 0, 0 });
+        }
+
         TEST_F(StandEventHandlerTest, ItDoesntMakeAStandAssignmentRequestIfFlightplanTrackedBySomeoneElse)
         {
             // Trigger the menu first to set the last airport

--- a/test/test/stands/StandEventHandlerTest.cpp
+++ b/test/test/stands/StandEventHandlerTest.cpp
@@ -130,6 +130,33 @@ namespace UKControllerPluginTest {
                 }
             };
 
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "1L"))
+                .Times(1);
+
+            this->handler.ProcessWebsocketMessage(message);
+            ASSERT_EQ(1, this->handler.GetAssignedStandForCallsign("BAW123"));
+        }
+
+        TEST_F(StandEventHandlerTest, ItHandlesNoFlightplanForAnnotations)
+        {
+            WebsocketMessage message{
+                "App\\Events\\StandAssignedEvent",
+                "private-stand-assignments",
+                nlohmann::json {
+                    {"callsign", "BAW123"},
+                    {"stand_id", 1},
+                }
+            };
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(nullptr));
+
             this->handler.ProcessWebsocketMessage(message);
             ASSERT_EQ(1, this->handler.GetAssignedStandForCallsign("BAW123"));
         }
@@ -218,6 +245,15 @@ namespace UKControllerPluginTest {
                 }
             };
 
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, ""))
+                .Times(1);
+
             this->handler.ProcessWebsocketMessage(message);
             ASSERT_EQ(this->handler.noStandAssigned, this->handler.GetAssignedStandForCallsign("BAW123"));
         }
@@ -283,6 +319,24 @@ namespace UKControllerPluginTest {
                 nlohmann::json(),
             };
 
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp1
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp1));
+
+            EXPECT_CALL(*pluginReturnedFp1, AnnotateFlightStrip(3, "1L"))
+                .Times(1);
+
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp2
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("VIR245"))
+                .WillByDefault(Return(pluginReturnedFp2));
+
+            EXPECT_CALL(*pluginReturnedFp2, AnnotateFlightStrip(3, "55"))
+                .Times(1);
+
             EXPECT_CALL(this->api, GetAssignedStands())
                 .Times(1)
                 .WillOnce(Return(assignments));
@@ -346,6 +400,15 @@ namespace UKControllerPluginTest {
                 nlohmann::json(),
             };
 
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "1L"))
+                .Times(1);
+
             EXPECT_CALL(this->api, GetAssignedStands())
                 .Times(1)
                 .WillOnce(Return(assignments));
@@ -370,6 +433,15 @@ namespace UKControllerPluginTest {
                 "bla",
                 nlohmann::json(),
             };
+
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "1L"))
+                .Times(1);
 
             EXPECT_CALL(this->api, GetAssignedStands())
                 .Times(1)
@@ -397,6 +469,15 @@ namespace UKControllerPluginTest {
                 nlohmann::json(),
             };
 
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "1L"))
+                .Times(1);
+
             EXPECT_CALL(this->api, GetAssignedStands())
                 .Times(1)
                 .WillOnce(Return(assignments));
@@ -421,6 +502,15 @@ namespace UKControllerPluginTest {
                 "bla",
                 nlohmann::json(),
             };
+
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "1L"))
+                .Times(1);
 
             EXPECT_CALL(this->api, GetAssignedStands())
                 .Times(1)
@@ -448,6 +538,15 @@ namespace UKControllerPluginTest {
                 nlohmann::json(),
             };
 
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "1L"))
+                .Times(1);
+
             EXPECT_CALL(this->api, GetAssignedStands())
                 .Times(1)
                 .WillOnce(Return(assignments));
@@ -473,6 +572,15 @@ namespace UKControllerPluginTest {
                 "bla",
                 nlohmann::json(),
             };
+
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "1L"))
+                .Times(1);
 
             EXPECT_CALL(this->api, GetAssignedStands())
                 .Times(1)
@@ -1020,6 +1128,12 @@ namespace UKControllerPluginTest {
             ON_CALL(this->plugin, GetSelectedFlightplan())
                 .WillByDefault(Return(pluginReturnedFp));
 
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "55"))
+                .Times(1);
+
             EXPECT_CALL(this->api, AssignStandToAircraft("BAW123", 2))
                 .Times(1);
 
@@ -1067,6 +1181,12 @@ namespace UKControllerPluginTest {
 
             ON_CALL(this->plugin, GetSelectedFlightplan())
                 .WillByDefault(Return(pluginReturnedFp));
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, "55"))
+                .Times(1);
 
             EXPECT_CALL(this->api, AssignStandToAircraft("BAW123", 2))
                 .Times(1)
@@ -1167,7 +1287,13 @@ namespace UKControllerPluginTest {
             ON_CALL(this->plugin, GetSelectedFlightplan())
                 .WillByDefault(Return(pluginReturnedFp));
 
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
             EXPECT_CALL(this->api, DeleteStandAssignmentForAircraft("BAW123"))
+                .Times(1);
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, ""))
                 .Times(1);
 
             this->handler.StandSelected(1, "--", {});
@@ -1217,7 +1343,13 @@ namespace UKControllerPluginTest {
             ON_CALL(this->plugin, GetSelectedFlightplan())
                 .WillByDefault(Return(pluginReturnedFp));
 
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Return(pluginReturnedFp));
+
             EXPECT_CALL(this->api, DeleteStandAssignmentForAircraft("BAW123"))
+                .Times(1);
+
+            EXPECT_CALL(*pluginReturnedFp, AnnotateFlightStrip(3, ""))
                 .Times(1);
 
             this->handler.StandSelected(1, "", {});

--- a/test/test/stands/StandEventHandlerTest.cpp
+++ b/test/test/stands/StandEventHandlerTest.cpp
@@ -292,6 +292,28 @@ namespace UKControllerPluginTest {
             ASSERT_EQ(2, this->handler.GetAssignedStandForCallsign("VIR245"));
         }
 
+        TEST_F(StandEventHandlerTest, ItClearsPreviousAssignmentsOnWebsocketConnection)
+        {
+            nlohmann::json assignments = nlohmann::json::array();
+            assignments.push_back({
+                {"callsign", "BAW123"},
+                {"stand_id", 1},
+            });
+            WebsocketMessage message{
+                "pusher:connection_established",
+                "bla",
+                nlohmann::json(),
+            };
+
+            EXPECT_CALL(this->api, GetAssignedStands())
+                .Times(1)
+                .WillOnce(Return(assignments));
+
+            this->handler.SetAssignedStand("RYR234", 3);
+            this->handler.ProcessWebsocketMessage(message);
+            ASSERT_EQ(this->handler.noStandAssigned, this->handler.GetAssignedStandForCallsign("RYR234"));
+        }
+
         TEST_F(StandEventHandlerTest, ItHandlesNonArrayStandAssignments)
         {
             nlohmann::json assignments = nlohmann::json::object();

--- a/test/test/stands/StandEventHandlerTest.cpp
+++ b/test/test/stands/StandEventHandlerTest.cpp
@@ -1144,6 +1144,56 @@ namespace UKControllerPluginTest {
             EXPECT_EQ(this->handler.noStandAssigned, this->handler.GetAssignedStandForCallsign("BAW123"));
         }
 
+        TEST_F(StandEventHandlerTest, ItDeletesStandAssignmentsViaTheEditBoxIfSet)
+        {
+            this->handler.SetAssignedStand("BAW123", 2);
+
+            // Trigger the menu first to set the last airport
+            ON_CALL(this->flightplan, IsTracked())
+                .WillByDefault(Return(false));
+
+            ON_CALL(this->flightplan, IsTrackedByUser())
+                .WillByDefault(Return(false));
+
+            ON_CALL(this->plugin, GetUserControllerObject())
+                .WillByDefault(Return(this->mockController));
+
+            ON_CALL(*this->mockController, IsVatsimRecognisedController())
+                .WillByDefault(Return(true));
+
+            ON_CALL(this->flightplan, GetCallsign())
+                .WillByDefault(Return("BAW123"));
+
+            ON_CALL(this->flightplan, GetOrigin())
+                .WillByDefault(Return("EGKK"));
+
+            ON_CALL(this->flightplan, GetDistanceFromOrigin())
+                .WillByDefault(Return(4));
+
+            this->handler.DisplayStandSelectionMenu(this->flightplan, this->radarTarget, "", { 0, 0 });
+
+            std::shared_ptr<NiceMock<MockEuroScopeCFlightPlanInterface>> pluginReturnedFp
+                = std::make_shared<NiceMock<MockEuroScopeCFlightPlanInterface>>();
+
+            ON_CALL(*pluginReturnedFp, IsTracked())
+                .WillByDefault(Return(false));
+
+            ON_CALL(*pluginReturnedFp, IsTrackedByUser())
+                .WillByDefault(Return(false));
+
+            ON_CALL(*pluginReturnedFp, GetCallsign())
+                .WillByDefault(Return("BAW123"));
+
+            ON_CALL(this->plugin, GetSelectedFlightplan())
+                .WillByDefault(Return(pluginReturnedFp));
+
+            EXPECT_CALL(this->api, DeleteStandAssignmentForAircraft("BAW123"))
+                .Times(1);
+
+            this->handler.StandSelected(1, "", {});
+            EXPECT_EQ(this->handler.noStandAssigned, this->handler.GetAssignedStandForCallsign("BAW123"));
+        }
+
         TEST_F(StandEventHandlerTest, ItHandlesApiExceptionsInAssignmentDeletion)
         {
             this->handler.SetAssignedStand("BAW123", 2);

--- a/test/test/stands/StandModuleTest.cpp
+++ b/test/test/stands/StandModuleTest.cpp
@@ -6,6 +6,7 @@
 #include "tag/TagItemCollection.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "controller/HandoffEventHandlerCollection.h"
+#include "flightplan/FlightPlanEventHandlerCollection.h"
 
 using ::testing::NiceMock;
 using ::testing::Test;
@@ -13,6 +14,7 @@ using ::testing::Return;
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
 using UKControllerPlugin::Controller::HandoffEventHandlerCollection;
 using UKControllerPlugin::Plugin::FunctionCallEventHandler;
+using UKControllerPlugin::Flightplan::FlightPlanEventHandlerCollection;
 using UKControllerPlugin::Stands::BootstrapPlugin;
 using UKControllerPlugin::Tag::TagItemCollection;
 using UKControllerPlugin::Websocket::WebsocketEventProcessorCollection;
@@ -28,6 +30,7 @@ namespace UKControllerPluginTest {
                 {
                     container.websocketProcessors.reset(new WebsocketEventProcessorCollection);
                     container.tagHandler.reset(new TagItemCollection);
+                    container.flightplanHandler.reset(new FlightPlanEventHandlerCollection);
                     container.pluginFunctionHandlers.reset(new FunctionCallEventHandler);
 
                     nlohmann::json gatwick = nlohmann::json::array();
@@ -77,6 +80,12 @@ namespace UKControllerPluginTest {
         {
             BootstrapPlugin(this->container, this->dependencyLoader);
             EXPECT_EQ(1, this->container.websocketProcessors->CountProcessorsForChannel("private-stand-assignments"));
+        }
+
+        TEST_F(StandModuleTest, ItRegistersForFlightplanEvents)
+        {
+            BootstrapPlugin(this->container, this->dependencyLoader);
+            EXPECT_EQ(1, this->container.flightplanHandler->CountHandlers());
         }
 
         TEST_F(StandModuleTest, ItRegistersTheStandAssignmentPopupMenuFunction)

--- a/test/test/stands/StandModuleTest.cpp
+++ b/test/test/stands/StandModuleTest.cpp
@@ -82,8 +82,15 @@ namespace UKControllerPluginTest {
         TEST_F(StandModuleTest, ItRegistersTheStandAssignmentPopupMenuFunction)
         {
             BootstrapPlugin(this->container, this->dependencyLoader);
-            EXPECT_EQ(1, this->container.pluginFunctionHandlers->CountTagFunctions());
             EXPECT_TRUE(this->container.pluginFunctionHandlers->HasTagFunction(9007));
+            EXPECT_EQ(1, this->container.pluginFunctionHandlers->CountCallbacks());
+            EXPECT_TRUE(this->container.pluginFunctionHandlers->HasCallbackFunction(5000));
+        }
+
+        TEST_F(StandModuleTest, ItRegistersTheStandAssignmentEditBoxFunction)
+        {
+            BootstrapPlugin(this->container, this->dependencyLoader);
+            EXPECT_TRUE(this->container.pluginFunctionHandlers->HasTagFunction(9008));
             EXPECT_EQ(1, this->container.pluginFunctionHandlers->CountCallbacks());
             EXPECT_TRUE(this->container.pluginFunctionHandlers->HasCallbackFunction(5000));
         }


### PR DESCRIPTION
- Annotate flight strips when stands are assigned so that they can be seen in vSMR
- Add an edit box so that stands may be typed in
- Prevent non-controllers from assigning stands