### PR TITLE
fix(departure-releases): fix colours in the release status view and add documentation

### DIFF
--- a/docs/UserGuide/Features/DepartureReleases.md
+++ b/docs/UserGuide/Features/DepartureReleases.md
@@ -37,6 +37,18 @@ There are two options for viewing the status of releases that you have requested
 and Countdown TAG items described below, or you can use the `Open Departure Release Status View` TAG function to popup
 a temporary display for a given aircrafts releases.
 
+The `Departure Release Status View` displays the callsigns of controllers that have been targeted for release, the time
+until the release becomes active, if the release has been approved and has a conditional released at time, and the time until the release
+approval expires if the release is approved and has an expiry.
+
+The controller callsign indicates the status of the release:
+
+- Green = Approved
+- Red = Rejected
+- Orange = Request has expired and another one should be made
+- Blue = Acknowledged
+- White = Pending
+
 ## How Do I Respond To A Release Request?
 
 If you are the target of a release request, you can use the `Departure Release Decision List` to make decisions on individual

--- a/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj
+++ b/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj
@@ -272,6 +272,7 @@
     <ClInclude Include="..\..\src\releases\ApproveDepartureReleaseDialog.h" />
     <ClInclude Include="..\..\src\releases\CompareDepartureReleases.h" />
     <ClInclude Include="..\..\src\releases\CompareEnrouteReleaseTypes.h" />
+    <ClInclude Include="..\..\src\releases\DepartureReleaseColours.h" />
     <ClInclude Include="..\..\src\releases\DepartureReleaseCountdownColours.h" />
     <ClInclude Include="..\..\src\releases\DepartureReleaseDecisionList.h" />
     <ClInclude Include="..\..\src\releases\DepartureReleaseEventHandler.h" />

--- a/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj.filters
+++ b/msvc/UKControllerPlugin/UKControllerPlugin.vcxproj.filters
@@ -1079,6 +1079,9 @@
     <ClInclude Include="..\..\src\releases\ToggleDepartureReleaseDecisionList.h">
       <Filter>src\releases</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\releases\DepartureReleaseColours.h">
+      <Filter>src\releases</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\resource\UKControllerPlugin.rc">

--- a/src/releases/DepartureReleaseRequestView.cpp
+++ b/src/releases/DepartureReleaseRequestView.cpp
@@ -181,11 +181,11 @@ namespace UKControllerPlugin {
             }
 
             if (request->RequestExpired()) {
-                return statusIndicatorReleaseAcknowledged;
+                return statusIndicatorReleaseExpired;
             }
 
             if (request->Acknowledged()) {
-                return statusIndicatorReleased;
+                return statusIndicatorReleaseAcknowledged;
             }
 
             return statusIndicatorReleasePending;


### PR DESCRIPTION
The colours were a bit mixed up and the User Guide doesnt describe what they mean

fix #291 