### PR TITLE
fix(websocket): reset websocket after period of inactivity

### DIFF
--- a/src/websocket/WebsocketConnection.h
+++ b/src/websocket/WebsocketConnection.h
@@ -107,7 +107,7 @@ namespace UKControllerPlugin {
                 bool asyncWriteInProgress = false;
 
                 // The last time something happened
-                std::chrono::system_clock::time_point lastActivityTime;
+                std::chrono::system_clock::time_point lastActivityTime = std::chrono::system_clock::now();
 
                 // The next time to try reconnecting
                 std::chrono::system_clock::time_point nextReconnectAttempt =


### PR DESCRIPTION
For some reason, the websocket stops receiving events after a while. To try and maintain
functionality whilst we fix this, reset the socket after 5 minutes of inactivity.