### PR TITLE
fix(websocket): add local system aborted code to websocket resets

### DIFF
--- a/src/websocket/WebsocketConnection.cpp
+++ b/src/websocket/WebsocketConnection.cpp
@@ -406,7 +406,7 @@ namespace UKControllerPlugin {
                 ec == boost::asio::ssl::error::unspecified_system_error ||
                 ec == boost::beast::error::timeout ||
                 ec == boost::beast::websocket::error::closed ||
-                ec.value() == 1236 // The network connection was aborted by the local system
+                ec.value() == 1236  // The network connection was aborted by the local system
             ) {
                 this->ResetWebsocket();
                 LogWarning("Disconnected from websocket: " + ec.message());

--- a/src/websocket/WebsocketConnection.cpp
+++ b/src/websocket/WebsocketConnection.cpp
@@ -405,7 +405,8 @@ namespace UKControllerPlugin {
                 ec == boost::asio::ssl::error::unexpected_result ||
                 ec == boost::asio::ssl::error::unspecified_system_error ||
                 ec == boost::beast::error::timeout ||
-                ec == boost::beast::websocket::error::closed
+                ec == boost::beast::websocket::error::closed ||
+                ec.value() == 1236 // The network connection was aborted by the local system
             ) {
                 this->ResetWebsocket();
                 LogWarning("Disconnected from websocket: " + ec.message());

--- a/src/websocket/WebsocketConnection.cpp
+++ b/src/websocket/WebsocketConnection.cpp
@@ -400,6 +400,7 @@ namespace UKControllerPlugin {
             // Handle disconnection
             if (
                 ec == boost::asio::error::eof ||
+                ec == boost::asio::error::connection_aborted ||
                 ec == boost::asio::error::connection_reset ||
                 ec == boost::asio::ssl::error::stream_truncated ||
                 ec == boost::asio::ssl::error::unexpected_result ||


### PR DESCRIPTION
This is a new code that's started coming up very rarely (it appears after someone stays connected for several hours), but needs to be treated as a reason to reset the websocket connection.

Fix #203