### PR TITLE
feat(controllers): Implement controller positions V2 dependency

### DIFF
--- a/src/controller/ControllerPosition.cpp
+++ b/src/controller/ControllerPosition.cpp
@@ -4,35 +4,40 @@
 namespace UKControllerPlugin {
     namespace Controller {
         ControllerPosition::ControllerPosition(
+            int id,
             std::string callsign,
             double frequency,
-            std::string type,
-            std::vector<std::string> topdown
-        ) {
-            this->callsign = callsign;
-            this->frequency = frequency;
-            this->type = type;
-            this->topdown = topdown;
+            std::vector<std::string> topdown,
+            bool requestsDepartureReleases,
+            bool receivesDepartureReleases
+        ): id(id), requestsDepartureReleases(requestsDepartureReleases),
+           receivesDepartureReleases(receivesDepartureReleases), callsign(callsign),
+           frequency(frequency), topdown(std::move(topdown))
+        { }
+
+        int ControllerPosition::GetId() const
+        {
+            return this->id;
         }
 
-        std::string ControllerPosition::GetUnit(void) const
+        std::string ControllerPosition::GetUnit() const
         {
             return this->callsign.substr(0, this->callsign.find('_'));
         }
 
-        std::string ControllerPosition::GetCallsign(void) const
+        std::string ControllerPosition::GetCallsign() const
         {
             return this->callsign;
         }
 
-        double ControllerPosition::GetFrequency(void) const
+        double ControllerPosition::GetFrequency() const
         {
             return this->frequency;
         }
 
-        std::string ControllerPosition::GetType(void) const
+        std::string ControllerPosition::GetType() const
         {
-            return this->type;
+            return callsign.substr(this->callsign.size() - 3, this->callsign.size());
         }
 
         bool ControllerPosition::HasTopdownAirfield(std::string icao) const
@@ -44,16 +49,26 @@ namespace UKControllerPlugin {
             ) != this->topdown.cend();
         }
 
-        std::vector<std::string> ControllerPosition::GetTopdown(void) const
+        bool ControllerPosition::RequestsDepartureReleases() const
+        {
+            return this->requestsDepartureReleases;
+        }
+
+        bool ControllerPosition::ReceivesDepartureReleases() const
+        {
+            return this->receivesDepartureReleases;
+        }
+
+        std::vector<std::string> ControllerPosition::GetTopdown() const
         {
             return this->topdown;
         }
 
-        bool ControllerPosition::operator==(const ControllerPosition & position) const
+        bool ControllerPosition::operator==(const ControllerPosition& position) const
         {
-            return fabs(this->frequency - position.GetFrequency()) < 0.001 &&
-                this->callsign.compare(position.GetCallsign()) == 0 &&
-                this->type.compare(position.GetType()) == 0;
+            return this->GetId() == position.GetId() &&
+                fabs(this->frequency - position.GetFrequency()) < 0.001 &&
+                this->callsign.compare(position.GetCallsign()) == 0;
         }
     }  // namespace Controller
 }  // namespace UKControllerPlugin

--- a/src/controller/ControllerPosition.h
+++ b/src/controller/ControllerPosition.h
@@ -4,37 +4,50 @@ namespace UKControllerPlugin {
     namespace Controller {
 
         /*
-            Class that repsents a potential UK Controller position.
+            Class that represents a potential UK Controller position.
         */
         class ControllerPosition
         {
             public:
                 ControllerPosition(
+                    int id,
                     std::string callsign,
                     double frequency,
-                    std::string type,
-                    std::vector<std::string> topdown
+                    std::vector<std::string> topdown,
+                    bool requestsDepartureReleases,
+                    bool receivesDepartureReleases
                 );
-                std::string GetUnit(void) const;
-                std::string GetCallsign(void) const;
-                double GetFrequency(void) const;
-                std::vector<std::string> GetTopdown(void) const;
-                std::string GetType(void) const;
+
+                int GetId() const;
+                std::string GetUnit() const;
+                std::string GetCallsign() const;
+                double GetFrequency() const;
+                std::vector<std::string> GetTopdown() const;
+                std::string GetType() const;
                 bool HasTopdownAirfield(std::string icao) const;
+                bool RequestsDepartureReleases() const;
+                bool ReceivesDepartureReleases() const;
                 bool operator==(const ControllerPosition & position) const;
 
             private:
+
+                // The id of the controller in the API
+                const int id;
+
                 // The default controller callsign
-                std::string callsign;
+                const std::string callsign;
 
                 // The controller frequency
-                double frequency;
-
-                // The type of position e.g. APP, CTR
-                std::string type;
+                const double frequency;
 
                 // The airfields for which this controller has some level of top-down responsibility.
-                std::vector<std::string> topdown;
+                const std::vector<std::string> topdown;
+
+                // Can the controller request a departure release
+                const bool requestsDepartureReleases;
+
+                // Can the controller receive a departure release
+                const bool receivesDepartureReleases;
         };
     }  // namespace Controller
 }  // namespace UKControllerPlugin

--- a/src/controller/ControllerPositionCollection.h
+++ b/src/controller/ControllerPositionCollection.h
@@ -14,20 +14,20 @@ namespace UKControllerPlugin {
         class ControllerPositionCollection
         {
         public:
-            bool AddPosition(std::unique_ptr<ControllerPosition> position);
-            const ControllerPosition & FetchPositionByCallsign(std::string callsign) const;
-            const ControllerPosition & FetchPositionByFacilityTypeAndFrequency(
-                std::string facility,
-                std::string type,
-                double frequency
-            ) const;
-            size_t GetSize(void) const;
-            bool HasPosition(std::string callsign) const;
+                bool AddPosition(std::shared_ptr<ControllerPosition> position);
+                const std::shared_ptr<ControllerPosition> FetchPositionById(int id) const;
+                const ControllerPosition& FetchPositionByCallsign(std::string callsign) const;
+                const ControllerPosition& FetchPositionByFacilityTypeAndFrequency(
+                    std::string facility,
+                    std::string type,
+                    double frequency
+                ) const;
+                size_t GetSize(void) const;
+                bool HasPosition(std::string callsign) const;
 
         private:
-            std::map<std::string, std::unique_ptr<ControllerPosition>> positions;
-            bool IsPossibleAirfieldPosition(std::string facility) const;
-            bool IsPossibleAreaPosition(std::string facility) const;
+                std::map<std::string, std::shared_ptr<ControllerPosition>> positions;
+                std::map<int, std::shared_ptr<ControllerPosition>> positionsById;
         };
     }  // namespace Controller
 }  // namespace UKControllerPlugin

