### PR TITLE
fix(push-events): data not synchronising on second instance startup

### DIFF
--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -667,7 +667,7 @@ set(src__push
     "push/PushEventProxyWindow.h"
     "push/PushEventSubscription.cpp"
     "push/PushEventSubscription.h"
-        push/PushEvent.cpp push/PushEventConnectionInterface.cpp)
+        push/PushEvent.cpp push/PushEventConnectionInterface.cpp push/ProxyPushDataSync.cpp push/ProxyPushDataSync.h)
 source_group("src\\push" FILES ${src__push})
 
 set(src__radarscreen

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -667,7 +667,9 @@ set(src__push
     "push/PushEventProxyWindow.h"
     "push/PushEventSubscription.cpp"
     "push/PushEventSubscription.h"
-        push/PushEvent.cpp push/PushEventConnectionInterface.cpp push/ProxyPushDataSync.cpp push/ProxyPushDataSync.h)
+    push/PushEvent.cpp
+    push/PushEventConnectionInterface.cpp
+    push/ProxyPushDataSync.cpp push/ProxyPushDataSync.h)
 source_group("src\\push" FILES ${src__push})
 
 set(src__radarscreen

--- a/src/plugin/push/ProxyPushDataSync.cpp
+++ b/src/plugin/push/ProxyPushDataSync.cpp
@@ -1,0 +1,21 @@
+#include "ProxyPushDataSync.h"
+#include "PushEventProcessorCollection.h"
+
+namespace UKControllerPlugin::Push {
+
+    ProxyPushDataSync::ProxyPushDataSync(const PushEventProcessorCollection& processors)
+        : processors(processors), synced(false)
+    {
+    }
+
+    void ProxyPushDataSync::TimedEventTrigger()
+    {
+        if (synced) {
+            return;
+        }
+
+        LogInfo("Syncing proxy push event data");
+        processors.PluginEventsSynced();
+        synced = true;
+    }
+} // namespace UKControllerPlugin::Push

--- a/src/plugin/push/ProxyPushDataSync.h
+++ b/src/plugin/push/ProxyPushDataSync.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "timedevent/AbstractTimedEvent.h"
+
+namespace UKControllerPlugin::Push {
+    class PushEventProcessorCollection;
+
+    /*
+     * When proxy connections are created, we need to make sure their data is synced (more or less)
+     * with the API. This handler triggers on a timer once ES is loaded (so we know all the handlers are registered)
+     * and triggers their synced event.
+     */
+    class ProxyPushDataSync : public TimedEvent::AbstractTimedEvent
+    {
+        public:
+        ProxyPushDataSync(const PushEventProcessorCollection& processors);
+        void TimedEventTrigger() override;
+
+        private:
+        // All the push event processors
+        const PushEventProcessorCollection& processors;
+
+        // Has the sync been done
+        bool synced;
+    };
+} // namespace UKControllerPlugin::Push

--- a/src/plugin/push/PushEventBootstrap.cpp
+++ b/src/plugin/push/PushEventBootstrap.cpp
@@ -1,4 +1,5 @@
 #include "PollingPushEventConnection.h"
+#include "ProxyPushDataSync.h"
 #include "PushEventBootstrap.h"
 #include "PushEventProtocolHandler.h"
 #include "PushEventProxyConnection.h"
@@ -22,6 +23,8 @@ namespace UKControllerPlugin::Push {
         // Create a websocket connection depending on whether we're the main plugin
         if (duplicatePlugin) {
             pushEvents = std::make_shared<PushEventProxyConnection>();
+            container.timedHandler->RegisterEvent(
+                std::make_shared<ProxyPushDataSync>(*container.pushEventProcessors), 5);
         } else {
             const auto pollingEvents = std::make_shared<PollingPushEventConnection>(
                 *container.api, *container.taskRunner, *container.pushEventProcessors);

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -401,7 +401,7 @@ set(test__push
     "push/PushEventProtocolHandlerTest.cpp"
     "push/PushEventProxyConnetionTest.cpp"
     "push/PushEventProxyHandlerTest.cpp"
-)
+        push/ProxyPushDataSyncTest.cpp)
 source_group("test\\push" FILES ${test__push})
 
 set(test__radarscreen

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -401,7 +401,7 @@ set(test__push
     "push/PushEventProtocolHandlerTest.cpp"
     "push/PushEventProxyConnetionTest.cpp"
     "push/PushEventProxyHandlerTest.cpp"
-        push/ProxyPushDataSyncTest.cpp)
+    push/ProxyPushDataSyncTest.cpp)
 source_group("test\\push" FILES ${test__push})
 
 set(test__radarscreen

--- a/test/plugin/push/ProxyPushDataSyncTest.cpp
+++ b/test/plugin/push/ProxyPushDataSyncTest.cpp
@@ -1,0 +1,41 @@
+#include "push/ProxyPushDataSync.h"
+#include "push/PushEventProcessorCollection.h"
+#include "push/PushEventSubscription.h"
+
+using testing::NiceMock;
+using testing::Test;
+using UKControllerPlugin::Push::ProxyPushDataSync;
+using UKControllerPlugin::Push::PushEventProcessorCollection;
+using UKControllerPlugin::Push::PushEventSubscription;
+
+namespace UKControllerPluginTest::Push {
+
+    class ProxyPushDataSyncTest : public Test
+    {
+        public:
+        ProxyPushDataSyncTest() : eventProcessor(std::make_shared<NiceMock<MockPushEventProcessor>>()), sync(collection)
+        {
+            this->collection.AddProcessor(this->eventProcessor);
+        }
+
+        PushEventProcessorCollection collection;
+        std::shared_ptr<NiceMock<MockPushEventProcessor>> eventProcessor;
+        ProxyPushDataSync sync;
+    };
+
+    TEST_F(ProxyPushDataSyncTest, ItSyncsProxyDataOnFirstTimedEvent)
+    {
+        EXPECT_CALL(*this->eventProcessor, PluginEventsSynced).Times(1);
+
+        sync.TimedEventTrigger();
+    }
+
+    TEST_F(ProxyPushDataSyncTest, ItDoesntSyncOnSubsequentTimedEvents)
+    {
+        EXPECT_CALL(*this->eventProcessor, PluginEventsSynced).Times(1);
+
+        sync.TimedEventTrigger();
+        sync.TimedEventTrigger();
+        sync.TimedEventTrigger();
+    }
+} // namespace UKControllerPluginTest::Push

--- a/test/plugin/push/PushEventBootstrapTest.cpp
+++ b/test/plugin/push/PushEventBootstrapTest.cpp
@@ -2,7 +2,6 @@
 #include "push/PushEventBootstrap.h"
 #include "push/PushEventProcessorCollection.h"
 #include "timedevent/TimedEventCollection.h"
-#include "memory"
 
 using testing::Test;
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
@@ -44,8 +43,13 @@ namespace UKControllerPluginTest::Push {
     TEST_F(PushEventBootstrapTest, ItSetsUpProtocolHandlerForTimedEventsOnDuplicatePlugin)
     {
         BootstrapPlugin(this->container, true);
-        EXPECT_EQ(1, this->container.timedHandler->CountHandlers());
         EXPECT_EQ(1, this->container.timedHandler->CountHandlersForFrequency(1));
+    }
+
+    TEST_F(PushEventBootstrapTest, ItSetsUpProxySyncOnDuplicatePlugin)
+    {
+        BootstrapPlugin(this->container, true);
+        EXPECT_EQ(1, this->container.timedHandler->CountHandlersForFrequency(5));
     }
 
     TEST_F(PushEventBootstrapTest, ItSetsUpProxyHandlerForPushEventsOnNonDuplicatePlugin)


### PR DESCRIPTION
Until now, some push events (stands etc) were not syncing up when a second
instance of EuroScope was started. This fixes the synchronisation.

Fix #399