### PR TITLE
fix(srd): only prepopulate SRD destination for EG and EI airfields

### DIFF
--- a/src/plugin/srd/SrdSearchDialog.cpp
+++ b/src/plugin/srd/SrdSearchDialog.cpp
@@ -374,8 +374,11 @@ namespace UKControllerPlugin {
             std::wstring wideOrigin = HelperFunctions::ConvertToWideString(defaultValues->origin);
             SetDlgItemText(hwnd, IDC_SRD_ORIGIN, wideOrigin.c_str());
 
-            std::wstring wideDestination = HelperFunctions::ConvertToWideString(defaultValues->destination);
-            SetDlgItemText(hwnd, IDC_SRD_DESTINATION, wideDestination.c_str());
+            auto destination = defaultValues->destination;
+            if (destination.size() >= 2 && (destination.substr(0, 2) == "EG" || destination.substr(0, 2) == "EI")) {
+                std::wstring wideDestination = HelperFunctions::ConvertToWideString(destination);
+                SetDlgItemText(hwnd, IDC_SRD_DESTINATION, wideDestination.c_str());
+            }
 
             std::wstring wideCruise = std::to_wstring(defaultValues->requestedLevel);
             SetDlgItemText(hwnd, IDC_SRD_CRUISE, wideCruise.c_str());


### PR DESCRIPTION
The SRD only goes up to the FIR boundary / some EI airfields.

If the airfield is outside the FIR/EI, don't prepopulate the destination airfield.

fix #380