--- a/src/controller/ControllerPositionCollectionFactory.cpp
+++ b/src/controller/ControllerPositionCollectionFactory.cpp
@@ -11,8 +11,9 @@ using UKControllerPlugin::HelperFunctions;
 namespace UKControllerPlugin {
     namespace Controller {
 
-        // Initilise the required dependency constant
-        const std::string ControllerPositionCollectionFactory::requiredDependency = "DEPENDENCY_CONTROLLER_POSITIONS";
+        // Initialise the required dependency constant
+        const std::string ControllerPositionCollectionFactory::requiredDependency =
+            "DEPENDENCY_CONTROLLER_POSITIONS_V2";
 
         std::unique_ptr<ControllerPositionCollection> ControllerPositionCollectionFactory::Create(
             DependencyLoaderInterface& dependency
@@ -20,43 +21,69 @@ namespace UKControllerPlugin {
             std::unique_ptr<ControllerPositionCollection> collection(new ControllerPositionCollection);
             nlohmann::json controllerPositions = dependency.LoadDependency(
                 requiredDependency,
-                nlohmann::json::object()
+                nlohmann::json::array()
             );
 
-            if (!controllerPositions.is_object()) {
-                LogError("Unable to load controller positions, dependency data invalid");
+            if (!DependencyDataValid(controllerPositions)) {
+                LogError("Unable to load controller positions, V2 dependency data is invalid");
                 return collection;
             }
 
-            for (nlohmann::json::iterator posIt = controllerPositions.begin();
-                posIt != controllerPositions.end();
-                posIt++
-            ) {
 
-                // Missing data, skip this position.
-                if (!posIt.value()["frequency"].is_number() || !posIt.value()["top-down"].is_array()) {
-                    LogWarning("Invalid controller position " + posIt.key());
-                    continue;
-                }
-
-                std::string callsign = posIt.key();
-                std::string posType = callsign.substr(callsign.size() - 3, callsign.size());
-                double frequency = posIt.value()["frequency"];
-
-                try {
-                    collection->AddPosition(std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition(callsign, frequency, posType, posIt.value()["top-down"])
-                    ));
-                } catch (std::invalid_argument) {
-                    LogError("Failed adding position " + callsign + " to controller collection");
-                    // Do nothing if something goes wrong.
-                }
+            for (auto controllerPosition : controllerPositions) {
+                collection->AddPosition(
+                    std::make_shared<ControllerPosition>(
+                        controllerPosition.at("id").get<int>(),
+                        controllerPosition.at("callsign").get<std::string>(),
+                        controllerPosition.at("frequency").get<double>(),
+                        controllerPosition.at("top_down").get<std::vector<std::string>>(),
+                        controllerPosition.at("requests_departure_releases").get<bool>(),
+                        controllerPosition.at("receives_departure_releases").get<bool>()
+                    )
+                );
             }
 
             LogInfo(
                 "Loaded " + std::to_string(collection->GetSize()) + " controllers into controller position collection"
             );
             return collection;
+        }
+
+        /*
+         * The frequency being a number is required, because positions such as EGNX_TWR have a frequency
+         * of 124.000. In the dependency this comes out as 124.
+         */
+        bool ControllerPositionCollectionFactory::DependencyDataValid(nlohmann::json& data)
+        {
+            return data.is_array() &&
+                std::find_if_not(
+                    data.cbegin(),
+                    data.cend(),
+                    [](const nlohmann::json& position) -> bool
+                    {
+                        return position.is_object() &&
+                            position.contains("id") &&
+                            position.at("id").is_number_integer() &&
+                            position.contains("callsign") &&
+                            position.at("callsign").is_string() &&
+                            position.contains("frequency") &&
+                            position.at("frequency").is_number() &&
+                            position.contains("top_down") &&
+                            position.at("top_down").is_array() &&
+                            std::find_if_not(
+                                position.at("top_down").cbegin(),
+                                position.at("top_down").cend(),
+                                [](const nlohmann::json& topdown) -> bool
+                                {
+                                    return topdown.is_string();
+                                }
+                            ) == position.at("top_down").cend() &&
+                            position.contains("requests_departure_releases") &&
+                            position.at("requests_departure_releases").is_boolean() &&
+                            position.contains("receives_departure_releases") &&
+                            position.at("receives_departure_releases").is_boolean();
+                    }
+                ) == data.cend();
         }
     }  // namespace Controller
 }  // namespace UKControllerPlugin

--- a/src/controller/ControllerPositionCollectionFactory.h
+++ b/src/controller/ControllerPositionCollectionFactory.h
@@ -16,8 +16,9 @@ namespace UKControllerPlugin {
         {
             public:
                 static std::unique_ptr<ControllerPositionCollection> Create(
-                    UKControllerPlugin::Dependency::DependencyLoaderInterface& dependency
+                    Dependency::DependencyLoaderInterface& dependency
                 );
+                static bool DependencyDataValid(nlohmann::json& data);
                 static const std::string requiredDependency;
         };
     }  // namespace Controller

--- a/src/ownership/AirfieldOwnershipManager.cpp
+++ b/src/ownership/AirfieldOwnershipManager.cpp
@@ -19,7 +19,7 @@ namespace UKControllerPlugin {
         )
             : airfields(airfields),
             activeCallsigns(activeCallsigns),
-            notFoundControllerPosition("", 199.998, "XXX", {}),
+            notFoundControllerPosition(-1, "", 199.998, {}, true, false),
             notFoundCallsign("", "", this->notFoundControllerPosition)
         {
 

--- a/test/test/controller/ActiveCallsignCollectionTest.cpp
+++ b/test/test/controller/ActiveCallsignCollectionTest.cpp
@@ -21,8 +21,8 @@ namespace UKControllerPluginTest {
             public:
 
                 ActiveCallsignCollectionTest()
-                    : testPosition("LON_S_CTR", 129.420, "CTR", {}),
-                    testCallsign("LON_S_CTR", "Testy Boi", testPosition)
+                    : testPosition(1, "LON_S_CTR", 129.420, {}, true, false),
+                      testCallsign("LON_S_CTR", "Testy Boi", testPosition)
                 {
                     handler1.reset(new NiceMock<MockActiveCallsignEventHandler>());
                     handler2.reset(new NiceMock<MockActiveCallsignEventHandler>());
@@ -240,9 +240,9 @@ namespace UKControllerPluginTest {
 
         TEST_F(ActiveCallsignCollectionTest, FlushEmptiesTheCollection)
         {
-            ControllerPosition controller1("LON_S_CTR", 129.420, "CTR", {});
-            ControllerPosition controller2("LON_C_CTR", 127.100, "CTR", {});
-            ControllerPosition controller3("LON_E_CTR", 121.200, "CTR", {});
+            ControllerPosition controller1(1, "LON_S_CTR", 129.420, {}, true, false);
+            ControllerPosition controller2(2, "LON_C_CTR", 127.100, {}, true, false);
+            ControllerPosition controller3(3, "LON_E_CTR", 121.200, {}, true, false);
             ActiveCallsign cs1("LON_S_CTR", "Bob Jones", controller1);
             ActiveCallsign cs2("LON_C_CTR", "Jones Bob", controller2);
             ActiveCallsign cs3("LON_E_CTR", "Jimbob Jump", controller3);
@@ -288,7 +288,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(ActiveCallsignCollectionTest, RemoveCallsignDoesNotChangeUserIfNotUserLoggingOff)
         {
-            ControllerPosition pos2("LON_E_CTR", 121.220, "CTR", { });
+            ControllerPosition pos2(2, "LON_E_CTR", 121.220, {}, true, false);
             ActiveCallsign callsign2("LON_E_CTR", "Testy McTestingon", pos2);
             collection.AddUserCallsign(this->testCallsign);
             collection.AddCallsign(callsign2);
@@ -299,8 +299,8 @@ namespace UKControllerPluginTest {
 
         TEST_F(ActiveCallsignCollectionTest, CorrectlyHandlesMismatchingCallsigns)
         {
-            ControllerPosition pos("LON_S_CTR", 129.420, "CTR", { "EGKK", "EGLL", "EGLC" });
-            ControllerPosition pos2("LON_N_CTR", 133.700, "CTR", {"EGCC", "EGGP"});
+            ControllerPosition pos(1, "LON_S_CTR", 129.420, { "EGKK", "EGLL", "EGLC" }, true, false);
+            ControllerPosition pos2(2, "LON_N_CTR", 133.700, {"EGCC", "EGGP"}, true, false);
             ActiveCallsign callsign("LON_S_CTR", "Testy McTest", pos2);
             ActiveCallsign callsign2("LON_S_CTR", "Testy McTest", pos2);
             collection.AddUserCallsign(callsign);

--- a/test/test/controller/ActiveCallsignMonitorTest.cpp
+++ b/test/test/controller/ActiveCallsignMonitorTest.cpp
@@ -55,60 +55,62 @@ namespace UKControllerPluginTest {
                     // Add the controllers
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGKK_DEL", 199.998, "DEL", { "EGKK" })
+                            new ControllerPosition(1, "EGKK_DEL", 199.998, {"EGKK"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGKK_TWR", 199.999, "TWR", { "EGKK" })
+                            new ControllerPosition(2, "EGKK_TWR", 199.999, {"EGKK"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_2_TWR", 199.997, "TWR", { "EGKK" })
+                            new ControllerPosition(3, "EGKK_2_TWR", 199.997, {"EGKK"}, true, false)
                     )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGKK_APP", 199.990, "APP", { "EGKK" })
+                            new ControllerPosition(4, "EGKK_APP", 199.990, {"EGKK"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGLL_S_TWR", 199.998, "TWR", { "EGLL" })
+                            new ControllerPosition(5, "EGLL_S_TWR", 199.998, {"EGLL"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGLL_N_APP", 199.998, "APP", { "EGLL" })
+                            new ControllerPosition(6, "EGLL_N_APP", 199.998, {"EGLL"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
                             new ControllerPosition(
+                                5,
                                 "LTC_S_CTR",
                                 134.120,
-                                "CTR",
-                                { "EGLL", "EGKK", "EGLC", "EGKA", "EGKB", "EGMC", "EGMD" }
+                                {"EGLL", "EGKK", "EGLC", "EGKA", "EGKB", "EGMC", "EGMD"},
+                                true,
+                                false
                             )
                         )
                     );
 
                     // Add the active callsigns
                     this->kkTwr = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_TWR", 199.999, "TWR", { "EGKK" })
+                        new ControllerPosition(2, "EGKK_TWR", 199.999, {"EGKK"}, true, false)
                     );
                     this->kkTwr2 = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_2_TWR", 199.997, "TWR", { "EGKK" })
+                        new ControllerPosition(3, "EGKK_2_TWR", 199.997, {"EGKK"}, true, false)
                     );
                     this->kkApp = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_APP", 199.990, "APP", { "EGKK" })
+                        new ControllerPosition(4, "EGKK_APP", 199.990, {"EGKK"}, true, false)
                     );
                     this->llTwr = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGLL_S_TWR", 199.998, "TWR", { "EGLL" })
+                        new ControllerPosition(5, "EGLL_S_TWR", 199.998, {"EGLL"}, true, false)
                     );
                     this->llApp = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGLL_N_APP", 199.998, "APP", { "EGLL" })
+                        new ControllerPosition(6, "EGLL_N_APP", 199.998, {"EGLL"}, true, false)
                     );
 
                     this->activeCallsigns.AddCallsign(ActiveCallsign("EGKK_TWR", "Testy McTest", *kkTwr));

--- a/test/test/controller/ActiveCallsignTest.cpp
+++ b/test/test/controller/ActiveCallsignTest.cpp
@@ -8,107 +8,104 @@ using UKControllerPlugin::Controller::ControllerPosition;
 namespace UKControllerPluginTest {
     namespace Controller {
 
-        TEST(ActiveCallsign, LessThanOperatorReturnsTrueIfCallsignLess)
+        class ActiveCallsignTest : public testing::Test
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
+            public:
+                ActiveCallsignTest()
+                    : controller(1, "LON_S_CTR", 129.420, {"EGKK"}, true, false),
+                      controller2(2, "LON_C_CTR", 127.100, {"EGSS"}, true, false)
+                { }
+
+                ControllerPosition controller;
+                ControllerPosition controller2;
+        };
+
+        TEST_F(ActiveCallsignTest, LessThanOperatorReturnsTrueIfCallsignLess)
+        {
             ActiveCallsign pos1("LON_S1_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_TRUE(pos1 < pos2);
         }
 
-        TEST(ActiveCallsign, LessThanOperatorReturnsFalseIfCallsignSame)
+        TEST_F(ActiveCallsignTest, LessThanOperatorReturnsFalseIfCallsignSame)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_FALSE(pos1 < pos2);
         }
 
-        TEST(ActiveCallsign, LessThanOperatorReturnsFalseIfCallsignMore)
+        TEST_F(ActiveCallsignTest, LessThanOperatorReturnsFalseIfCallsignMore)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S__CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_FALSE(pos1 < pos2);
         }
 
-        TEST(ActiveCallsign, GreaterThanOperatorReturnsFalseIfCallsignLess)
+        TEST_F(ActiveCallsignTest, GreaterThanOperatorReturnsFalseIfCallsignLess)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S1_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_FALSE(pos1 > pos2);
         }
 
-        TEST(ActiveCallsign, GreaterThanOperatorReturnsFalseIfCallsignSame)
+        TEST_F(ActiveCallsignTest, GreaterThanOperatorReturnsFalseIfCallsignSame)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_FALSE(pos1 > pos2);
         }
 
-        TEST(ActiveCallsign, GreaterThanOperatorReturnsTrueIfCallsignMore)
+        TEST_F(ActiveCallsignTest, GreaterThanOperatorReturnsTrueIfCallsignMore)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S__CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_TRUE(pos1 > pos2);
         }
 
-        TEST(ActiveCallsign, EqualityOperatorReturnsTrueIfAllEqual)
+        TEST_F(ActiveCallsignTest, EqualityOperatorReturnsTrueIfAllEqual)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_TRUE(pos1 == pos2);
         }
 
-        TEST(ActiveCallsign, EqualityOperatorReturnsFalseIfCallsignDifferent)
+        TEST_F(ActiveCallsignTest, EqualityOperatorReturnsFalseIfCallsignDifferent)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S__CTR", "Testy McTest", controller);
             EXPECT_FALSE(pos1 == pos2);
         }
 
-        TEST(ActiveCallsign, EqualityOperatorReturnsFalseIfControllerDifferent)
+        TEST_F(ActiveCallsignTest, EqualityOperatorReturnsFalseIfControllerDifferent)
         {
-            ControllerPosition controller1("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ControllerPosition controller2("LON_C_CTR", 127.100, "CTR", { "EGSS" });
-            ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller1);
+            ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller2);
             EXPECT_FALSE(pos1 == pos2);
         }
 
-        TEST(ActiveCallsign, InequalityOperatorReturnsFalseIfAllSame)
+        TEST_F(ActiveCallsignTest, InequalityOperatorReturnsFalseIfAllSame)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_FALSE(pos1 != pos2);
         }
 
-        TEST(ActiveCallsign, InequalityOperatorReturnsTrueIfCallsignNotSame)
+        TEST_F(ActiveCallsignTest, InequalityOperatorReturnsTrueIfCallsignNotSame)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S__CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller);
             EXPECT_TRUE(pos1 != pos2);
         }
 
-        TEST(ActiveCallsign, InequalityOperatorReturnsTrueIfControllerDifferent)
+        TEST_F(ActiveCallsignTest, InequalityOperatorReturnsTrueIfControllerDifferent)
         {
-            ControllerPosition controller1("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ControllerPosition controller2("LON_C_CTR", 127.100, "CTR", { "EGSS" });
-            ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller1);
+            ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller);
             ActiveCallsign pos2("LON_S_CTR", "Testy McTest", controller2);
             EXPECT_TRUE(pos1 != pos2);
         }
 
-        TEST(ActiveCallsign, CopyConstructorCopiesAllItems)
+        TEST_F(ActiveCallsignTest, CopyConstructorCopiesAllItems)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
             ActiveCallsign pos1("LON_S_CTR", "Testy McTest", controller);
             ActiveCallsign pos2 = pos1;
             EXPECT_TRUE(pos1 == pos2);

--- a/test/test/controller/ControllerPositionCollectionFactoryTest.cpp
+++ b/test/test/controller/ControllerPositionCollectionFactoryTest.cpp
@@ -26,60 +26,333 @@ namespace UKControllerPluginTest {
 
         TEST_F(ControllerPositionCollectionFactoryTest, ReturnsEmptyCollectionIfNoDependencyFound)
         {
-            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS", nlohmann::json::object()))
-                .WillByDefault(Return(nlohmann::json::object()));
-            std::shared_ptr<ControllerPositionCollection> collection = ControllerPositionCollectionFactory::Create(
-                dependency
-            );
-            EXPECT_EQ(0, collection->GetSize());
-        }
-
-        TEST_F(ControllerPositionCollectionFactoryTest, ReturnsEmptyCollectionIfInvalidJson)
-        {
-            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS", nlohmann::json::object()))
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
                 .WillByDefault(Return(nlohmann::json::array()));
-            std::shared_ptr<ControllerPositionCollection> collection = ControllerPositionCollectionFactory::Create(
-                dependency
-            );
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
             EXPECT_EQ(0, collection->GetSize());
         }
 
-        TEST_F(ControllerPositionCollectionFactoryTest, AddsDoesntAddControllerIfNotValid)
+        TEST_F(ControllerPositionCollectionFactoryTest, ReturnsEmptyCollectionIfJsonNotArray)
         {
-            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS", nlohmann::json::object()))
-                .WillByDefault(Return("{\"EGAA_GND\": {\"frequency\": \"test\", \"top-down\" : [\"EGAA\"]}}"_json));
-            std::shared_ptr<ControllerPositionCollection> collection = ControllerPositionCollectionFactory::Create(
-                dependency
-            );
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(nlohmann::json::object()));
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
             EXPECT_EQ(0, collection->GetSize());
         }
 
-        TEST_F(ControllerPositionCollectionFactoryTest, AddsControllerIfValid)
+        TEST_F(ControllerPositionCollectionFactoryTest, ItAddsControllers)
         {
-            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS", nlohmann::json::object()))
-                .WillByDefault(Return("{\"EGAA_GND\": {\"frequency\": 121.750, \"top-down\" : [\"EGAA\"]}}"_json));
-            std::shared_ptr<ControllerPositionCollection> collection = ControllerPositionCollectionFactory::Create(
-                dependency
-            );
-            ControllerPosition position = collection->FetchPositionByCallsign("EGAA_GND");
-            EXPECT_EQ(0, position.GetCallsign().compare("EGAA_GND"));
-            EXPECT_EQ(121.750, position.GetFrequency());
-            EXPECT_EQ(0, position.GetType().compare("GND"));
-            EXPECT_THAT(position.GetTopdown(), ElementsAre("EGAA"));
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                }, // Normal frequency
+                {
+                    {"id", 2},
+                    {"callsign", "EGAA_TWR"},
+                    {"frequency", 123},
+                    {"top_down", nlohmann::json::array({"EGAA"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", false},
+                }, // Frequency ending with all zeros - comes out as integer in dependency
+                {
+                    {"id", 3},
+                    {"callsign", "EGAA_GND"},
+                    {"frequency", 123.450},
+                    {"top_down", nlohmann::json::array()},
+                    {"requests_departure_releases", false},
+                    {"receives_departure_releases", false},
+                } // No top-down
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(3, collection->GetSize());
+
+            ControllerPosition positionNormal = collection->FetchPositionByCallsign("EGAA_R_APP");
+            EXPECT_EQ(1, positionNormal.GetId());
+            EXPECT_EQ("EGAA_R_APP", positionNormal.GetCallsign());
+            EXPECT_EQ(121.750, positionNormal.GetFrequency());
+            EXPECT_EQ(std::vector<std::string>({"EGAA", "EGAC"}), positionNormal.GetTopdown());
+            EXPECT_TRUE(positionNormal.RequestsDepartureReleases());
+            EXPECT_TRUE(positionNormal.ReceivesDepartureReleases());
+
+            ControllerPosition positionAllZeroFrequency = collection->FetchPositionByCallsign("EGAA_TWR");
+            EXPECT_EQ(2, positionAllZeroFrequency.GetId());
+            EXPECT_EQ("EGAA_TWR", positionAllZeroFrequency.GetCallsign());
+            EXPECT_EQ(123.000, positionAllZeroFrequency.GetFrequency());
+            EXPECT_EQ(std::vector<std::string>({"EGAA"}), positionAllZeroFrequency.GetTopdown());
+            EXPECT_TRUE(positionAllZeroFrequency.RequestsDepartureReleases());
+            EXPECT_FALSE(positionAllZeroFrequency.ReceivesDepartureReleases());
+
+            ControllerPosition positionNoTopDown = collection->FetchPositionByCallsign("EGAA_GND");
+            EXPECT_EQ(3, positionNoTopDown.GetId());
+            EXPECT_EQ("EGAA_GND", positionNoTopDown.GetCallsign());
+            EXPECT_EQ(123.450, positionNoTopDown.GetFrequency());
+            EXPECT_EQ(std::vector<std::string>(), positionNoTopDown.GetTopdown());
+            EXPECT_FALSE(positionNoTopDown.RequestsDepartureReleases());
+            EXPECT_FALSE(positionNoTopDown.ReceivesDepartureReleases());
         }
 
-        TEST_F(ControllerPositionCollectionFactoryTest, AddsControllerIfValidWithZeroEndingFrequency)
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithMissingId)
         {
-            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS", nlohmann::json::object()))
-                .WillByDefault(Return("{\"EGAA_GND\": {\"frequency\": 121.000, \"top-down\" : [\"EGAA\"]}}"_json));
-            std::shared_ptr<ControllerPositionCollection> collection = ControllerPositionCollectionFactory::Create(
-                dependency
-            );
-            ControllerPosition position = collection->FetchPositionByCallsign("EGAA_GND");
-            EXPECT_EQ(0, position.GetCallsign().compare("EGAA_GND"));
-            EXPECT_EQ(121.000, position.GetFrequency());
-            EXPECT_EQ(0, position.GetType().compare("GND"));
-            EXPECT_THAT(position.GetTopdown(), ElementsAre("EGAA"));
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
         }
-    }  // namespace Controller
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithIdNotInteger)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", "abc"},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithMissingCallsign)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithCallsignNotString)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", 123},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithFrequencyMissing)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithFrequencyNotFloat)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", "abc"},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithTopDownMissing)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithTopDownNotArray)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", "abc"},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithTopDownInvalidItem)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", 123})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithRequestsDepartureReleasesMissing)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"receives_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithRequestsDepartureReleasesNotBoolean)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", "abc"},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithReceivesDepartureReleasesMissing)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+
+        TEST_F(ControllerPositionCollectionFactoryTest, ItDoesntAddControllerWithReceivesDepartureReleasesNotBoolean)
+        {
+            nlohmann::json data = nlohmann::json::array({
+                {
+                    {"id", 1},
+                    {"callsign", "EGAA_R_APP"},
+                    {"frequency", 121.750},
+                    {"top_down", nlohmann::json::array({"EGAA", "EGAC"})},
+                    {"requests_departure_releases", true},
+                    {"receives_departure_releases", "abc"},
+                },
+            });
+
+            ON_CALL(this->dependency, LoadDependency("DEPENDENCY_CONTROLLER_POSITIONS_V2", nlohmann::json::array()))
+                .WillByDefault(Return(data));
+
+            auto collection = ControllerPositionCollectionFactory::Create(dependency);
+            EXPECT_EQ(0, collection->GetSize());
+        }
+    } // namespace Controller
 }  // namespace UKControllerPluginTest

