### PR TITLE
chore(versions): Have a beta branch to put breaking features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
   release:
     name: Release
     runs-on: windows-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
     needs: [build, format]
     concurrency:
       group: ukcp-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
   release:
     name: Release
     runs-on: windows-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/alpha')
     needs: [build, format]
     concurrency:
       group: ukcp-release

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "repositoryUrl": "https://github.com/VATSIM-UK/uk-controller-plugin",
     "branches": [
       "main",
-      {"name": "beta", "prerelease": true}
+      {"name": "beta", "prerelease": true},
+      {"name": "alpha", "prerelease": true}
     ],
     "tagFormat": "${version}",
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "release": {
     "repositoryUrl": "https://github.com/VATSIM-UK/uk-controller-plugin",
     "branches": [
-      "main"
+      "main",
+      {"name": "beta", "prerelease": true}
     ],
     "tagFormat": "${version}",
     "plugins": [


### PR DESCRIPTION
Some BC-breaking features coming up and moving forward, we may want to have the option to release experimental features early and to coordinate with ops for the controller pack. This adds the beta branch for semantic release purposes.