### PR TITLE
fix(bootstrap): fix euroscope crash in development mode

### DIFF
--- a/src/plugin/bootstrap/DllInterface.cpp
+++ b/src/plugin/bootstrap/DllInterface.cpp
@@ -1,7 +1,7 @@
 #include "pch/pch.h"
 #include "bootstrap/InitialisePlugin.h"
 #include "update/PluginVersion.h"
-#include "helper/HelperFunctions.h"
+#include "update/CheckDevelopmentVersion.h"
 
 #ifndef UKCP_CORE_API
 #define UKCP_CORE_API extern "C" __declspec(dllexport)
@@ -10,6 +10,7 @@
 
 
 using UKControllerPlugin::Plugin::PluginVersion;
+using UKControllerPluginUtils::Update::IsDevelopmentVersion;
 
 // The one true app to rule them all...
 UKControllerPlugin::InitialisePlugin thePluginApp;
@@ -94,8 +95,7 @@ UKCP_CORE_API const char* GetPluginVersion()
  */
 UKCP_CORE_DIRECT_API void EuroScopePlugInInit(EuroScopePlugIn::CPlugIn** ppPlugInInstance)
 {
-    std::string version(PluginVersion::version);
-    if (version != "#VERSION_STRING#" && version != "non-release-build") {
+    if (!IsDevelopmentVersion(PluginVersion::version)) {
         MessageBox(
             GetActiveWindow(),
             L"Core binary cannot be loaded directly in release versions.",
@@ -113,7 +113,7 @@ UKCP_CORE_DIRECT_API void EuroScopePlugInInit(EuroScopePlugIn::CPlugIn** ppPlugI
  */
 UKCP_CORE_DIRECT_API void EuroScopePlugInExit(void)
 {
-    if (PluginVersion::version != "#VERSION_STRING#" && PluginVersion::version != "non-release-build") {
+    if (!IsDevelopmentVersion(PluginVersion::version)) {
         return;
     }
 

--- a/src/plugin/bootstrap/InitialisePlugin.cpp
+++ b/src/plugin/bootstrap/InitialisePlugin.cpp
@@ -81,27 +81,10 @@ using UKControllerPlugin::Dependency::DependencyLoader;
 
 namespace UKControllerPlugin {
     /*
-        Creates a dummy plugin to fill the spot.
-    */
-    void InitialisePlugin::CreateDummy(void)
-    {
-        this->fallbackPlugin = std::unique_ptr<EuroScopePlugIn::CPlugIn>(
-            new EuroScopePlugIn::CPlugIn(
-                EuroScopePlugIn::COMPATIBILITY_CODE,
-                "UK Controller Plugin (Disabled)",
-                "XXX",
-                "VATSIM UK",
-                "VATSIM United Kingdom Division"
-            )
-        );
-    }
-
-    /*
         Clean up after ourself as we get closed down.
     */
     void InitialisePlugin::EuroScopeCleanup(void)
     {
-        // Shut down the container, task runner and logs.
         this->container->taskRunner.reset();
         this->container.reset();
         this->duplicatePlugin.reset();

--- a/src/plugin/bootstrap/InitialisePlugin.h
+++ b/src/plugin/bootstrap/InitialisePlugin.h
@@ -27,9 +27,6 @@ namespace UKControllerPlugin {
 
         private:
 
-            void CreateDummy(void);
-
-
             // In the event of an invalid version, this is the "dummy" fallback plugin.
             std::unique_ptr<EuroScopePlugIn::CPlugIn> fallbackPlugin;
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -125,6 +125,7 @@ set(srd
 source_group("srd" FILES ${srd})
 
 set(update
+    "update/CheckDevelopmentVersion.cpp"
     "update/LoadChangelog.cpp"
     "update/LoadChangelog.h"
     "update/PluginVersion.cpp"

--- a/src/utils/update/CheckDevelopmentVersion.cpp
+++ b/src/utils/update/CheckDevelopmentVersion.cpp
@@ -1,0 +1,17 @@
+#include "pch/pch.h"
+#include "update/CheckDevelopmentVersion.h"
+
+const std::string NO_VERSION_SPECIFIED = "#VERSION_STRING#";
+const std::string NON_RELEASE_BUILD = "non-release-build";
+
+namespace UKControllerPluginUtils::Update {
+    bool IsDevelopmentVersion(std::string version)
+    {
+        return version == NO_VERSION_SPECIFIED || version == NON_RELEASE_BUILD;
+    }
+
+    bool IsDevelopmentVersion(const char* version)
+    {
+        return IsDevelopmentVersion(std::string(version));
+    }
+} // namespace UKControllerPluginUtils::Update

--- a/src/utils/update/CheckDevelopmentVersion.h
+++ b/src/utils/update/CheckDevelopmentVersion.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace UKControllerPluginUtils::Update {
+    bool IsDevelopmentVersion(const char* version);
+    bool IsDevelopmentVersion(std::string version);
+} // namespace UKControllerPluginUtils::Update

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -65,6 +65,7 @@ source_group("test\\squawk" FILES ${test__squawk})
 
 set(test__update
     "update/UpdateBinariesTest.cpp"
+    "update/CheckDevelopmentVersionTest.cpp"
 )
 source_group("test\\update" FILES ${test__update})
 

--- a/test/utils/update/CheckDevelopmentVersionTest.cpp
+++ b/test/utils/update/CheckDevelopmentVersionTest.cpp
@@ -1,0 +1,35 @@
+#include "pch/pch.h"
+#include "update/CheckDevelopmentVersion.h"
+
+using testing::Test;
+using UKControllerPluginUtils::Update::IsDevelopmentVersion;
+
+namespace UKControllerPluginUtilsTest::Update {
+    class CheckDevelopmentVersionTest: public Test
+    {};
+
+    TEST_F(CheckDevelopmentVersionTest, IsDevelopmentIfVersionUnspecified)
+    {
+        EXPECT_TRUE(IsDevelopmentVersion("#VERSION_STRING#"));
+    }
+
+    TEST_F(CheckDevelopmentVersionTest, IsDevelopmentIfVersionNonRelease)
+    {
+        EXPECT_TRUE(IsDevelopmentVersion("non-release-build"));
+    }
+
+    TEST_F(CheckDevelopmentVersionTest, IsNotDevelopmentOnRelease)
+    {
+        EXPECT_FALSE(IsDevelopmentVersion("1.5.0-"));
+    }
+
+    TEST_F(CheckDevelopmentVersionTest, IsNotDevelopmentOnBetaRelease)
+    {
+        EXPECT_FALSE(IsDevelopmentVersion("1.6.0-beta1"));
+    }
+
+    TEST_F(CheckDevelopmentVersionTest, DevelopmentVersionsAreCheckedForStrings)
+    {
+        EXPECT_TRUE(IsDevelopmentVersion(std::string("#VERSION_STRING#")));
+    }
+} // namespace UKControllerPluginUtilsTest::Update


### PR DESCRIPTION
It was crashing when you shutdown the plugin if the core binary is loaded directly

fix #317