--- a/test/test/controller/ControllerPositionCollectionTest.cpp
+++ b/test/test/controller/ControllerPositionCollectionTest.cpp
@@ -8,179 +8,195 @@ using UKControllerPlugin::Controller::ControllerPositionCollection;
 namespace UKControllerPluginTest {
     namespace Controller {
 
-        TEST(ControllerPositionCollection, AddsCallsignOnlyAddsOnce)
+        class ControllerPositionCollectionTest : public testing::Test
         {
-            std::unique_ptr<ControllerPosition> controllerFirst(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-            std::unique_ptr<ControllerPosition> controllerSecond(
-                new ControllerPosition("EGFF_APP", 999.999, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
+            public:
+                void SetUp() override
+                {
+                    controllerFirst.reset(
+                        new ControllerPosition(
+                            1,
+                            "EGFF_APP",
+                            125.850,
+                            std::vector<std::string>{"EGGD", "EGFF"},
+                            true,
+                            false
+                        )
+                    );
+                    controllerSecond.reset(
+                        new ControllerPosition(
+                            2,
+                            "EGFF_APP",
+                            999.999,
+                            std::vector<std::string>{"EGGD", "EGFF"},
+                            true,
+                            false
+                        )
+                    );
+                    controllerThird.reset(
+                        new ControllerPosition(
+                            3,
+                            "ESSEX_APP",
+                            120.620,
+                            std::vector<std::string>{"EGSS", "EGGW"},
+                            true,
+                            false
+                        )
+                    );
+                    controllerFourth.reset(
+                        new ControllerPosition(
+                            4,
+                            "THAMES_APP",
+                            133.700,
+                            std::vector<std::string>{"EGLC"},
+                            true,
+                            false
+                        )
+                    );
+                    controllerFifth.reset(
+                        new ControllerPosition(
+                            5,
+                            "SOLENT_APP",
+                            120.220,
+                            std::vector<std::string>{"EGHI"},
+                            true,
+                            false
+                        )
+                    );
+                }
 
+                std::shared_ptr<ControllerPosition> controllerFirst;
+                std::shared_ptr<ControllerPosition> controllerSecond;
+                std::shared_ptr<ControllerPosition> controllerThird;
+                std::shared_ptr<ControllerPosition> controllerFourth;
+                std::shared_ptr<ControllerPosition> controllerFifth;
+        };
+
+        TEST_F(ControllerPositionCollectionTest, AddsCallsignOnlyAddsOnce)
+        {
             ControllerPositionCollection collection;
-            EXPECT_TRUE(collection.AddPosition(std::move(std::move(controllerFirst))));
-            EXPECT_FALSE(collection.AddPosition(std::move(controllerSecond)));
+            EXPECT_TRUE(collection.AddPosition(controllerFirst));
+            EXPECT_FALSE(collection.AddPosition(controllerSecond));
         }
 
-        TEST(ControllerPositionCollection, GetSizeReturnsNumberOfPositions)
+        TEST_F(ControllerPositionCollectionTest, GetSizeReturnsNumberOfPositions)
         {
-            std::unique_ptr<ControllerPosition> controllerFirst(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-            std::unique_ptr<ControllerPosition> controllerSecond(
-                new ControllerPosition("EGGD_APP", 125.650, "APP", std::vector<std::string> {"EGGD"})
-            );
-
             ControllerPositionCollection collection;
             EXPECT_EQ(0, collection.GetSize());
-            collection.AddPosition(std::move(controllerFirst));
-            collection.AddPosition(std::move(controllerSecond));
+            collection.AddPosition(controllerFirst);
+            collection.AddPosition(controllerThird);
             EXPECT_EQ(2, collection.GetSize());
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByCallsignReturnsPositionIfFound)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByCallsignReturnsPositionIfFound)
         {
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-
-            ControllerPosition * rawController = controller.get();
             ControllerPositionCollection collection;
-            collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*rawController, collection.FetchPositionByCallsign("EGFF_APP"));
+            collection.AddPosition(controllerFirst);
+            EXPECT_EQ(*controllerFirst, collection.FetchPositionByCallsign("EGFF_APP"));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByCallsignThrowsExceptionIfNotFound)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByCallsignThrowsExceptionIfNotFound)
         {
             ControllerPositionCollection collection;
             EXPECT_THROW(collection.FetchPositionByCallsign("EGFF_APP"), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfPositionNotFound)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByIdReturnsPositionIfFound)
+        {
+            ControllerPositionCollection collection;
+            collection.AddPosition(controllerFirst);
+            EXPECT_EQ(controllerFirst, collection.FetchPositionById(1));
+        }
+
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByIdReturnsNullptrIfNotFound)
+        {
+            ControllerPositionCollection collection;
+            EXPECT_EQ(nullptr, collection.FetchPositionById(-55));
+        }
+
+        TEST_F(ControllerPositionCollectionTest,
+               FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfPositionNotFound)
         {
             ControllerPositionCollection collection;
             EXPECT_THROW(collection.FetchPositionByFacilityTypeAndFrequency("EGBB", "APP", 121.200), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoFrequencyMatch)
+        TEST_F(ControllerPositionCollectionTest,
+               FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoFrequencyMatch)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-            collection.AddPosition(std::move(controller));
+            collection.AddPosition(controllerFirst);
             EXPECT_THROW(collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "APP", 121.200), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoTypeMatch)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoTypeMatch)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-            collection.AddPosition(std::move(controller));
+            collection.AddPosition(controllerFirst);
             EXPECT_THROW(collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "TWR", 125.850), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoFacilityMatch)
