### PR TITLE
175 stand annotation exceptions

### DIFF
--- a/src/flightplan/DeferredFlightplanEvent.cpp
+++ b/src/flightplan/DeferredFlightplanEvent.cpp
@@ -28,16 +28,16 @@ namespace UKControllerPlugin {
         */
         void DeferredFlightPlanEvent::Run(void)
         {
-            try {
-                std::shared_ptr<EuroScopeCFlightPlanInterface> currentFlightplan =
-                    this->plugin.GetFlightplanForCallsign(callsign);
-                std::shared_ptr<EuroScopeCRadarTargetInterface> currentRadarTarget =
-                    this->plugin.GetRadarTargetForCallsign(callsign);
+            std::shared_ptr<EuroScopeCFlightPlanInterface> currentFlightplan =
+                this->plugin.GetFlightplanForCallsign(callsign);
+            std::shared_ptr<EuroScopeCRadarTargetInterface> currentRadarTarget =
+                this->plugin.GetRadarTargetForCallsign(callsign);
 
-                this->handler.FlightPlanEvent(*currentFlightplan, *currentRadarTarget);
-            } catch (std::invalid_argument) {
-                // If we cant find the ES data, then nothing we can do.
+            if (!currentFlightplan || !currentRadarTarget) {
+                return;
             }
+
+            this->handler.FlightPlanEvent(*currentFlightplan, *currentRadarTarget);
         }
 
     }  // namespace Flightplan

--- a/src/historytrail/HistoryTrailRenderer.cpp
+++ b/src/historytrail/HistoryTrailRenderer.cpp
@@ -310,27 +310,25 @@ namespace UKControllerPlugin {
 
             int roundNumber;
             // Loop through the history trails.
+
+            std::shared_ptr<EuroScopeCRadarTargetInterface> radarTarget;
             for (
                 HistoryTrailRepository::const_iterator aircraft = this->trails.cbegin();
                 aircraft != this->trails.cend();
                 ++aircraft
             ) {
-
-                try {
-                    std::shared_ptr<EuroScopeCRadarTargetInterface> radarTarget =
-                        this->plugin.GetRadarTargetForCallsign(aircraft->second->GetCallsign());
-
-                    // If they're not going fast enough or are off the screen, don't display the trail.
-                    if (radarScreen.GetGroundspeedForCallsign(aircraft->second->GetCallsign()) < this->minimumSpeed ||
-                        radarScreen.PositionOffScreen(*aircraft->second->GetTrail().begin()) ||
-                        radarTarget->GetFlightLevel() < this->minimumDisplayAltitude ||
-                        radarTarget->GetFlightLevel() > this->maximumDisplayAltitude
-                    ) {
-                        continue;
-                    }
+                // Check the radar target exists
+                radarTarget = this->plugin.GetRadarTargetForCallsign(aircraft->second->GetCallsign());
+                if (!radarTarget) {
+                    continue;
                 }
-                catch (std::invalid_argument) {
-                    // No radar target, continue.
+
+                // If they're not going fast enough or are off the screen, don't display the trail.
+                if (radarScreen.GetGroundspeedForCallsign(aircraft->second->GetCallsign()) < this->minimumSpeed ||
+                    radarScreen.PositionOffScreen(*aircraft->second->GetTrail().begin()) ||
+                    radarTarget->GetFlightLevel() < this->minimumDisplayAltitude ||
+                    radarTarget->GetFlightLevel() > this->maximumDisplayAltitude
+                    ) {
                     continue;
                 }
 

--- a/src/hold/HoldDisplay.cpp
+++ b/src/hold/HoldDisplay.cpp
@@ -340,20 +340,19 @@ namespace UKControllerPlugin {
                 it != aircraft.cend();
                 ++it
             ) {
-                try {
-                    rt = this->plugin.GetRadarTargetForCallsign((*it)->GetCallsign());
-
-                    // If the aircraft is above the displaying levels of the hold, dont map
-                    int occupied = GetOccupiedLevel(rt->GetFlightLevel(), rt->GetVerticalSpeed());
-                    if (occupied > this->maximumLevel || occupied < this->minimumLevel) {
-                        continue;
-                    }
-
-                    levelMap[occupied].insert(*it);
+                // Check for the radar target
+                rt = this->plugin.GetRadarTargetForCallsign((*it)->GetCallsign());
+                if (!rt) {
+                    continue;
                 }
-                catch (std::invalid_argument) {
-                    // Cant display, dont have the data
+
+                // If the aircraft is above the displaying levels of the hold, dont map
+                int occupied = GetOccupiedLevel(rt->GetFlightLevel(), rt->GetVerticalSpeed());
+                if (occupied > this->maximumLevel || occupied < this->minimumLevel) {
+                    continue;
                 }
+
+                levelMap[occupied].insert(*it);
             }
 
             // Only display holding aircraft if at least one of them is assigned to it.
@@ -913,11 +912,11 @@ namespace UKControllerPlugin {
                             );
                         }
 
-                        // Render the aircraft data
-                        try {
-                            rt = this->plugin.GetRadarTargetForCallsign((*it)->GetCallsign());
-                            fp = this->plugin.GetFlightplanForCallsign((*it)->GetCallsign());
 
+                        rt = this->plugin.GetRadarTargetForCallsign((*it)->GetCallsign());
+                        fp = this->plugin.GetFlightplanForCallsign((*it)->GetCallsign());
+
+                        if (fp && rt) {
                             if (rt->GetPosition().DistanceTo(this->navaid.coordinates) < this->sameLevelBoxDistance) {
                                 aircraftInProximity = true;
                             }
@@ -965,8 +964,8 @@ namespace UKControllerPlugin {
                             // Cleared level - plus a clickspot for the aircraft in question
                             graphics.DrawString(
                                 fp->GetClearedAltitude() == 0
-                                    ? L"---"
-                                    : GetLevelDisplayString(fp->GetClearedAltitude()),
+                                ? L"---"
+                                : GetLevelDisplayString(fp->GetClearedAltitude()),
                                 clearedLevelDisplay,
                                 this->clearedLevelBrush
                             );
@@ -991,9 +990,6 @@ namespace UKControllerPlugin {
                                     this->dataBrush
                                 );
                             }
-                        }
-                        catch (std::invalid_argument) {
-                            // Skip the render
                         }
 
                         aircraftIndex++;

--- a/src/initialaltitude/InitialAltitudeEventHandler.cpp
+++ b/src/initialaltitude/InitialAltitudeEventHandler.cpp
@@ -202,22 +202,21 @@ namespace UKControllerPlugin {
 
             LogInfo("Mass assigning initial altitudes");
 
+            std::shared_ptr<EuroScopeCFlightPlanInterface> fp;
+            std::shared_ptr<EuroScopeCRadarTargetInterface> rt;
             for (
                 StoredFlightplanCollection::const_iterator it = this->storedFlightplans.cbegin();
                 it != this->storedFlightplans.cend();
                 ++it
             ) {
-                try {
+                fp = this->plugin.GetFlightplanForCallsign(it->second->GetCallsign());
+                rt = this->plugin.GetRadarTargetForCallsign(it->second->GetCallsign());
 
-                    this->FlightPlanEvent(
-                        *this->plugin.GetFlightplanForCallsign(it->second->GetCallsign()),
-                        *this->plugin.GetRadarTargetForCallsign(it->second->GetCallsign())
-                    );
-
-                }
-                catch (std::invalid_argument) {
+                if (!fp || !rt) {
                     continue;
                 }
+
+                this->FlightPlanEvent(*fp, *rt);
             }
         }
 

--- a/src/plugin/UKPlugin.cpp
+++ b/src/plugin/UKPlugin.cpp
@@ -267,7 +267,7 @@ namespace UKControllerPlugin {
         EuroScopePlugIn::CFlightPlan plan = this->FlightPlanSelect(callsign.c_str());
 
         if (!plan.IsValid()) {
-            throw std::invalid_argument("Flightplan not found");
+            return nullptr;
         }
 
         return std::make_shared<EuroScopeCFlightPlanWrapper>(plan);
@@ -281,7 +281,7 @@ namespace UKControllerPlugin {
         EuroScopePlugIn::CRadarTarget target = this->RadarTargetSelect(callsign.c_str());
 
         if (!target.IsValid()) {
-            throw std::invalid_argument("Target not found");
+            return nullptr;
         }
 
         return std::make_shared<EuroScopeCRadarTargetWrapper>(target);
@@ -295,7 +295,7 @@ namespace UKControllerPlugin {
         EuroScopePlugIn::CFlightPlan fp = this->FlightPlanSelectASEL();
 
         if (!fp.IsValid()) {
-            return NULL;
+            return nullptr;
         }
 
         return std::make_shared<EuroScopeCFlightPlanWrapper>(fp);

--- a/src/squawk/ApiSquawkAllocationHandler.cpp
+++ b/src/squawk/ApiSquawkAllocationHandler.cpp
@@ -49,19 +49,17 @@ namespace UKControllerPlugin {
         void ApiSquawkAllocationHandler::TimedEventTrigger(void)
         {
             std::lock_guard<std::mutex> lock(this->queueGuard);
+            std::shared_ptr<EuroScopeCFlightPlanInterface> flightplan;
             for (
                 std::set<UKControllerPlugin::Squawk::ApiSquawkAllocation>::iterator it = this->allocationQueue.begin();
                 it != this->allocationQueue.end();
             ) {
-                try {
-                    std::shared_ptr<EuroScopeCFlightPlanInterface> flightplan =
-                        this->plugin.GetFlightplanForCallsign(it->callsign);
-
+                flightplan = this->plugin.GetFlightplanForCallsign(it->callsign);
+                if (!flightplan) {
+                    LogInfo("Could not find flightplan for " + it->callsign + " when trying to assign squawk");
+                } else {
                     flightplan->SetSquawk(it->squawk);
                     LogInfo("Assigned squawk " + it->squawk + " to " + it->callsign);
-                } catch (std::invalid_argument) {
-                    // Flightplan has gone somewhere, do nothing
-                    LogInfo("Could not find flightplan for " + it->callsign + " when trying to assign squawk");
                 }
 
                 this->allocationQueue.erase(it++);

--- a/src/stands/StandEventHandler.cpp
+++ b/src/stands/StandEventHandler.cpp
@@ -134,11 +134,16 @@ namespace UKControllerPlugin {
 
         void StandEventHandler::RemoveFlightStripAnnotation(std::string callsign) const
         {
-             // Find the flightplan to apply annotation
-            std::shared_ptr<EuroScopeCFlightPlanInterface> fp = this->plugin.GetFlightplanForCallsign(callsign);
+            // Find the flightplan to apply annotation
+            std::shared_ptr<EuroScopeCFlightPlanInterface> fp = nullptr;
+            try {
+                fp = this->plugin.GetFlightplanForCallsign(callsign);
+            }
+            catch (std::invalid_argument) {
+                // Nothing to do
+            }
 
             if (!fp) {
-                LogWarning("Tried assign a stand for a non-existant aircraft");
                 return;
             }
 

--- a/src/stands/StandEventHandler.cpp
+++ b/src/stands/StandEventHandler.cpp
@@ -37,13 +37,7 @@ namespace UKControllerPlugin {
         void StandEventHandler::AnnotateFlightStrip(std::string callsign, int standId) const
         {
             // Find the flightplan to apply annotation
-            std::shared_ptr<EuroScopeCFlightPlanInterface> fp = nullptr;
-            try {
-                fp = this->plugin.GetFlightplanForCallsign(callsign);
-            }
-            catch (std::invalid_argument) {
-                // Nothing to do
-            }
+            std::shared_ptr<EuroScopeCFlightPlanInterface> fp = this->plugin.GetFlightplanForCallsign(callsign);
 
             if (!fp) {
                 return;
@@ -132,16 +126,13 @@ namespace UKControllerPlugin {
             return this->lastAirfieldUsed;
         }
 
+        /*
+            Remove the flight strip annotation for vSMR
+        */
         void StandEventHandler::RemoveFlightStripAnnotation(std::string callsign) const
         {
             // Find the flightplan to apply annotation
-            std::shared_ptr<EuroScopeCFlightPlanInterface> fp = nullptr;
-            try {
-                fp = this->plugin.GetFlightplanForCallsign(callsign);
-            }
-            catch (std::invalid_argument) {
-                // Nothing to do
-            }
+            std::shared_ptr<EuroScopeCFlightPlanInterface> fp = this->plugin.GetFlightplanForCallsign(callsign);
 
             if (!fp) {
                 return;

--- a/test/test/flightplan/DeferredFlightplanEventTest.cpp
+++ b/test/test/flightplan/DeferredFlightplanEventTest.cpp
@@ -57,7 +57,7 @@ namespace UKControllerPluginTest {
         TEST_F(DeferredFlightplanEventTest, ItHandlesMissingFlightplansGracefully)
         {
             ON_CALL(this->mockPlugin, GetFlightplanForCallsign(this->callsign))
-                .WillByDefault(Throw(std::invalid_argument("Boo!")));
+                .WillByDefault(Return(nullptr));
 
             ON_CALL(this->mockPlugin, GetRadarTargetForCallsign(this->callsign))
                 .WillByDefault(Return(this->mockRadarTarget));
@@ -71,7 +71,7 @@ namespace UKControllerPluginTest {
                 .WillByDefault(Return(this->mockFlightplan));
 
             ON_CALL(this->mockPlugin, GetRadarTargetForCallsign(this->callsign))
-                .WillByDefault(Throw(std::invalid_argument("Boo!")));
+                .WillByDefault(Return(nullptr));
 
             EXPECT_NO_THROW(this->event.Run());
         }

--- a/test/test/hold/HoldDisplayTest.cpp
+++ b/test/test/hold/HoldDisplayTest.cpp
@@ -701,7 +701,7 @@ namespace UKControllerPluginTest {
 
             // This one shouldn't make it through as no radar target
             ON_CALL(this->mockPlugin, GetRadarTargetForCallsign("BMI234"))
-                .WillByDefault(Throw(std::invalid_argument("Test")));
+                .WillByDefault(Return(nullptr));
 
             // This one shouldnt make it through as its too high
             std::shared_ptr<NiceMock<MockEuroScopeCRadarTargetInterface>> radarTargetLot555 =

--- a/test/test/squawk/ApiSquawkAllocationHandlerTest.cpp
+++ b/test/test/squawk/ApiSquawkAllocationHandlerTest.cpp
@@ -108,7 +108,7 @@ namespace UKControllerPluginTest {
             this->handler.AddAllocationToQueue(event2);
 
             ON_CALL(this->mockPlugin, GetFlightplanForCallsign("XXXXX"))
-                .WillByDefault(Throw(std::invalid_argument("Test")));
+                .WillByDefault(Return(nullptr));
 
             EXPECT_CALL(*this->mockFlightplan1, SetSquawk("0123"))
                 .Times(1);

--- a/test/test/stands/StandEventHandlerTest.cpp
+++ b/test/test/stands/StandEventHandlerTest.cpp
@@ -234,6 +234,24 @@ namespace UKControllerPluginTest {
             ASSERT_EQ(this->handler.noStandAssigned, this->handler.GetAssignedStandForCallsign("BAW123"));
         }
 
+        TEST_F(StandEventHandlerTest, ItHandlesNoFlightplanForUnassignmentRemovalOfAnnotations)
+        {
+            this->handler.SetAssignedStand("BAW123", 3);
+            WebsocketMessage message{
+                "App\\Events\\StandUnassignedEvent",
+                "private-stand-assignments",
+                nlohmann::json {
+                    {"callsign", "BAW123"}
+                }
+            };
+
+            ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
+                .WillByDefault(Throw(std::invalid_argument("Test")));
+
+            this->handler.ProcessWebsocketMessage(message);
+            ASSERT_EQ(this->handler.noStandAssigned, this->handler.GetAssignedStandForCallsign("BAW123"));
+        }
+
         TEST_F(StandEventHandlerTest, ItUnassignsStandsFromWebsocketMessage)
         {
             this->handler.SetAssignedStand("BAW123", 3);

--- a/test/test/stands/StandEventHandlerTest.cpp
+++ b/test/test/stands/StandEventHandlerTest.cpp
@@ -155,7 +155,8 @@ namespace UKControllerPluginTest {
             };
 
             ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
-                .WillByDefault(Throw(std::invalid_argument("Test")));
+                .WillByDefault(Return(nullptr));
+
 
             this->handler.ProcessWebsocketMessage(message);
             ASSERT_EQ(1, this->handler.GetAssignedStandForCallsign("BAW123"));
@@ -246,7 +247,7 @@ namespace UKControllerPluginTest {
             };
 
             ON_CALL(this->plugin, GetFlightplanForCallsign("BAW123"))
-                .WillByDefault(Throw(std::invalid_argument("Test")));
+                .WillByDefault(Return(nullptr));
 
             this->handler.ProcessWebsocketMessage(message);
             ASSERT_EQ(this->handler.noStandAssigned, this->handler.GetAssignedStandForCallsign("BAW123"));


### PR DESCRIPTION
- Fix a bug where clearing flight strip annotations would cause an exception if the flightplan didn't exist
- Refactored GetFlightplanForCallsign and GetRadarTargetForCallsign to return nullptr instead of throw exception when the returned plan/target is not valid. This brings them into line with the corresponding methods for getting the plan/target of the currently ASEL'd aircraft so we don't have two different systems for getting them in one class.