### PR TITLE
feat(sectorexitlelna.cpp): add H5 intention code

### DIFF
--- a/src/intention/SectorExitPointLelna.cpp
+++ b/src/intention/SectorExitPointLelna.cpp
@@ -10,7 +10,7 @@ namespace UKControllerPlugin {
     namespace IntentionCode {
 
         /*
-           Loop through the rest of the route to see where the aircraft goes in order to determine
+           Look at the rest of the route to see where the aircraft goes in order to determine
            the intention code.
         */
         std::string SectorExitPointLelna::GetIntentionCode(
@@ -18,7 +18,19 @@ namespace UKControllerPlugin {
             int foundPointIndex,
             int cruiseLevel
         ) const {
-            while (foundPointIndex < route.GetPointsNumber()) {
+            const int numberOfPointsInRoute = route.GetPointsNumber();
+
+            // The arrival airport is always the last point on the route
+            if (numberOfPointsInRoute >= 2)
+            {
+                std::string arrivalAirport = route.GetPointName(numberOfPointsInRoute - 1);
+                if (arrivalAirport.substr(0, 3) == "LFR" && arrivalAirport != "LFRC")
+                {
+                    return "H5";
+                }
+            }
+
+            while (foundPointIndex < numberOfPointsInRoute) {
                 if (strcmp(route.GetPointName(foundPointIndex), "DIN") == 0) {
                     return "H2";
                 }

--- a/test/test/intention/SectorExitPointLelnaTest.cpp
+++ b/test/test/intention/SectorExitPointLelnaTest.cpp
@@ -26,7 +26,7 @@ namespace UKControllerPluginTest {
             SectorExitPointLelna exitPoint("LELNA", "H2", SectorExitPointLelna::outSouth);
 
             EXPECT_CALL(routeMock, GetPointsNumber())
-                .Times(3)
+                .Times(1)
                 .WillRepeatedly(Return(2));
 
             EXPECT_CALL(routeMock, GetPointName(0))
@@ -34,7 +34,7 @@ namespace UKControllerPluginTest {
                 .WillRepeatedly(Return("LELNA"));
 
             EXPECT_CALL(routeMock, GetPointName(1))
-                .Times(3)
+                .Times(4)
                 .WillRepeatedly(Return("LFMN"));
 
             EXPECT_EQ(0, exitPoint.GetIntentionCode(routeMock, 0, 37000).compare("H2"));
@@ -46,7 +46,7 @@ namespace UKControllerPluginTest {
             SectorExitPointLelna exitPoint("LELNA", "H2", SectorExitPointLelna::outSouth);
 
             EXPECT_CALL(routeMock, GetPointsNumber())
-                .Times(2)
+                .Times(1)
                 .WillRepeatedly(Return(3));
 
             EXPECT_CALL(routeMock, GetPointName(0))
@@ -57,6 +57,10 @@ namespace UKControllerPluginTest {
                 .Times(1)
                 .WillRepeatedly(Return("DIN"));
 
+            EXPECT_CALL(routeMock, GetPointName(2))
+                .Times(1)
+                .WillRepeatedly(Return("LEMD"));
+
             EXPECT_EQ(0, exitPoint.GetIntentionCode(routeMock, 0, 37000).compare("H2"));
         }
 
@@ -66,7 +70,7 @@ namespace UKControllerPluginTest {
             SectorExitPointLelna exitPoint("LELNA", "H2", SectorExitPointLelna::outSouth);
 
             EXPECT_CALL(routeMock, GetPointsNumber())
-                .Times(2)
+                .Times(1)
                 .WillRepeatedly(Return(3));
 
             EXPECT_CALL(routeMock, GetPointName(0))
@@ -77,6 +81,10 @@ namespace UKControllerPluginTest {
                 .Times(3)
                 .WillRepeatedly(Return("ARE"));
 
+            EXPECT_CALL(routeMock, GetPointName(2))
+                .Times(1)
+                .WillRepeatedly(Return("LEMD"));
+
             EXPECT_EQ(0, exitPoint.GetIntentionCode(routeMock, 0, 37000).compare("H3"));
         }
 
@@ -86,7 +94,7 @@ namespace UKControllerPluginTest {
             SectorExitPointLelna exitPoint("LELNA", "H2", SectorExitPointLelna::outSouth);
 
             EXPECT_CALL(routeMock, GetPointsNumber())
-                .Times(2)
+                 .Times(1)
                 .WillRepeatedly(Return(3));
 
             EXPECT_CALL(routeMock, GetPointName(0))
@@ -97,7 +105,51 @@ namespace UKControllerPluginTest {
                 .Times(2)
                 .WillRepeatedly(Return("DOMOK"));
 
+            EXPECT_CALL(routeMock, GetPointName(2))
+                .Times(1)
+                .WillRepeatedly(Return("LEMD"));
+
             EXPECT_EQ(0, exitPoint.GetIntentionCode(routeMock, 0, 37000).compare("H3"));
+        }
+
+        TEST(SectorExitPointLelna, GetIntentionCodeReturnsCorrectIntentionCodeForBrestFirArrivals)
+        {
+            StrictMock<MockEuroscopeExtractedRouteInterface> routeMock;
+            SectorExitPointLelna exitPoint("LELNA", "H2", SectorExitPointLelna::outSouth);
+
+            EXPECT_CALL(routeMock, GetPointsNumber())
+                .Times(1)
+                .WillRepeatedly(Return(3));
+
+            EXPECT_CALL(routeMock, GetPointName(2))
+                .Times(1)
+                .WillRepeatedly(Return("LFRO"));
+
+            EXPECT_EQ(0, exitPoint.GetIntentionCode(routeMock, 0, 37000).compare("H5"));
+        }
+
+        TEST(SectorExitPointLelna, GetIntentionCodeReturnsCorrectIntentionCodeForCherbourgArrivals)
+        {
+            StrictMock<MockEuroscopeExtractedRouteInterface> routeMock;
+            SectorExitPointLelna exitPoint("LELNA", "H2", SectorExitPointLelna::outSouth);
+
+            EXPECT_CALL(routeMock, GetPointsNumber())
+                .Times(1)
+                .WillRepeatedly(Return(3));
+
+            EXPECT_CALL(routeMock, GetPointName(0))
+                .Times(3)
+                .WillRepeatedly(Return("LELNA"));
+
+            EXPECT_CALL(routeMock, GetPointName(1))
+                .Times(3)
+                .WillRepeatedly(Return("HELLO"));
+
+            EXPECT_CALL(routeMock, GetPointName(2))
+                .Times(4)
+                .WillRepeatedly(Return("LFRC"));
+
+            EXPECT_EQ(0, exitPoint.GetIntentionCode(routeMock, 0, 37000).compare("H2"));
         }
     }  // namespace IntentionCode
 }  // namespace UKControllerPluginTest


### PR DESCRIPTION
Add the H5 intention code for arrivals into airports in Brest FIR (LFRR) with the exception of LFRC

Fix #200