+        TEST_F(ControllerPositionCollectionTest,
+               FetchPositionByFacilityTypeAndFrequencyThrowsExceptionIfNoFacilityMatch)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-            collection.AddPosition(std::move(controller));
+            collection.AddPosition(controllerFirst);
             EXPECT_THROW(collection.FetchPositionByFacilityTypeAndFrequency("EGHI", "APP", 125.850), std::out_of_range);
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyReturnsOnMatch)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByFacilityTypeAndFrequencyReturnsOnMatch)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-
-            ControllerPosition * controllerRaw = controller.get();
-            collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "APP", 125.850));
+            collection.AddPosition(controllerFirst);
+            EXPECT_EQ(*controllerFirst, collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "APP", 125.850));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyReturnsOnMatchFrequencyDelta)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByFacilityTypeAndFrequencyReturnsOnMatchFrequencyDelta)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.8505, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-
-            ControllerPosition * controllerRaw = controller.get();
-            collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "APP", 125.8514));
+            collection.AddPosition(controllerFirst);
+            EXPECT_EQ(*controllerFirst, collection.FetchPositionByFacilityTypeAndFrequency("EGFF", "APP", 125.8501));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyWillWorkForEssex)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByFacilityTypeAndFrequencyWillWorkForEssex)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("ESSEX_APP", 120.620, "APP", std::vector<std::string> {"EGSS, EGGW, EGSC"})
-            );
-
-            ControllerPosition * controllerRaw = controller.get();
-            collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("ESSEX", "APP", 120.620));
+            collection.AddPosition(controllerThird);
+            EXPECT_EQ(*controllerThird, collection.FetchPositionByFacilityTypeAndFrequency("ESSEX", "APP", 120.620));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyWillWorkForThames)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByFacilityTypeAndFrequencyWillWorkForThames)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("THAMES", 132.700, "APP", std::vector<std::string> {"EGLC, EGKB"})
-            );
-
-            ControllerPosition * controllerRaw = controller.get();
-            collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("THAMES", "APP", 132.700));
+            collection.AddPosition(controllerFourth);
+            EXPECT_EQ(*controllerFourth, collection.FetchPositionByFacilityTypeAndFrequency("THAMES", "APP", 133.700));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyWillWorkForSolent)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByFacilityTypeAndFrequencyWillWorkForSolent)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("SOLENT", 120.220, "APP", std::vector<std::string> {"EGLC, EGKB"})
-            );
-
-            ControllerPosition * controllerRaw = controller.get();
-            collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("SOLENT", "APP", 120.220));
+            collection.AddPosition(controllerFifth);
+            EXPECT_EQ(*controllerFifth, collection.FetchPositionByFacilityTypeAndFrequency("SOLENT", "APP", 120.220));
         }
 
-        TEST(ControllerPositionCollection, FetchPositionByFacilityTypeAndFrequencyWillWorkForAbbreviations)
+        TEST_F(ControllerPositionCollectionTest, FetchPositionByFacilityTypeAndFrequencyWillWorkForAbbreviations)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("ESSEX_APP", 120.620, "APP", std::vector<std::string> {"EGSS, EGGW, EGSC"})
-            );
-
-            ControllerPosition * controllerRaw = controller.get();
-            collection.AddPosition(std::move(controller));
-            EXPECT_EQ(*controllerRaw, collection.FetchPositionByFacilityTypeAndFrequency("ESX", "APP", 120.620));
+            collection.AddPosition(controllerThird);
+            EXPECT_EQ(*controllerThird, collection.FetchPositionByFacilityTypeAndFrequency("ESX", "APP", 120.620));
         }
 
-        TEST(ControllerPositionCollection, HasPositionReturnsFalseIfDoesntExist)
+        TEST_F(ControllerPositionCollectionTest, HasPositionReturnsFalseIfDoesntExist)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-            collection.AddPosition(std::move(controller));
+            collection.AddPosition(controllerFirst);
             EXPECT_FALSE(collection.HasPosition("EGHI_TWR"));
         }
 
-        TEST(ControllerPositionCollection, HasPositionReturnsTrueIfExists)
+        TEST_F(ControllerPositionCollectionTest, HasPositionReturnsTrueIfExists)
         {
             ControllerPositionCollection collection;
-            std::unique_ptr<ControllerPosition> controller(
-                new ControllerPosition("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"})
-            );
-            collection.AddPosition(std::move(controller));
+            collection.AddPosition(controllerFirst);
             EXPECT_TRUE(collection.HasPosition("EGFF_APP"));
         }
     }  // namespace Controller

--- a/test/test/controller/ControllerPositionHierarchyFactoryTest.cpp
+++ b/test/test/controller/ControllerPositionHierarchyFactoryTest.cpp
@@ -22,12 +22,12 @@ namespace UKControllerPluginTest {
                     this->collection = std::make_unique<ControllerPositionCollection>();
                     this->collection->AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGKK_GND", 121.800, "GND", { "EGKK" })
+                            new ControllerPosition(1, "EGKK_GND", 121.800, {"EGKK"}, true, false)
                         )
                     );
                     this->collection->AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGKK_TWR", 124.220, "TWR", { "EGKK" })
