### PR TITLE
fix(externalintegrations): make debug command handler message only

### DIFF
--- a/src/integration/ExternalMessageEventHandler.cpp
+++ b/src/integration/ExternalMessageEventHandler.cpp
@@ -95,7 +95,7 @@ namespace UKControllerPlugin {
             cds.lpData = (PVOID)command.c_str();
 
             // Find the hidden window
-            HWND window = FindWindowEx(NULL, NULL, this->windowClass.lpszClassName, NULL);
+            HWND window = FindWindowEx(HWND_MESSAGE, NULL, this->windowClass.lpszClassName, NULL);
             if (window == NULL) {
                 return true;
             }


### PR DESCRIPTION
Technically, we should call with HWND_MESSAGE when finding the window to ensurethat we only find the
message-only window. Doesnt affect production at all.