### PR TITLE
fix(squawk): unhandled exception when forcing local squawk recycle

### DIFF
--- a/src/squawk/SquawkGenerator.cpp
+++ b/src/squawk/SquawkGenerator.cpp
@@ -107,6 +107,11 @@ namespace UKControllerPlugin {
                 return false;
             }
 
+            if (!this->activeCallsigns.UserHasCallsign())
+            {
+                return false;
+            }
+
             if (!this->StartSquawkUpdate(flightplan)) {
                 return false;
             }

--- a/test/test/squawk/SquawkGeneratorTest.cpp
+++ b/test/test/squawk/SquawkGeneratorTest.cpp
@@ -556,6 +556,28 @@ namespace UKControllerPluginTest {
             EXPECT_FALSE(this->generator->ForceLocalSquawkForAircraft(*this->mockFlightplan, *this->mockRadarTarget));
         }
 
+        TEST_F(SquawkGeneratorTest, ForceLocalSquawkForAircraftReturnsFalseOnNoUserController)
+        {
+            ON_CALL(this->pluginLoopback, GetUserControllerObject())
+                .WillByDefault(Return(nullptr));
+
+            ON_CALL(this->pluginLoopback, GetUserControllerObject())
+                .WillByDefault(Return(this->mockSelfController));
+
+            ON_CALL(*this->mockFlightplan, IsTrackedByUser())
+                .WillByDefault(Return(true));
+
+            this->activeCallsigns.RemoveCallsign(
+                ActiveCallsign(
+                    "EGKK_APP",
+                    "Testy McTestface",
+                    *this->controller
+                )
+            );
+
+            EXPECT_FALSE(this->generator->ForceLocalSquawkForAircraft(*this->mockFlightplan, *this->mockRadarTarget));
+        }
+
         TEST_F(SquawkGeneratorTest, ForceLocalSquawkAssignsSquawks)
         {
             ON_CALL(this->pluginLoopback, GetUserControllerObject())


### PR DESCRIPTION
If a user didn't have an ActiveCallsign, the ActiveCallsigns would throw an exception that would be
uncaught (e.g. if not PRIM'd up)

Fix #208