+                            new ControllerPosition(2, "EGKK_TWR", 124.220, {"EGKK"}, true, false)
                         )
                     );
                     this->factory = std::make_unique<ControllerPositionHierarchyFactory>(

--- a/test/test/controller/ControllerPositionHierarchyTest.cpp
+++ b/test/test/controller/ControllerPositionHierarchyTest.cpp
@@ -8,39 +8,46 @@ using UKControllerPlugin::Controller::ControllerPositionHierarchy;
 namespace UKControllerPluginTest {
     namespace Controller {
 
-        TEST(ControllerPositionHierarchy, AddPositionAddsToHierarchy)
+        class ControllerPositionHierarchyTest : public testing::Test
         {
-            ControllerPosition position("EGKK_DEL", 121.950, "DEL", { "EGKK" });
+            public:
+                ControllerPositionHierarchyTest()
+                    : position1(1, "EGKK_DEL", 121.950, {"EGKK"}, true, false),
+                      position2(2, "EGKK_GND", 121.800, {"EGKK"}, true, false),
+                      position3(3, "EGKK_TWR", 124.220, {"EGKK"}, true, false)
+                { }
+
+                ControllerPosition position1;
+                ControllerPosition position2;
+                ControllerPosition position3;
+        };
+
+        TEST_F(ControllerPositionHierarchyTest, AddPositionAddsToHierarchy)
+        {
             ControllerPositionHierarchy hierarchy;
 
-            hierarchy.AddPosition(position);
+            hierarchy.AddPosition(position1);
             EXPECT_EQ(1, hierarchy.CountPositions());
         }
 
-        TEST(ControllerPositionHierarchy, PositionInHierarchyReturnsTrueIfInHierarchy)
+        TEST_F(ControllerPositionHierarchyTest, PositionInHierarchyReturnsTrueIfInHierarchy)
         {
-            ControllerPosition position("EGKK_DEL", 121.950, "DEL", { "EGKK" });
             ControllerPositionHierarchy hierarchy;
 
-            hierarchy.AddPosition(position);
-            EXPECT_TRUE(hierarchy.PositionInHierarchy(position));
+            hierarchy.AddPosition(position1);
+            EXPECT_TRUE(hierarchy.PositionInHierarchy(position1));
         }
 
-        TEST(ControllerPositionHierarchy, PositionInHierarchyReturnsFalseIfNotInHierarchy)
+        TEST_F(ControllerPositionHierarchyTest, PositionInHierarchyReturnsFalseIfNotInHierarchy)
         {
-            ControllerPosition position("EGKK_DEL", 121.950, "DEL", { "EGKK" });
-            ControllerPosition position2("EGKK_GND", 121.800, "GND", { "EGKK" });
             ControllerPositionHierarchy hierarchy;
 
-            hierarchy.AddPosition(position);
+            hierarchy.AddPosition(position1);
             EXPECT_FALSE(hierarchy.PositionInHierarchy(position2));
         }
 
-        TEST(ControllerPositionHierarchy, OrderIsDeterminedByFIFO)
+        TEST_F(ControllerPositionHierarchyTest, OrderIsDeterminedByFIFO)
         {
-            ControllerPosition position1("EGKK_DEL", 121.950, "DEL", { "EGKK" });
-            ControllerPosition position2("EGKK_GND", 121.800, "GND", { "EGKK" });
-            ControllerPosition position3("EGKK_TWR", 124.220, "TWR", { "EGKK" });
             ControllerPositionHierarchy hierarchy;
 
             hierarchy.AddPosition(position1);
@@ -53,53 +60,45 @@ namespace UKControllerPluginTest {
             EXPECT_EQ(it++->get(), position3);
         }
 
-        TEST(ControllerPositionHierarchy, EqualityReturnsFalseIfDifferentSizes)
+        TEST_F(ControllerPositionHierarchyTest, EqualityReturnsFalseIfDifferentSizes)
         {
-            ControllerPosition position("EGKK_DEL", 121.950, "DEL", { "EGKK" });
-            ControllerPosition position2("EGKK_GND", 121.800, "GND", { "EGKK" });
             ControllerPositionHierarchy hierarchy1;
             ControllerPositionHierarchy hierarchy2;
 
-            hierarchy1.AddPosition(position);
+            hierarchy1.AddPosition(position1);
             EXPECT_FALSE(hierarchy1 == hierarchy2);
         }
 
-        TEST(ControllerPositionHierarchy, EqualityReturnsFalseIfPositions)
+        TEST_F(ControllerPositionHierarchyTest, EqualityReturnsFalseIfPositions)
         {
-            ControllerPosition position("EGKK_DEL", 121.950, "DEL", { "EGKK" });
-            ControllerPosition position2("EGKK_GND", 121.800, "GND", { "EGKK" });
             ControllerPositionHierarchy hierarchy1;
             ControllerPositionHierarchy hierarchy2;
 
-            hierarchy1.AddPosition(position);
+            hierarchy1.AddPosition(position1);
             hierarchy2.AddPosition(position2);
             EXPECT_FALSE(hierarchy1 == hierarchy2);
         }
 
-        TEST(ControllerPositionHierarchy, EqualityReturnsFalseIfWrongOrder)
+        TEST_F(ControllerPositionHierarchyTest, EqualityReturnsFalseIfWrongOrder)
         {
-            ControllerPosition position("EGKK_DEL", 121.950, "DEL", { "EGKK" });
-            ControllerPosition position2("EGKK_GND", 121.800, "GND", { "EGKK" });
             ControllerPositionHierarchy hierarchy1;
             ControllerPositionHierarchy hierarchy2;
 
-            hierarchy1.AddPosition(position);
+            hierarchy1.AddPosition(position1);
             hierarchy1.AddPosition(position2);
             hierarchy2.AddPosition(position2);
-            hierarchy2.AddPosition(position);
+            hierarchy2.AddPosition(position1);
             EXPECT_FALSE(hierarchy1 == hierarchy2);
         }
 
-        TEST(ControllerPositionHierarchy, EqualityReturnsTrueIfEqual)
+        TEST_F(ControllerPositionHierarchyTest, EqualityReturnsTrueIfEqual)
         {
-            ControllerPosition position("EGKK_DEL", 121.950, "DEL", { "EGKK" });
-            ControllerPosition position2("EGKK_GND", 121.800, "GND", { "EGKK" });
             ControllerPositionHierarchy hierarchy1;
             ControllerPositionHierarchy hierarchy2;
 
-            hierarchy1.AddPosition(position);
+            hierarchy1.AddPosition(position1);
             hierarchy1.AddPosition(position2);
-            hierarchy2.AddPosition(position);
+            hierarchy2.AddPosition(position1);
             hierarchy2.AddPosition(position2);
             EXPECT_TRUE(hierarchy1 == hierarchy2);
         }

--- a/test/test/controller/ControllerPositionTest.cpp
+++ b/test/test/controller/ControllerPositionTest.cpp
@@ -6,89 +6,118 @@ using UKControllerPlugin::Controller::ControllerPosition;
 namespace UKControllerPluginTest {
     namespace Controller {
 
-        TEST(ControllerPosition, GetCallsignReturnsCallsign)
+        class ControllerPositionTest : public testing::Test
         {
-            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"});
+            public:
+
+                ControllerPositionTest()
+                    : controller(1, "EGFF_APP", 125.850, std::vector<std::string>{"EGGD", "EGFF"}, true, false)
+                { }
+
+                ControllerPosition controller;
+        };
+
+        TEST_F(ControllerPositionTest, GetIdReturnsId)
+        {
+            EXPECT_EQ(1, controller.GetId());
+        }
+
+        TEST_F(ControllerPositionTest, GetCallsignReturnsCallsign)
+        {
             EXPECT_EQ(0, controller.GetCallsign().compare("EGFF_APP"));
         }
 
-        TEST(ControllerPosition, GetFrequencyReturnsFrequency)
+        TEST_F(ControllerPositionTest, GetFrequencyReturnsFrequency)
         {
-            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"});
             EXPECT_EQ(125.850, controller.GetFrequency());
         }
 
-        TEST(ControllerPosition, GetTypeReturnsType)
+        TEST_F(ControllerPositionTest, GetTypeReturnsType)
         {
-            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD, EGFF"});
             EXPECT_EQ(0, controller.GetType().compare("APP"));
         }
 
-        TEST(ControllerPosition, GetTopdownReturnsTopdown)
+        TEST_F(ControllerPositionTest, GetTopdownReturnsTopdown)
         {
-            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            std::vector<std::string> expected = { "EGGD", "EGFF" };
+            std::vector<std::string> expected = {"EGGD", "EGFF"};
             EXPECT_EQ(expected, controller.GetTopdown());
         }
 
-        TEST(ControllerPosition, ComparisonOperatorReturnsTrueIfSame)
+        TEST_F(ControllerPositionTest, RequestsDepartureReleasesReturnsWhetherItCan)
         {
-            ControllerPosition controller1("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            ControllerPosition controller2("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            EXPECT_TRUE(controller1 == controller2);
+            EXPECT_TRUE(controller.RequestsDepartureReleases());
         }
 
-        TEST(ControllerPosition, ComparisonOperatorReturnsTrueIfSameFrequencyDelta)
+        TEST_F(ControllerPositionTest, ReceivesDepartureReleasesReturnsWhetherItCan)
         {
-            ControllerPosition controller1("EGFF_APP", 125.8502, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            ControllerPosition controller2("EGFF_APP", 125.8501, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            EXPECT_TRUE(controller1 == controller2);
+            EXPECT_FALSE(controller.ReceivesDepartureReleases());
         }
 
-        TEST(ControllerPosition, ComparisonOperatorReturnsFalseIfDifferentCallsign)
+        TEST_F(ControllerPositionTest, ComparisonOperatorReturnsTrueIfSame)
         {
-            ControllerPosition controller1("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            ControllerPosition controller2("EGFF_R_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            EXPECT_FALSE(controller1 == controller2);
+            ControllerPosition controller2(
+                1,
+                "EGFF_APP",
+                125.850,
+                std::vector<std::string>{"EGGD", "EGFF"},
+                true,
+                false
+            );
+            EXPECT_TRUE(controller == controller2);
         }
 
-        TEST(ControllerPosition, ComparisonOperatorReturnsFalseIfDifferentFrequency)
+        TEST_F(ControllerPositionTest, ComparisonOperatorReturnsTrueIfSameFrequencyDelta)
         {
-            ControllerPosition controller1("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            ControllerPosition controller2("EGFF_APP", 125.650, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            EXPECT_FALSE(controller1 == controller2);
+            ControllerPosition controller2(
+                1,
+                "EGFF_APP",
+                125.8501,
+                std::vector<std::string>{"EGGD", "EGFF"},
+                true,
+                false
+            );
+            EXPECT_TRUE(controller == controller2);
         }
 
-        TEST(ControllerPosition, ComparisonOperatorReturnsFalseIfDifferentBoundary)
+        TEST_F(ControllerPositionTest, ComparisonOperatorReturnsFalseIfDifferentCallsign)
         {
-            ControllerPosition controller1("EGFF_APP", 125.851, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            ControllerPosition controller2("EGFF_APP", 125.650, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            EXPECT_FALSE(controller1 == controller2);
+            ControllerPosition controller2(
+                1,
+                "EGFF_R_APP",
+                125.850,
+                std::vector<std::string>{"EGGD", "EGFF"},
+                true,
+                false
+            );
+            EXPECT_FALSE(controller == controller2);
         }
 
-        TEST(ControllerPosition, ComparisonOperatorReturnsFalseIfDifferentType)
+        TEST_F(ControllerPositionTest, ComparisonOperatorReturnsFalseIfDifferentFrequency)
         {
-            ControllerPosition controller1("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
-            ControllerPosition controller2("EGFF_APP", 125.850, "CTR", std::vector<std::string> {"EGGD", "EGFF"});
-            EXPECT_FALSE(controller1 == controller2);
+            ControllerPosition controller2(
+                1,
+                "EGFF_APP",
+                125.650,
+                std::vector<std::string>{"EGGD", "EGFF"},
+                true,
+                false
+            );
+            EXPECT_FALSE(controller == controller2);
         }
 
-        TEST(ControllerPosition, GetUnitReturnsTheAirfieldOrAreaUnit)
+        TEST_F(ControllerPositionTest, GetUnitReturnsTheAirfieldOrAreaUnit)
         {
-            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
             EXPECT_TRUE("EGFF" == controller.GetUnit());
         }
 
-        TEST(ControllerPosition, ItReturnsTrueOnTopdownAirfield)
+        TEST_F(ControllerPositionTest, ItReturnsTrueOnTopdownAirfield)
         {
-            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
             EXPECT_TRUE(controller.HasTopdownAirfield("EGFF"));
             EXPECT_TRUE(controller.HasTopdownAirfield("EGGD"));
         }
 
-        TEST(ControllerPosition, ItReturnsFalseOnNoTopdownAirfield)
+        TEST_F(ControllerPositionTest, ItReturnsFalseOnNoTopdownAirfield)
         {
-            ControllerPosition controller("EGFF_APP", 125.850, "APP", std::vector<std::string> {"EGGD", "EGFF"});
             EXPECT_FALSE(controller.HasTopdownAirfield("EGLL"));
         }
     }  // namespace Controller

--- a/test/test/handoff/HandoffCollectionFactoryTest.cpp
+++ b/test/test/handoff/HandoffCollectionFactoryTest.cpp
@@ -22,10 +22,10 @@ namespace UKControllerPluginTest {
                 {
                     std::vector<std::string> handoffs = { "EGKK" };
                     controllers.AddPosition(
-                        std::make_unique<ControllerPosition>("EGKK_APP", 126.820, "APP", handoffs)
+                        std::make_unique<ControllerPosition>(1, "EGKK_APP", 126.820, handoffs, true, false)
                     );
                     controllers.AddPosition(
-                        std::make_unique<ControllerPosition>("LON_S_CTR", 129.420, "CTR", handoffs)
+                        std::make_unique<ControllerPosition>(2, "LON_S_CTR", 129.420, handoffs, true, false)
                     );
                 }
 

--- a/test/test/handoff/HandoffCollectionTest.cpp
+++ b/test/test/handoff/HandoffCollectionTest.cpp
@@ -17,7 +17,7 @@ namespace UKControllerPluginTest {
             public:
 
                 HandoffCollectionTest()
-                    : position(new ControllerPosition("EGKK_GND", 122.8, "GND", {"EGKK"}))
+                    : position(new ControllerPosition(1, "EGKK_GND", 122.8, {"EGKK"}, true, false))
                 {
                     this->hierarchy1.reset(new ControllerPositionHierarchy);
                     this->hierarchy1->AddPosition(*this->position);

--- a/test/test/handoff/HandoffEventHandlerTest.cpp
+++ b/test/test/handoff/HandoffEventHandlerTest.cpp
@@ -31,18 +31,19 @@ namespace UKControllerPluginTest {
         {
             public:
                 HandoffEventHandlerTest()
-                    : handler(handoffs, activeCallsigns), position1("LON_S_CTR", 129.420, "CTR", {}),
-                    position2("LON_SC_CTR", 132.6, "CTR", {}),
-                    tagData(
-                        mockFlightplan,
-                        mockRadarTarget,
-                        1,
-                        EuroScopePlugIn::TAG_DATA_CORRELATED,
-                        itemString,
-                        &euroscopeColourCode,
-                        &tagColour,
-                        &fontSize
-                    )
+                    : position1(1, "LON_S_CTR", 129.420, {}, true, false),
+                      position2(2, "LON_SC_CTR", 132.6, {}, true, false),
+                      tagData(
+                          mockFlightplan,
+                          mockRadarTarget,
+                          1,
+                          EuroScopePlugIn::TAG_DATA_CORRELATED,
+                          itemString,
+                          &euroscopeColourCode,
+                          &tagColour,
+                          &fontSize
+                      ),
+                      handler(handoffs, activeCallsigns)
                 {
                     ON_CALL(this->mockFlightplan, GetCallsign())
                         .WillByDefault(Return("BAW123"));

--- a/test/test/initialaltitude/InitialAltitudeEventHandlerTest.cpp
+++ b/test/test/initialaltitude/InitialAltitudeEventHandlerTest.cpp
@@ -56,7 +56,9 @@ namespace UKControllerPluginTest {
                 InitialAltitudeEventHandlerTest()
                     :  owners(airfields, callsigns),
                     login(plugin, ControllerStatusEventHandlerCollection()),
-                    handler(sids, callsigns, owners, login, deferredEvents, plugin, flightplans)
+                    handler(sids, callsigns, owners, login, deferredEvents, plugin, flightplans),
+                    controller(1, "LON_S_CTR", 129.420, {"EGKK"}, true, false),
+                    userCallsign("LON_S_CTR", "Test", controller)
                 {
 
                 }
@@ -71,6 +73,8 @@ namespace UKControllerPluginTest {
                         .WillByDefault(Return("BAW123"));
                 }
 
+                ControllerPosition controller;
+                ActiveCallsign userCallsign;
                 AirfieldCollection airfields;
                 DeferredEventHandler deferredEvents;
                 NiceMock<MockEuroScopeCFlightPlanInterface> mockFlightPlan;
@@ -337,13 +341,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, FlightPlanEventDoesNotAssignIfAirfieldIsNotOwnedByUser)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
-
             callsigns.AddUserCallsign(userCallsign);
 
             EXPECT_CALL(mockFlightPlan, GetDistanceFromOrigin())
@@ -379,12 +376,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, FlightPlanEventDoesNotAssignIfSidNotFound)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -427,12 +418,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, FlightPlanEventDoesNotAssignIfAlreadyAssignedOnSameSid)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -487,12 +472,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, FlightPlanEventAssignsIfSidFound)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -546,12 +525,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, FlightPlanEventAcceptsDeprecatedSids)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -605,12 +578,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, FlightPlanEventDoesAssignIfDifferentSid)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -672,12 +639,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, FlightPlanEventDoesAssignAfterDisconnect)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -855,12 +816,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, NewActiveCallsignAssignsIfUserCallsign)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -927,12 +882,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialAltitudeEventHandlerTest, NewActiveCallsignDoesNotAssignIfNotUserCallsign)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddCallsign(userCallsign);
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
             owners.RefreshOwner("EGKK");

--- a/test/test/initialheading/InitialHeadingEventHandlerTest.cpp
+++ b/test/test/initialheading/InitialHeadingEventHandlerTest.cpp
@@ -57,7 +57,9 @@ namespace UKControllerPluginTest {
                 InitialHeadingEventHandlerTest()
                     :  owners(airfields, callsigns),
                     login(plugin, ControllerStatusEventHandlerCollection()),
-                    handler(sids, callsigns, owners, login, deferredEvents, plugin, flightplans)
+                    handler(sids, callsigns, owners, login, deferredEvents, plugin, flightplans),
+                    controller(1, "LON_S_CTR", 129.420, {"EGKK"}, true, false),
+                    userCallsign("LON_S_CTR", "Test", controller)
                 {
 
                 }
@@ -73,6 +75,9 @@ namespace UKControllerPluginTest {
                         .WillByDefault(Return("BAW123"));
                 }
 
+
+                ControllerPosition controller;
+                ActiveCallsign userCallsign;
                 AirfieldCollection airfields;
                 DeferredEventHandler deferredEvents;
                 NiceMock<MockEuroScopeCFlightPlanInterface> mockFlightPlan;
@@ -360,13 +365,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, FlightPlanEventDoesNotAssignIfAirfieldIsNotOwnedByUser)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
-
             callsigns.AddUserCallsign(userCallsign);
 
             EXPECT_CALL(mockFlightPlan, GetDistanceFromOrigin())
@@ -402,12 +400,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, FlightPlanEventDoesNotAssignIfSidNotFound)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -450,12 +442,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, FlightPlanEventDoesNotAssignIfAlreadyAssignedOnSameSid)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -506,12 +492,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, FlightPlanEventAssignsIfSidFound)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -561,12 +541,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, FlightPlanEventAcceptsDeprecatedSids)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -616,12 +590,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, FlightPlanEventDoesAssignIfDifferentSid)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -679,12 +647,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, FlightPlanEventDoesAssignAfterDisconnect)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -855,12 +817,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, NewActiveCallsignAssignsIfUserCallsign)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddUserCallsign(userCallsign);
 
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
@@ -923,12 +879,6 @@ namespace UKControllerPluginTest {
 
         TEST_F(InitialHeadingEventHandlerTest, NewActiveCallsignDoesNotAssignIfNotUserCallsign)
         {
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGKK" });
-            ActiveCallsign userCallsign(
-                "LON_S_CTR",
-                "Test",
-                controller
-            );
             callsigns.AddCallsign(userCallsign);
             airfields.AddAirfield(std::unique_ptr<AirfieldModel>(new AirfieldModel("EGKK", { "LON_S_CTR" })));
             owners.RefreshOwner("EGKK");

--- a/test/test/metar/PressureMonitorTest.cpp
+++ b/test/test/metar/PressureMonitorTest.cpp
@@ -31,7 +31,7 @@ namespace UKControllerPluginTest {
             public:
                 PressureMonitorTest()
                     : userSetting(mockUserSettingProvider), messager(mockPlugin), monitor(messager, activeCallsigns),
-                    gatwickTower("EGKK_TWR", 124.22, "TWR", {"EGKK"})
+                      gatwickTower(1, "EGKK_TWR", 124.22, {"EGKK"}, true, false)
                 {
                     this->activeCallsigns.AddUserCallsign(
                         ActiveCallsign(

--- a/test/test/notifications/NotificationTest.cpp
+++ b/test/test/notifications/NotificationTest.cpp
@@ -39,8 +39,8 @@ namespace UKControllerPluginTest {
                     std::chrono::system_clock::now() - std::chrono::hours(1);
                 std::chrono::system_clock::time_point oneHoursTime =
                     std::chrono::system_clock::now() + std::chrono::hours(1);
-                ControllerPosition position = ControllerPosition("EGKK_TWR", 124.220, "TWR", { "EGKK" });
-                ControllerPosition position2 = ControllerPosition("EGKK_APP", 126.820, "APP", { "EGKK" });
+                ControllerPosition position = ControllerPosition(1, "EGKK_TWR", 124.220, {"EGKK"}, true, false);
+                ControllerPosition position2 = ControllerPosition(2, "EGKK_APP", 126.820, {"EGKK"}, true, false);
         };
 
         TEST_F(NotificationTest, ItHasAnId)

--- a/test/test/notifications/NotificationsEventHandlerTest.cpp
+++ b/test/test/notifications/NotificationsEventHandlerTest.cpp
@@ -31,16 +31,20 @@ namespace UKControllerPluginTest {
                 }
 
                 std::shared_ptr<ControllerPosition> controller1 = std::make_shared<ControllerPosition>(
+                    1,
                     "EGLL_N_APP",
                     199.998,
-                    "APP",
-                    topDown
+                    topDown,
+                    true,
+                    false
                 );
                 std::shared_ptr<ControllerPosition> controller2 = std::make_shared<ControllerPosition>(
+                    2,
                     "EGLL_S_TWR",
                     199.998,
-                    "APP",
-                    topDown
+                    topDown,
+                    true,
+                    false
                 );
                 std::vector<std::string> topDown = {"EGLL"};
                 ActiveCallsign callsign = ActiveCallsign("EGLL_S_TWR", "Bobby", *controller1);

--- a/test/test/notifications/NotificationsRepositoryFactoryTest.cpp
+++ b/test/test/notifications/NotificationsRepositoryFactoryTest.cpp
@@ -41,26 +41,32 @@ namespace UKControllerPluginTest {
                     std::vector<std::string> handoffs = { "EGKK" };
 
                     std::unique_ptr<ControllerPosition>position1 = std::make_unique<ControllerPosition>(
+                        1,
                         "EGKK_DEL",
                         121.950,
-                        "DEL",
-                        handoffs
+                        handoffs,
+                        true,
+                        false
                     );
                     this->position1 = position1.get();
 
                     std::unique_ptr<ControllerPosition>position2 = std::make_unique<ControllerPosition>(
+                        2,
                         "EGKK_TWR",
                         124.220,
-                        "TWR",
-                        handoffs
+                        handoffs,
+                        true,
+                        false
                     );
                     this->position2 = position2.get();
 
                     std::unique_ptr<ControllerPosition> position3 = std::make_unique<ControllerPosition>(
+                        3,
                         "EGKK_APP",
                         126.820,
-                        "APP",
-                        handoffs
+                        handoffs,
+                        true,
+                        false
                     );
                     this->position3 = position3.get();
 

--- a/test/test/ownership/AirfieldOwnershipHandlerTest.cpp
+++ b/test/test/ownership/AirfieldOwnershipHandlerTest.cpp
@@ -111,52 +111,54 @@ namespace UKControllerPluginTest {
                     // Add the controllers
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGKK_DEL", 199.998, "DEL", { "EGKK" })
+                            new ControllerPosition(1, "EGKK_DEL", 199.998, {"EGKK"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGKK_TWR", 199.999, "TWR", { "EGKK" })
+                            new ControllerPosition(2, "EGKK_TWR", 199.999, {"EGKK"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGKK_APP", 199.990, "APP", { "EGKK" })
+                            new ControllerPosition(3, "EGKK_APP", 199.990, {"EGKK"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGLL_S_TWR", 199.998, "TWR", { "EGLL" })
+                            new ControllerPosition(4, "EGLL_S_TWR", 199.998, {"EGLL"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
-                            new ControllerPosition("EGLL_N_APP", 199.998, "APP", { "EGLL" })
+                            new ControllerPosition(5, "EGLL_N_APP", 199.998, {"EGLL"}, true, false)
                         )
                     );
                     this->controllerCollection.AddPosition(
                         std::unique_ptr<ControllerPosition>(
                             new ControllerPosition(
+                                6,
                                 "LTC_S_CTR",
                                 134.120,
-                                "CTR",
-                                { "EGLL", "EGKK", "EGLC", "EGKA", "EGKB", "EGMC", "EGMD" }
+                                {"EGLL", "EGKK", "EGLC", "EGKA", "EGKB", "EGMC", "EGMD"},
+                                true,
+                                false
                             )
                         )
                     );
 
                     // Add the active callsigns
                     this->kkTwr = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_TWR", 199.999, "TWR", { "EGKK" })
+                        new ControllerPosition(2, "EGKK_TWR", 199.999, {"EGKK"}, true, false)
                     );
                     this->kkApp = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_APP", 199.990, "APP", { "EGKK" })
+                        new ControllerPosition(3, "EGKK_APP", 199.990, {"EGKK"}, true, false)
                     );
                     this->llTwr = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGLL_S_TWR", 199.998, "TWR", { "EGLL" })
+                        new ControllerPosition(4, "EGLL_S_TWR", 199.998, {"EGLL"}, true, false)
                     );
                     this->llApp = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGLL_N_APP", 199.998, "APP", { "EGLL" })
+                        new ControllerPosition(5, "EGLL_N_APP", 199.998, {"EGLL"}, true, false)
                     );
 
                     this->activeCallsigns.AddCallsign(ActiveCallsign("EGKK_TWR", "Testy McTest", *kkTwr));
@@ -273,7 +275,7 @@ namespace UKControllerPluginTest {
             ActiveCallsignDisconnectResetsOwnerToOtherCallsignIfPositionStillActive
         ) {
             // Add the spare controller
-            ControllerPosition pos("EGKK_TWR", 199.998, "TWR", { "EGKK" });
+            ControllerPosition pos(1, "EGKK_TWR", 199.998, {"EGKK"}, true, false);
             this->activeCallsigns.AddCallsign(ActiveCallsign("EGKK_1_TWR", "Another Guy", pos));
 
             ActiveCallsign gatwick = this->activeCallsigns.GetCallsign("EGKK_TWR");

--- a/test/test/ownership/AirfieldOwnershipManagerTest.cpp
+++ b/test/test/ownership/AirfieldOwnershipManagerTest.cpp
@@ -22,20 +22,24 @@ namespace UKControllerPluginTest {
             public:
 
                 AirfieldOwnershipManagerTest(void)
-                    : manager(this->airfields, this->activeCallsigns)
+                    : controller1(1, "EGGD_TWR", 133.850, {"EGGD"}, true, true),
+                      controller2(2, "EGGD_GND", 121.920, {"EGGD"}, true, true),
+                      manager(this->airfields, this->activeCallsigns)
                 {
 
                 }
 
                 void SetUp()
                 {
-                    std::vector<std::string> topDown = { "EGGD_GND", "EGGD_TWR", "EGGD_APP", "EGFF_APP", "LON_W_CTR" };
-                    this->airfields.AddAirfield(std::make_unique<UKControllerPlugin::Airfield::AirfieldModel>(
+                    std::vector<std::string> topDown = {"EGGD_GND", "EGGD_TWR", "EGGD_GND", "EGFF_APP", "LON_W_CTR"};
+                    this->airfields.AddAirfield(std::make_unique<AirfieldModel>(
                         "EGGD",
                         topDown
                     ));
                 };
 
+                ControllerPosition controller1;
+                ControllerPosition controller2;
                 AirfieldOwnershipManager manager;
                 ActiveCallsignCollection activeCallsigns;
                 AirfieldCollection airfields;
@@ -48,18 +52,16 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, RefreshOwnerSetsOwner)
         {
-            ControllerPosition controller("EGGD_TWR", 133.850, "TWR", { "EGGD" });
-            this->activeCallsigns.AddCallsign(ActiveCallsign("EGGD_TWR", "Testy McTestface", controller));
+            this->activeCallsigns.AddCallsign(ActiveCallsign("EGGD_TWR", "Testy McTestface", controller1));
 
             this->manager.RefreshOwner("EGGD");
 
             EXPECT_TRUE(this->manager.AirfieldHasOwner("EGGD"));
         }
 
-        TEST_F(AirfieldOwnershipManagerTest, RefreshOwnerSetsOwnerToCorrectController)
+        TEST_F(AirfieldOwnershipManagerTest, RefreshOwnerSetsOwnerToCorrectcontroller1)
         {
-            ControllerPosition controller("EGGD_TWR", 133.850, "TWR", { "EGGD" });
-            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller);
+            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller1);
             this->activeCallsigns.AddCallsign(active);
 
             this->manager.RefreshOwner("EGGD");
@@ -69,10 +71,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, RefreshOwnerSetsOwnerWithCorrectPriority)
         {
-            ControllerPosition controller1("EGGD_TWR", 133.850, "TWR", { "EGGD" });
             ActiveCallsign active1("EGGD_TWR", "Testy McTestface", controller1);
-
-            ControllerPosition controller2("EGGD_GND", 121.920, "GND", { "EGGD" });
             ActiveCallsign active2("EGGD_GND", "Testy McTestface 2", controller2);
 
             this->activeCallsigns.AddCallsign(active1);
@@ -87,10 +86,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, RefreshAfterLogOffChangesOwner)
         {
-            ControllerPosition controller1("EGGD_TWR", 133.850, "TWR", { "EGGD" });
             ActiveCallsign active1("EGGD_TWR", "Testy McTestface", controller1);
-
-            ControllerPosition controller2("EGGD_GND", 121.920, "GND", { "EGGD" });
             ActiveCallsign active2("EGGD_GND", "Testy McTestface 2", controller2);
 
             this->activeCallsigns.AddCallsign(active1);
@@ -107,10 +103,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, FlushRemovesAllOwners)
         {
-            ControllerPosition controller1("EGGD_TWR", 133.850, "TWR", { "EGGD" });
             ActiveCallsign active1("EGGD_TWR", "Testy McTestface", controller1);
-
-            ControllerPosition controller2("EGGD_GND", 121.920, "GND", { "EGGD" });
             ActiveCallsign active2("EGGD_GND", "Testy McTestface 2", controller2);
 
             this->activeCallsigns.AddCallsign(active1);
@@ -124,8 +117,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, AirfieldOwnedByUserReturnsTrueIfActiveCallsignIsUser)
         {
-            ControllerPosition controller("EGGD_TWR", 133.850, "TWR", { "EGGD" });
-            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller);
+            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller1);
 
             this->activeCallsigns.AddUserCallsign(active);
 
@@ -136,8 +128,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, AirfieldOwnedByUserReturnsFalseIfActiveCallsignNotUser)
         {
-            ControllerPosition controller("EGGD_TWR", 133.850, "TWR", { "EGGD" });
-            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller);
+            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller1);
 
             this->activeCallsigns.AddCallsign(active);
 
@@ -148,8 +139,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, GetOwnerReturnsOwnerIfFound)
         {
-            ControllerPosition controller("EGGD_TWR", 133.850, "TWR", { "EGGD" });
-            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller);
+            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller1);
             this->activeCallsigns.AddCallsign(active);
 
             this->manager.RefreshOwner("EGGD");
@@ -159,8 +149,7 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, GetOwnerReturnsNoneIfNotFound)
         {
-            ControllerPosition controller("EGGD_TWR", 133.850, "TWR", { "EGGD" });
-            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller);
+            ActiveCallsign active("EGGD_TWR", "Testy McTestface", controller1);
             this->activeCallsigns.AddCallsign(active);
 
             EXPECT_EQ(this->manager.notFoundCallsign, this->manager.GetOwner("EGPF"));
@@ -168,29 +157,25 @@ namespace UKControllerPluginTest {
 
         TEST_F(AirfieldOwnershipManagerTest, GetOwnedReturnsNothingIfNotFound)
         {
-            ControllerPosition controller1("EGGD_TWR", 133.850, "TWR", { "EGGD" });
-            ControllerPosition controller2("EGGD_APP", 133.850, "TWR", { "EGGD" });
             ActiveCallsign active1("EGGD_TWR", "Testy McTestface", controller1);
-            ActiveCallsign active2("EGGD_APP", "Testy McTestface 2", controller2);
+            ActiveCallsign active2("EGGD_GND", "Testy McTestface 2", controller2);
             this->activeCallsigns.AddCallsign(active1);
             this->activeCallsigns.AddCallsign(active2);
             this->manager.RefreshOwner("EGGD");
 
-            EXPECT_EQ(0, this->manager.GetOwnedAirfields("EGGD_APP").size());
+            EXPECT_EQ(0, this->manager.GetOwnedAirfields("EGGD_TWR").size());
         }
 
         TEST_F(AirfieldOwnershipManagerTest, GetOwnedReturnsOwnedAirfields)
         {
-            ControllerPosition controller1("EGGD_TWR", 133.850, "TWR", { "EGGD" });
-            ControllerPosition controller2("EGGD_APP", 133.850, "TWR", { "EGGD" });
             ActiveCallsign active1("EGGD_TWR", "Testy McTestface", controller1);
-            ActiveCallsign active2("EGGD_APP", "Testy McTestface 2", controller2);
+            ActiveCallsign active2("EGGD_GND", "Testy McTestface 2", controller2);
             this->activeCallsigns.AddCallsign(active1);
             this->activeCallsigns.AddCallsign(active2);
             this->manager.RefreshOwner("EGGD");
 
-            EXPECT_EQ(1, this->manager.GetOwnedAirfields("EGGD_TWR").size());
-            EXPECT_TRUE("EGGD" == this->manager.GetOwnedAirfields("EGGD_TWR").begin()->GetIcao());
+            EXPECT_EQ(1, this->manager.GetOwnedAirfields("EGGD_GND").size());
+            EXPECT_TRUE("EGGD" == this->manager.GetOwnedAirfields("EGGD_GND").begin()->GetIcao());
         }
 
         TEST_F(AirfieldOwnershipManagerTest, ItHasANoOwnerObject)

--- a/test/test/prenote/AbstractPrenoteTest.cpp
+++ b/test/test/prenote/AbstractPrenoteTest.cpp
@@ -34,9 +34,9 @@ namespace UKControllerPluginTest {
 
         TEST(AbstractPrenote, GetControllersReturnsControllerHierarchy)
         {
-            ControllerPosition position1("EGKK_DEL", 121.950, "DEL", { "EGKK" });
-            ControllerPosition position2("EGKK_GND", 121.800, "GND", { "EGKK" });
-            ControllerPosition position3("EGKK_TWR", 124.220, "TWR", { "EGKK" });
+            ControllerPosition position1(1, "EGKK_DEL", 121.950, {"EGKK"}, true, false);
+            ControllerPosition position2(2, "EGKK_GND", 121.800, {"EGKK"}, true, false);
+            ControllerPosition position3(3, "EGKK_TWR", 124.220, {"EGKK"}, true, false);
             std::unique_ptr<ControllerPositionHierarchy> hierarchy = std::make_unique<ControllerPositionHierarchy>();
 
             hierarchy->AddPosition(position1);

--- a/test/test/prenote/PrenoteFactoryTest.cpp
+++ b/test/test/prenote/PrenoteFactoryTest.cpp
@@ -28,10 +28,10 @@ namespace UKControllerPluginTest {
                 {
                     this->collection = std::make_unique<ControllerPositionCollection>();
                     this->collection->AddPosition(std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_GND", 121.800, "GND", { "EGKK" }))
+                            new ControllerPosition(1, "EGKK_GND", 121.800, {"EGKK"}, true, false))
                     );
                     this->collection->AddPosition(std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_TWR", 124.220, "TWR", { "EGKK" }))
+                            new ControllerPosition(2, "EGKK_TWR", 124.220, {"EGKK"}, true, false))
                     );
                     this->hierarchyFactory = std::make_unique<ControllerPositionHierarchyFactory>(
                         *this->collection

--- a/test/test/prenote/PrenoteMessageTest.cpp
+++ b/test/test/prenote/PrenoteMessageTest.cpp
@@ -31,7 +31,7 @@ namespace UKControllerPluginTest {
                         new ActiveCallsign(
                             "LTC_SE_CTR",
                             "Testy McTestface",
-                            ControllerPosition("LTC_SE_CTR", 121.225, "CTR", {})
+                            ControllerPosition(1, "LTC_SE_CTR", 121.225, {}, true, false)
                         )
                     );
                     departurePrenote.reset(new DeparturePrenote(NULL, "EGKK", "BIG2X"));

--- a/test/test/prenote/PrenoteModuleTest.cpp
+++ b/test/test/prenote/PrenoteModuleTest.cpp
@@ -32,10 +32,10 @@ namespace UKControllerPluginTest {
                 {
                     container.controllerPositions.reset(new ControllerPositionCollection);
                     container.controllerPositions->AddPosition(std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_GND", 121.800, "GND", { "EGKK" }))
+                            new ControllerPosition(1, "EGKK_GND", 121.800, {"EGKK"}, true, false))
                     );
                     container.controllerPositions->AddPosition(std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_TWR", 124.220, "TWR", { "EGKK" }))
+                            new ControllerPosition(2, "EGKK_TWR", 124.220, {"EGKK"}, true, false))
                     );
                     this->container.flightplanHandler.reset(new FlightPlanEventHandlerCollection);
                     container.userMessager.reset(new UserMessager(this->mockPlugin));

--- a/test/test/prenote/PrenoteServiceFactoryTest.cpp
+++ b/test/test/prenote/PrenoteServiceFactoryTest.cpp
@@ -37,10 +37,10 @@ namespace UKControllerPluginTest {
                 {
                     this->collection = std::make_unique<ControllerPositionCollection>();
                     this->collection->AddPosition(std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_GND", 121.800, "GND", { "EGKK" }))
+                            new ControllerPosition(1, "EGKK_GND", 121.800, {"EGKK"}, true, false))
                     );
                     this->collection->AddPosition(std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_TWR", 124.220, "TWR", { "EGKK" }))
+                            new ControllerPosition(2, "EGKK_TWR", 124.220, {"EGKK"}, true, false))
                     );
                     this->hierarchyFactory = std::make_unique<ControllerPositionHierarchyFactory>(
                         *this->collection

--- a/test/test/prenote/PrenoteServiceTest.cpp
+++ b/test/test/prenote/PrenoteServiceTest.cpp
@@ -76,13 +76,13 @@ namespace UKControllerPluginTest {
 
                     // Add controllers
                     this->controllerUser = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_GND", 121.800, "GND", { "EGKK" })
+                        new ControllerPosition(1, "EGKK_GND", 121.800, {"EGKK"}, true, false)
                     );
                     this->controllerOther = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_APP", 126.820, "APP", { "EGKK" })
+                        new ControllerPosition(2, "EGKK_APP", 126.820, {"EGKK"}, true, false)
                     );
                     this->controllerNoLondon = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("LON_S_CTR", 129.420, "CTR", { "EGKK" })
+                        new ControllerPosition(3, "LON_S_CTR", 129.420, {"EGKK"}, true, false)
                     );
                     this->activeCallsigns.AddUserCallsign(
                         ActiveCallsign(

--- a/test/test/squawk/SquawkAssignmentTest.cpp
+++ b/test/test/squawk/SquawkAssignmentTest.cpp
@@ -42,10 +42,10 @@ namespace UKControllerPluginTest {
         {
             public:
                 SquawkAssignmentTest(void)
-                    : kkApp("EGKK_APP", 126.820, "APP", { "EGKK" }),
-                    lonS("LON_S_CTR", 129.420, "CTR", { "EGLL" }),
-                    airfieldOwnership(this->airfields, this->activeCallsigns),
-                    assignment(this->plans, this->pluginLoopback, this->airfieldOwnership, this->activeCallsigns)
+                    : airfieldOwnership(this->airfields, this->activeCallsigns),
+                      kkApp(1, "EGKK_APP", 126.820, {"EGKK"}, true, false),
+                      lonS(2, "LON_S_CTR", 129.420, { "EGLL" }, true, false),
+                      assignment(this->plans, this->pluginLoopback, this->airfieldOwnership, this->activeCallsigns)
                 {
 
                 };
@@ -339,7 +339,7 @@ namespace UKControllerPluginTest {
                 .WillByDefault(Return(this->assignment.maxAssignmentAltitude + 1));
 
             this->activeCallsigns.Flush();
-            ControllerPosition controller("LON_S_CTR", 129.420, "CTR", { "EGLL" });
+            ControllerPosition controller(55, "LON_S_CTR", 129.420, {"EGLL"}, true, false);
             this->activeCallsigns.AddUserCallsign(
                 ActiveCallsign(
                     "LON_S_CTR",

--- a/test/test/squawk/SquawkEventHandlerTest.cpp
+++ b/test/test/squawk/SquawkEventHandlerTest.cpp
@@ -77,7 +77,7 @@ namespace UKControllerPluginTest {
                 SquawkEventHandlerTest()
                     : apiSquawkAllocations(new ApiSquawkAllocationHandler(this->pluginLoopback)),
                     login(this->pluginLoopback, ControllerStatusEventHandlerCollection()),
-                    controller("EGKK_APP", 126.820, "APP", { "EGKK" }),
+                    controller(1, "EGKK_APP", 126.820, {"EGKK"}, true, false),
                     airfieldOwnership(this->airfields, this->activeCallsigns),
                     assignmentRules(
                         this->plans,

--- a/test/test/squawk/SquawkGeneratorTest.cpp
+++ b/test/test/squawk/SquawkGeneratorTest.cpp
@@ -79,7 +79,7 @@ namespace UKControllerPluginTest {
                     );
 
                     this->controller = std::unique_ptr<ControllerPosition>(
-                        new ControllerPosition("EGKK_APP", 126.820, "APP", { "EGKK" })
+                        new ControllerPosition(1, "EGKK_APP", 126.820, {"EGKK"}, true, false)
                     );
                     this->activeCallsigns.AddUserCallsign(
                         ActiveCallsign(


### PR DESCRIPTION
This reformats the dependency into a nicer format, but also adds the controller position ID - allowing us to use that in departure releases.