### PR TITLE
fix(departure-releases): fix crash when acknowledging departure releases

### DIFF
--- a/src/releases/DepartureReleaseEventHandler.cpp
+++ b/src/releases/DepartureReleaseEventHandler.cpp
@@ -781,7 +781,7 @@ namespace UKControllerPlugin {
 
             // Release has been rejected
             if (context == "Reject") {
-                this->taskRunner.QueueAsynchronousTask([this, &release]()
+                this->taskRunner.QueueAsynchronousTask([this, release]()
                 {
                     try {
                         this->api.RejectDepartureReleaseRequest(
@@ -799,7 +799,7 @@ namespace UKControllerPlugin {
             }
 
             // Release has been acknowledged
-            this->taskRunner.QueueAsynchronousTask([this, &release]()
+            this->taskRunner.QueueAsynchronousTask([this, release]()
             {
                 try {
                     this->api.AcknowledgeDepartureReleaseRequest(


### PR DESCRIPTION
Releases were being accessed by reference, which would go out of scope during the asynchronous task.

fix #289