### PR TITLE
feat(sid): Allow duplicate SID identifiers when doing initial altitudes

### DIFF
--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -743,7 +743,7 @@ set(src__releases
 source_group("src\\releases" FILES ${src__releases})
 
 set(src__runway
-        runway/Runway.cpp runway/Runway.h runway/RunwayCollection.cpp runway/RunwayCollection.h)
+        runway/Runway.cpp runway/Runway.h runway/RunwayCollection.cpp runway/RunwayCollection.h runway/RunwayCollectionFactory.cpp runway/RunwayCollectionFactory.h runway/RunwayModule.cpp runway/RunwayModule.h)
 source_group("src\\runway" FILES ${src__runway})
 
 set(src__sectorfile

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -743,7 +743,10 @@ set(src__releases
 source_group("src\\releases" FILES ${src__releases})
 
 set(src__runway
-        runway/Runway.cpp runway/Runway.h runway/RunwayCollection.cpp runway/RunwayCollection.h runway/RunwayCollectionFactory.cpp runway/RunwayCollectionFactory.h runway/RunwayModule.cpp runway/RunwayModule.h)
+        runway/Runway.cpp runway/Runway.h
+        runway/RunwayCollection.cpp runway/RunwayCollection.h
+        runway/RunwayCollectionFactory.cpp runway/RunwayCollectionFactory.h
+        runway/RunwayModule.cpp runway/RunwayModule.h)
 source_group("src\\runway" FILES ${src__runway})
 
 set(src__sectorfile
@@ -773,7 +776,8 @@ set(src__sid
     "sid/SidModule.h"
     "sid/StandardInstrumentDeparture.cpp"
     "sid/StandardInstrumentDeparture.h"
-        sid/FlightplanSidMapper.cpp sid/FlightplanSidMapper.h sid/SidMapperInterface.h)
+    sid/FlightplanSidMapper.cpp sid/FlightplanSidMapper.h
+    sid/SidMapperInterface.h)
 source_group("src\\sid" FILES ${src__sid})
 
 set(src__squawk

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -743,7 +743,7 @@ set(src__releases
 source_group("src\\releases" FILES ${src__releases})
 
 set(src__runway
-        runway/Runway.cpp runway/Runway.h)
+        runway/Runway.cpp runway/Runway.h runway/RunwayCollection.cpp runway/RunwayCollection.h)
 source_group("src\\runway" FILES ${src__runway})
 
 set(src__sectorfile

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -742,6 +742,10 @@ set(src__releases
         releases/EnrouteRelease.cpp releases/EnrouteReleaseType.cpp releases/RejectDepartureReleaseDialog.cpp releases/RejectDepartureReleaseDialog.h releases/ReleaseApprovalRemarksUserMessage.cpp releases/ReleaseApprovalRemarksUserMessage.h releases/ReleaseRejectionRemarksUserMessage.cpp releases/ReleaseRejectionRemarksUserMessage.h)
 source_group("src\\releases" FILES ${src__releases})
 
+set(src__runway
+        runway/Runway.cpp runway/Runway.h)
+source_group("src\\runway" FILES ${src__runway})
+
 set(src__sectorfile
     "sectorfile/Runway.cpp"
     "sectorfile/Runway.h"
@@ -900,6 +904,7 @@ set(ALL_FILES
     ${src__radarscreen}
     ${src__regional}
     ${src__releases}
+    ${src__runway}
     ${src__sectorfile}
     ${src__selcal}
     ${src__sid}

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -773,7 +773,7 @@ set(src__sid
     "sid/SidModule.h"
     "sid/StandardInstrumentDeparture.cpp"
     "sid/StandardInstrumentDeparture.h"
-)
+        sid/FlightplanSidMapper.cpp sid/FlightplanSidMapper.h sid/SidMapperInterface.h)
 source_group("src\\sid" FILES ${src__sid})
 
 set(src__squawk

--- a/src/plugin/bootstrap/InitialisePlugin.cpp
+++ b/src/plugin/bootstrap/InitialisePlugin.cpp
@@ -43,6 +43,7 @@
 #include "push/PushEventBootstrap.h"
 #include "regional/RegionalPressureModule.h"
 #include "releases/ReleaseModule.h"
+#include "runway/RunwayModule.h"
 #include "sectorfile/SectorFileBootstrap.h"
 #include "selcal/SelcalModule.h"
 #include "sid/SidModule.h"
@@ -187,6 +188,7 @@ namespace UKControllerPlugin {
         // Boostrap all the modules at a plugin level
         Controller::BootstrapPlugin(*this->container, loader);
         Airfield::BootstrapPlugin(*this->container, loader);
+        Runway::BootstrapPlugin(*this->container, loader);
         CollectionBootstrap::BootstrapPlugin(*this->container, loader);
         FlightplanStorageBootstrap::BootstrapPlugin(*this->container);
         FlightRules::BootstrapPlugin(*this->container, loader);

--- a/src/plugin/bootstrap/PersistenceContainer.cpp
+++ b/src/plugin/bootstrap/PersistenceContainer.cpp
@@ -49,6 +49,7 @@
 #include "sectorfile/RunwayCollection.h"
 #include "setting/SettingRepository.h"
 #include "sid/SidCollection.h"
+#include "sid/SidMapperInterface.h"
 #include "squawk/SquawkAssignment.h"
 #include "squawk/SquawkEventHandler.h"
 #include "squawk/SquawkGenerator.h"

--- a/src/plugin/bootstrap/PersistenceContainer.cpp
+++ b/src/plugin/bootstrap/PersistenceContainer.cpp
@@ -45,6 +45,7 @@
 #include "radarscreen/RadarScreenFactory.h"
 #include "radarscreen/ScreenControls.h"
 #include "regional/RegionalPressureManager.h"
+#include "runway/RunwayCollection.h"
 #include "sectorfile/RunwayCollection.h"
 #include "setting/SettingRepository.h"
 #include "sid/SidCollection.h"

--- a/src/plugin/bootstrap/PersistenceContainer.h
+++ b/src/plugin/bootstrap/PersistenceContainer.h
@@ -112,6 +112,7 @@ namespace UKControllerPlugin {
     } // namespace Setting
     namespace Sid {
         class SidCollection;
+        class SidMapperInterface;
     } // namespace Sid
     namespace Squawk {
         class SquawkAssignment;
@@ -209,6 +210,7 @@ namespace UKControllerPlugin::Bootstrap {
 
         // Large collections that we don't want to go onto the stack
         std::unique_ptr<Sid::SidCollection> sids;
+        std::unique_ptr<Sid::SidMapperInterface> sidMapper;
         std::unique_ptr<const UKControllerPlugin::Airfield::AirfieldCollection> airfields;
         std::shared_ptr<UKControllerPlugin::Ownership::AirfieldServiceProviderCollection> airfieldOwnership;
         std::unique_ptr<UKControllerPlugin::Controller::ControllerPositionCollection> controllerPositions;

--- a/src/plugin/bootstrap/PersistenceContainer.h
+++ b/src/plugin/bootstrap/PersistenceContainer.h
@@ -101,6 +101,9 @@ namespace UKControllerPlugin {
     namespace Releases {
         class DepartureReleaseEventHandler;
     } // namespace Releases
+    namespace Runway {
+        class RunwayCollection;
+    } // namespace Runway
     namespace SectorFile {
         class RunwayCollection;
     } // namespace SectorFile
@@ -217,6 +220,7 @@ namespace UKControllerPlugin::Bootstrap {
         std::shared_ptr<UKControllerPlugin::Navaids::NavaidCollection> navaids;
         std::shared_ptr<UKControllerPlugin::Hold::PublishedHoldCollection> publishedHolds;
         std::unique_ptr<UKControllerPlugin::FlightRules::FlightRuleCollection> flightRules;
+        std::unique_ptr<UKControllerPlugin::Runway::RunwayCollection> runwayCollection;
 
         // Push events
         std::shared_ptr<Push::PushEventProcessorCollection> pushEventProcessors;

--- a/src/plugin/euroscope/EuroScopeCFlightPlanInterface.h
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanInterface.h
@@ -43,5 +43,6 @@ namespace UKControllerPlugin::Euroscope {
         [[nodiscard]] virtual bool IsVfr() const = 0;
         [[nodiscard]] virtual EuroScopePlugIn::CFlightPlan GetEuroScopeObject() const = 0;
         [[nodiscard]] virtual auto GetRemarks() const -> std::string = 0;
+        [[nodiscard]] virtual auto GetDepartureRunway() const -> std::string = 0;
     };
 } // namespace UKControllerPlugin::Euroscope

--- a/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.cpp
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.cpp
@@ -194,4 +194,9 @@ namespace UKControllerPlugin::Euroscope {
     {
         return this->originalData.GetFlightPlanData().GetRemarks();
     }
+
+    std::string EuroScopeCFlightPlanWrapper::GetDepartureRunway() const
+    {
+        return this->originalData.GetFlightPlanData().GetDepartureRwy();
+    }
 } // namespace UKControllerPlugin::Euroscope

--- a/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.h
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.h
@@ -29,6 +29,7 @@ namespace UKControllerPlugin::Euroscope {
         std::string GetOrigin() const override;
         std::string GetRawRouteString() const override;
         std::string GetSidName() const override;
+        std::string GetDepartureRunway() const override;
         bool HasAssignedSquawk() const override;
         bool HasControllerClearedAltitude() const override;
         bool HasControllerAssignedHeading() const override;

--- a/src/plugin/handoff/FlightplanSidHandoffMapper.cpp
+++ b/src/plugin/handoff/FlightplanSidHandoffMapper.cpp
@@ -1,21 +1,20 @@
 #include "FlightplanSidHandoffMapper.h"
 #include "HandoffCollection.h"
-#include "sid/SidCollection.h"
+#include "sid/SidMapperInterface.h"
 #include "sid/StandardInstrumentDeparture.h"
 
 namespace UKControllerPlugin::Handoff {
 
     FlightplanSidHandoffMapper::FlightplanSidHandoffMapper(
-        const HandoffCollection& handoffs, const Sid::SidCollection& sids)
-        : handoffs(handoffs), sids(sids)
+        const HandoffCollection& handoffs, const Sid::SidMapperInterface& sidMapper)
+        : handoffs(handoffs), sidMapper(sidMapper)
     {
     }
 
     auto FlightplanSidHandoffMapper::MapForFlightplan(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
         -> std::shared_ptr<HandoffOrder>
     {
-        const auto sid = this->sids.GetForFlightplan(flightplan);
-
+        const auto sid = this->sidMapper.MapFlightplanToSid(flightplan);
         if (!sid || !sid->HasHandoff()) {
             return nullptr;
         }

--- a/src/plugin/handoff/FlightplanSidHandoffMapper.h
+++ b/src/plugin/handoff/FlightplanSidHandoffMapper.h
@@ -5,7 +5,7 @@ namespace UKControllerPlugin {
         class EuroScopeCFlightPlanInterface;
     } // namespace Euroscope
     namespace Sid {
-        class SidCollection;
+        class SidMapperInterface;
     } // namespace Sid
 } // namespace UKControllerPlugin
 
@@ -20,7 +20,7 @@ namespace UKControllerPlugin::Handoff {
     class FlightplanSidHandoffMapper
     {
         public:
-        FlightplanSidHandoffMapper(const HandoffCollection& handoffs, const Sid::SidCollection& sids);
+        FlightplanSidHandoffMapper(const HandoffCollection& handoffs, const Sid::SidMapperInterface& sidMapper);
 
         [[nodiscard]] auto MapForFlightplan(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
             -> std::shared_ptr<HandoffOrder>;
@@ -30,6 +30,6 @@ namespace UKControllerPlugin::Handoff {
         const HandoffCollection& handoffs;
 
         // All the sids
-        const Sid::SidCollection& sids;
+        const Sid::SidMapperInterface& sidMapper;
     };
 } // namespace UKControllerPlugin::Handoff

--- a/src/plugin/handoff/HandoffModule.cpp
+++ b/src/plugin/handoff/HandoffModule.cpp
@@ -28,7 +28,7 @@ namespace UKControllerPlugin::Handoff {
             *container.controllerHierarchyFactory,
             dependency.LoadDependency(GetHandoffDependencyKey(), nlohmann::json::array()));
         airfieldMapper = std::make_shared<FlightplanAirfieldHandoffMapper>(*handoffs, *container.airfields);
-        sidMapper = std::make_shared<FlightplanSidHandoffMapper>(*handoffs, *container.sids);
+        sidMapper = std::make_shared<FlightplanSidHandoffMapper>(*handoffs, *container.sidMapper);
 
         std::shared_ptr<HandoffEventHandler> handler = std::make_shared<HandoffEventHandler>(
             std::make_shared<DepartureHandoffResolver>(*sidMapper, *airfieldMapper, *container.activeCallsigns),

--- a/src/plugin/initialaltitude/InitialAltitudeEventHandler.h
+++ b/src/plugin/initialaltitude/InitialAltitudeEventHandler.h
@@ -19,8 +19,7 @@ namespace UKControllerPlugin {
         class Login;
     } // namespace Controller
     namespace Sid {
-        class SidCollection;
-        class StandardInstrumentDeparture;
+        class SidMapperInterface;
     } // namespace Sid
     namespace Euroscope {
         class EuroscopePluginLoopbackInterface;
@@ -39,7 +38,7 @@ namespace UKControllerPlugin::InitialAltitude {
     {
         public:
         InitialAltitudeEventHandler(
-            const Sid::SidCollection& sids,
+            const Sid::SidMapperInterface& sidMapper,
             const Controller::ActiveCallsignCollection& activeCallsigns,
             const Ownership::AirfieldServiceProviderCollection& airfieldOwnership,
             const Controller::Login& login,
@@ -72,11 +71,8 @@ namespace UKControllerPlugin::InitialAltitude {
             Euroscope::EuroScopeCFlightPlanInterface& flightplan,
             Euroscope::EuroScopeCRadarTargetInterface& radarTarget) -> bool;
 
-        auto GetSidForFlight(Euroscope::EuroScopeCFlightPlanInterface& flightplan)
-            -> std::shared_ptr<Sid::StandardInstrumentDeparture>;
-
         // Used to generate initial altitudes.
-        const Sid::SidCollection& sids;
+        const Sid::SidMapperInterface& sidMapper;
 
         // Used to find out the users callsign.
         const Controller::ActiveCallsignCollection& activeCallsigns;

--- a/src/plugin/initialaltitude/InitialAltitudeModule.cpp
+++ b/src/plugin/initialaltitude/InitialAltitudeModule.cpp
@@ -24,7 +24,7 @@ namespace UKControllerPlugin::InitialAltitude {
     void InitialAltitudeModule::BootstrapPlugin(PersistenceContainer& persistence)
     {
         std::shared_ptr<InitialAltitudeEventHandler> initialAltitudeEventHandler(new InitialAltitudeEventHandler(
-            *persistence.sids,
+            *persistence.sidMapper,
             *persistence.activeCallsigns,
             *persistence.airfieldOwnership,
             *persistence.login,

--- a/src/plugin/initialheading/InitialHeadingEventHandler.h
+++ b/src/plugin/initialheading/InitialHeadingEventHandler.h
@@ -19,8 +19,7 @@ namespace UKControllerPlugin {
         class Login;
     } // namespace Controller
     namespace Sid {
-        class SidCollection;
-        class StandardInstrumentDeparture;
+        class SidMapperInterface;
     } // namespace Sid
     namespace Euroscope {
         class EuroscopePluginLoopbackInterface;
@@ -39,7 +38,7 @@ namespace UKControllerPlugin::InitialHeading {
     {
         public:
         InitialHeadingEventHandler(
-            const Sid::SidCollection& sids,
+            const Sid::SidMapperInterface& sidMapper,
             const Controller::ActiveCallsignCollection& activeCallsigns,
             const Ownership::AirfieldServiceProviderCollection& airfieldOwnership,
             const Controller::Login& login,
@@ -72,11 +71,8 @@ namespace UKControllerPlugin::InitialHeading {
             Euroscope::EuroScopeCFlightPlanInterface& flightplan,
             Euroscope::EuroScopeCRadarTargetInterface& radarTarget) -> bool;
 
-        auto GetSidForFlight(Euroscope::EuroScopeCFlightPlanInterface& flightplan)
-            -> std::shared_ptr<Sid::StandardInstrumentDeparture>;
-
         // Used to generate initial headings.
-        const Sid::SidCollection& sids;
+        const Sid::SidMapperInterface& sidMapper;
 
         // Used to find out the users callsign.
         const Controller::ActiveCallsignCollection& activeCallsigns;

--- a/src/plugin/initialheading/InitialHeadingModule.cpp
+++ b/src/plugin/initialheading/InitialHeadingModule.cpp
@@ -27,7 +27,7 @@ namespace UKControllerPlugin::InitialHeading {
     void BootstrapPlugin(PersistenceContainer& persistence)
     {
         std::shared_ptr<InitialHeadingEventHandler> handler(new InitialHeadingEventHandler(
-            *persistence.sids,
+            *persistence.sidMapper,
             *persistence.activeCallsigns,
             *persistence.airfieldOwnership,
             *persistence.login,

--- a/src/plugin/prenote/PrenoteModule.cpp
+++ b/src/plugin/prenote/PrenoteModule.cpp
@@ -71,7 +71,7 @@ namespace UKControllerPlugin::Prenote {
             *persistence.controllerHierarchyFactory);
 
         mapper = std::make_unique<PublishedPrenoteMapper>(
-            *prenotes, *persistence.airfields, *persistence.sids, *persistence.flightRules);
+            *prenotes, *persistence.airfields, *persistence.sidMapper, *persistence.flightRules);
 
         ControllerPositionHierarchyFactory hierarchyFactory(*persistence.controllerPositions);
 

--- a/src/plugin/prenote/PublishedPrenoteMapper.cpp
+++ b/src/plugin/prenote/PublishedPrenoteMapper.cpp
@@ -7,7 +7,7 @@
 #include "euroscope/EuroScopeCFlightPlanInterface.h"
 #include "flightrule/FlightRule.h"
 #include "flightrule/FlightRuleCollection.h"
-#include "sid/SidCollection.h"
+#include "sid/SidMapperInterface.h"
 #include "sid/StandardInstrumentDeparture.h"
 
 using UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface;
@@ -16,9 +16,9 @@ namespace UKControllerPlugin::Prenote {
     PublishedPrenoteMapper::PublishedPrenoteMapper(
         const PublishedPrenoteCollection& publishedPrenotes,
         const Airfield::AirfieldCollection& airfields,
-        const Sid::SidCollection& sids,
+        const Sid::SidMapperInterface& sidMapper,
         const FlightRules::FlightRuleCollection& flightRules)
-        : publishedPrenotes(publishedPrenotes), airfields(airfields), sids(sids), flightRules(flightRules)
+        : publishedPrenotes(publishedPrenotes), airfields(airfields), sidMapper(sidMapper), flightRules(flightRules)
     {
     }
 
@@ -64,7 +64,7 @@ namespace UKControllerPlugin::Prenote {
     void PublishedPrenoteMapper::MapSidPrenotes(
         const EuroScopeCFlightPlanInterface& flightplan, std::set<std::shared_ptr<PublishedPrenote>>& prenotes) const
     {
-        const auto sid = this->sids.GetForFlightplan(flightplan);
+        const auto sid = this->sidMapper.MapFlightplanToSid(flightplan);
         if (sid == nullptr) {
             return;
         }

--- a/src/plugin/prenote/PublishedPrenoteMapper.h
+++ b/src/plugin/prenote/PublishedPrenoteMapper.h
@@ -11,7 +11,7 @@ namespace UKControllerPlugin {
         class FlightRuleCollection;
     } // namespace FlightRules
     namespace Sid {
-        class SidCollection;
+        class SidMapperInterface;
     } // namespace Sid
 } // namespace UKControllerPlugin
 
@@ -27,7 +27,7 @@ namespace UKControllerPlugin::Prenote {
         PublishedPrenoteMapper(
             const PublishedPrenoteCollection& publishedPrenotes,
             const Airfield::AirfieldCollection& airfields,
-            const Sid::SidCollection& sids,
+            const Sid::SidMapperInterface& sidMapper,
             const FlightRules::FlightRuleCollection& flightRules);
 
         [[nodiscard]] auto MapForFlightplan(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
@@ -48,7 +48,7 @@ namespace UKControllerPlugin::Prenote {
         const Airfield::AirfieldCollection& airfields;
 
         // The sids for specific sid prenotes
-        const Sid::SidCollection& sids;
+        const Sid::SidMapperInterface& sidMapper;
 
         // For mapping flight rules
         const FlightRules::FlightRuleCollection& flightRules;

--- a/src/plugin/runway/Runway.cpp
+++ b/src/plugin/runway/Runway.cpp
@@ -2,8 +2,8 @@
 
 namespace UKControllerPlugin::Runway {
 
-    Runway::Runway(int id, int airfieldId, int heading, EuroScopePlugIn::CPosition threshold)
-        : id(id), airfieldId(airfieldId), heading(heading), threshold(threshold)
+    Runway::Runway(int id, int airfieldId, std::string identifier, int heading, EuroScopePlugIn::CPosition threshold)
+        : id(id), airfieldId(airfieldId), identifier(std::move(identifier)), heading(heading), threshold(threshold)
     {
     }
 

--- a/src/plugin/runway/Runway.cpp
+++ b/src/plugin/runway/Runway.cpp
@@ -1,0 +1,34 @@
+#include "Runway.h"
+
+namespace UKControllerPlugin::Runway {
+
+    Runway::Runway(int id, int airfieldId, int heading, EuroScopePlugIn::CPosition threshold)
+        : id(id), airfieldId(airfieldId), heading(heading), threshold(threshold)
+    {
+    }
+
+    auto Runway::Id() const -> int
+    {
+        return id;
+    }
+
+    auto Runway::AirfieldId() const -> int
+    {
+        return airfieldId;
+    }
+
+    auto Runway::Identifier() const -> const std::string&
+    {
+        return identifier;
+    }
+
+    auto Runway::Heading() const -> int
+    {
+        return heading;
+    }
+
+    auto Runway::Threshold() const -> const EuroScopePlugIn::CPosition&
+    {
+        return threshold;
+    }
+} // namespace UKControllerPlugin::Runway

--- a/src/plugin/runway/Runway.h
+++ b/src/plugin/runway/Runway.h
@@ -1,0 +1,33 @@
+#pragma once
+
+namespace UKControllerPlugin::Runway {
+    /**
+     * Represents a runway.
+     */
+    class Runway
+    {
+        public:
+        Runway(int id, int airfieldId, std::string identifier, int heading, EuroScopePlugIn::CPosition threshold);
+        [[nodiscard]] auto Id() const -> int;
+        [[nodiscard]] auto AirfieldId() const -> int;
+        [[nodiscard]] auto Identifier() const -> const std::string&;
+        [[nodiscard]] auto Heading() const -> int;
+        [[nodiscard]] auto Threshold() const -> const EuroScopePlugIn::CPosition&;
+
+        private:
+        // The id of the runway in the API
+        int id;
+
+        // The id of the airfield that this runway is at
+        int airfieldId;
+
+        // The identifier of the runway - e.g 27L
+        std::string identifier;
+
+        // The heading of the runway
+        int heading;
+
+        // The coordinates of the runway threshold
+        EuroScopePlugIn::CPosition threshold;
+    };
+} // namespace UKControllerPlugin::Runway

--- a/src/plugin/runway/RunwayCollection.cpp
+++ b/src/plugin/runway/RunwayCollection.cpp
@@ -1,0 +1,37 @@
+#include "Runway.h"
+#include "RunwayCollection.h"
+
+namespace UKControllerPlugin::Runway {
+
+    void RunwayCollection::Add(std::shared_ptr<class Runway> runway)
+    {
+        if (this->runways.count(runway->Id()) > 0) {
+            LogError("Duplicate runway added: " + std::to_string(runway->Id()));
+            return;
+        }
+
+        runways[runway->Id()] = runway;
+    }
+
+    auto RunwayCollection::Count() const -> size_t
+    {
+        return runways.size();
+    }
+
+    auto RunwayCollection::GetById(int id) const -> std::shared_ptr<class Runway>
+    {
+        return runways.count(id) == 1 ? runways.at(id) : nullptr;
+    }
+
+    auto RunwayCollection::GetByAirfieldAndIdentifier(int airfieldId, const std::string& identifier)
+        -> std::shared_ptr<class Runway>
+    {
+        auto runway = std::find_if(
+            runways.begin(),
+            runways.end(),
+            [&airfieldId, &identifier](std::pair<int, const std::shared_ptr<class Runway>&> runway) -> bool {
+                return runway.second->AirfieldId() == airfieldId && runway.second->Identifier() == identifier;
+            });
+        return runway != runways.cend() ? runway->second : nullptr;
+    }
+} // namespace UKControllerPlugin::Runway

--- a/src/plugin/runway/RunwayCollection.cpp
+++ b/src/plugin/runway/RunwayCollection.cpp
@@ -23,7 +23,7 @@ namespace UKControllerPlugin::Runway {
         return runways.count(id) == 1 ? runways.at(id) : nullptr;
     }
 
-    auto RunwayCollection::GetByAirfieldAndIdentifier(int airfieldId, const std::string& identifier)
+    auto RunwayCollection::GetByAirfieldAndIdentifier(int airfieldId, const std::string& identifier) const
         -> std::shared_ptr<class Runway>
     {
         auto runway = std::find_if(

--- a/src/plugin/runway/RunwayCollection.h
+++ b/src/plugin/runway/RunwayCollection.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace UKControllerPlugin::Runway {
+    class Runway;
+
+    /*
+     * A collection of all the runways stored in the plugin API.
+     */
+    class RunwayCollection
+    {
+        public:
+        void Add(std::shared_ptr<class Runway> runway);
+        [[nodiscard]] auto Count() const -> size_t;
+        [[nodiscard]] auto GetById(int id) const -> std::shared_ptr<class Runway>;
+        [[nodiscard]] auto GetByAirfieldAndIdentifier(int airfieldId, const std::string& identifier)
+            -> std::shared_ptr<class Runway>;
+
+        private:
+        // All the runways
+        std::map<int, std::shared_ptr<class Runway>> runways;
+    };
+} // namespace UKControllerPlugin::Runway

--- a/src/plugin/runway/RunwayCollection.h
+++ b/src/plugin/runway/RunwayCollection.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "RunwayCollectionFactory.h"
+
 namespace UKControllerPlugin::Runway {
     class Runway;
 

--- a/src/plugin/runway/RunwayCollection.h
+++ b/src/plugin/runway/RunwayCollection.h
@@ -14,7 +14,7 @@ namespace UKControllerPlugin::Runway {
         void Add(std::shared_ptr<class Runway> runway);
         [[nodiscard]] auto Count() const -> size_t;
         [[nodiscard]] auto GetById(int id) const -> std::shared_ptr<class Runway>;
-        [[nodiscard]] auto GetByAirfieldAndIdentifier(int airfieldId, const std::string& identifier)
+        [[nodiscard]] auto GetByAirfieldAndIdentifier(int airfieldId, const std::string& identifier) const
             -> std::shared_ptr<class Runway>;
 
         private:

--- a/src/plugin/runway/RunwayCollectionFactory.cpp
+++ b/src/plugin/runway/RunwayCollectionFactory.cpp
@@ -3,8 +3,7 @@
 #include "RunwayCollectionFactory.h"
 
 namespace UKControllerPlugin::Runway {
-    auto BuildRunwayCollection(const nlohmann::json& dependency)
-        -> std::unique_ptr<RunwayCollection>
+    auto BuildRunwayCollection(const nlohmann::json& dependency) -> std::unique_ptr<RunwayCollection>
     {
         auto collection = std::make_unique<RunwayCollection>();
         if (!dependency.is_array()) {

--- a/src/plugin/runway/RunwayCollectionFactory.cpp
+++ b/src/plugin/runway/RunwayCollectionFactory.cpp
@@ -1,0 +1,46 @@
+#include "Runway.h"
+#include "RunwayCollection.h"
+#include "RunwayCollectionFactory.h"
+
+namespace UKControllerPlugin::Runway {
+    auto BuildRunwayCollection(const nlohmann::json& dependency)
+        -> std::unique_ptr<RunwayCollection>
+    {
+        auto collection = std::make_unique<RunwayCollection>();
+        if (!dependency.is_array()) {
+            LogWarning("Runway dependency is not an array");
+            return collection;
+        }
+
+        for (const auto& runway : dependency) {
+            if (!RunwayValid(runway)) {
+                LogWarning("Invalid runway detected");
+                continue;
+            }
+
+            EuroScopePlugIn::CPosition threshold;
+            threshold.m_Latitude = runway.at("threshold_latitude").get<double>();
+            threshold.m_Longitude = runway.at("threshold_longitude").get<double>();
+
+            collection->Add(std::make_shared<class Runway>(
+                runway.at("id").get<int>(),
+                runway.at("airfield_id").get<int>(),
+                runway.at("identifier").get<std::string>(),
+                runway.at("heading").get<int>(),
+                std::move(threshold)));
+        }
+
+        LogInfo("Loaded " + std::to_string(collection->Count()) + " runways");
+        return collection;
+    }
+
+    auto RunwayValid(const nlohmann::json& runway) -> bool
+    {
+        return runway.is_object() && runway.contains("id") && runway.at("id").is_number_integer() &&
+               runway.contains("airfield_id") && runway.at("airfield_id").is_number_integer() &&
+               runway.contains("identifier") && runway.at("identifier").is_string() && runway.contains("heading") &&
+               runway.at("heading").is_number_integer() && runway.contains("threshold_latitude") &&
+               runway.at("threshold_latitude").is_number() && runway.contains("threshold_longitude") &&
+               runway.at("threshold_longitude").is_number();
+    }
+} // namespace UKControllerPlugin::Runway

--- a/src/plugin/runway/RunwayCollectionFactory.h
+++ b/src/plugin/runway/RunwayCollectionFactory.h
@@ -11,7 +11,7 @@ namespace UKControllerPlugin {
 
 namespace UKControllerPlugin::Runway {
     class RunwayCollection;
-    
+
     auto BuildRunwayCollection(const nlohmann::json& dependency) -> std::unique_ptr<RunwayCollection>;
     auto RunwayValid(const nlohmann::json& runway) -> bool;
 } // namespace UKControllerPlugin::Runway

--- a/src/plugin/runway/RunwayCollectionFactory.h
+++ b/src/plugin/runway/RunwayCollectionFactory.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace UKControllerPlugin {
+    namespace Bootstrap {
+        struct PersistenceContainer;
+    } // namespace Bootstrap
+    namespace Dependency {
+        class DependencyLoaderInterface;
+    } // namespace Dependency
+} // namespace UKControllerPlugin
+
+namespace UKControllerPlugin::Runway {
+    class RunwayCollection;
+    
+    auto BuildRunwayCollection(const nlohmann::json& dependency) -> std::unique_ptr<RunwayCollection>;
+    auto RunwayValid(const nlohmann::json& runway) -> bool;
+} // namespace UKControllerPlugin::Runway

--- a/src/plugin/runway/RunwayModule.cpp
+++ b/src/plugin/runway/RunwayModule.cpp
@@ -1,0 +1,15 @@
+#include "RunwayCollection.h"
+#include "RunwayCollectionFactory.h"
+#include "RunwayModule.h"
+#include "bootstrap/PersistenceContainer.h"
+#include "dependency/DependencyLoaderInterface.h"
+
+namespace UKControllerPlugin::Runway {
+
+    void
+    BootstrapPlugin(Bootstrap::PersistenceContainer& container, Dependency::DependencyLoaderInterface& dependencyLoader)
+    {
+        container.runwayCollection =
+            BuildRunwayCollection(dependencyLoader.LoadDependency("DEPENDENCY_RUNWAYS", nlohmann::json::array()));
+    }
+} // namespace UKControllerPlugin::Runway

--- a/src/plugin/runway/RunwayModule.h
+++ b/src/plugin/runway/RunwayModule.h
@@ -1,0 +1,13 @@
+namespace UKControllerPlugin {
+    namespace Bootstrap {
+        struct PersistenceContainer;
+    } // namespace Bootstrap
+    namespace Dependency {
+        class DependencyLoaderInterface;
+    } // namespace Dependency
+} // namespace UKControllerPlugin
+
+namespace UKControllerPlugin::Runway {
+    void BootstrapPlugin(
+        Bootstrap::PersistenceContainer& container, Dependency::DependencyLoaderInterface& dependencyLoader);
+} // namespace UKControllerPlugin::Runway

--- a/src/plugin/sid/FlightplanSidMapper.cpp
+++ b/src/plugin/sid/FlightplanSidMapper.cpp
@@ -1,0 +1,34 @@
+#include "FlightplanSidMapper.h"
+#include "airfield/AirfieldCollection.h"
+#include "airfield/AirfieldModel.h"
+#include "euroscope/EuroScopeCFlightPlanInterface.h"
+#include "runway/Runway.h"
+#include "runway/RunwayCollection.h"
+#include "sid/SidCollection.h"
+
+namespace UKControllerPlugin::Sid {
+
+    FlightplanSidMapper::FlightplanSidMapper(
+        const Airfield::AirfieldCollection& airfields,
+        const Runway::RunwayCollection& runways,
+        const SidCollection& sids)
+        : airfields(airfields), runways(runways), sids(sids)
+    {
+    }
+
+    auto FlightplanSidMapper::MapFlightplanToSid(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
+        -> std::shared_ptr<StandardInstrumentDeparture>
+    {
+        const auto airfield = airfields.FetchAirfieldByIcao(flightplan.GetOrigin());
+        if (!airfield) {
+            return nullptr;
+        }
+
+        const auto runway = runways.GetByAirfieldAndIdentifier(airfield->Id(), flightplan.GetDepartureRunway());
+        if (!runway) {
+            return nullptr;
+        }
+
+        return sids.GetByRunwayIdAndIdentifier(runway->Id(), flightplan.GetSidName());
+    }
+} // namespace UKControllerPlugin::Sid

--- a/src/plugin/sid/FlightplanSidMapper.h
+++ b/src/plugin/sid/FlightplanSidMapper.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "sid/SidMapperInterface.h"
+
+namespace UKControllerPlugin {
+    namespace Airfield {
+        class AirfieldCollection;
+    } // namespace Airfield
+    namespace Euroscope {
+        class EuroScopeCFlightPlanInterface;
+    } // namespace Euroscope
+    namespace Runway {
+        class RunwayCollection;
+    } // namespace Runway
+} // namespace UKControllerPlugin
+
+namespace UKControllerPlugin::Sid {
+    class SidCollection;
+    class StandardInstrumentDeparture;
+
+    /**
+     * Given a flightplan, resolve it to its Standard Instrument Departure.
+     */
+    class FlightplanSidMapper : public Sid::SidMapperInterface
+    {
+        public:
+        FlightplanSidMapper(
+            const Airfield::AirfieldCollection& airfields,
+            const Runway::RunwayCollection& runways,
+            const SidCollection& sids);
+        [[nodiscard]] auto MapFlightplanToSid(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
+            -> std::shared_ptr<StandardInstrumentDeparture>;
+
+        private:
+        // All the airfields
+        const Airfield::AirfieldCollection& airfields;
+
+        // All the runways
+        const Runway::RunwayCollection& runways;
+
+        // All the SIDs
+        const SidCollection& sids;
+    };
+} // namespace UKControllerPlugin::Sid

--- a/src/plugin/sid/SidCollection.cpp
+++ b/src/plugin/sid/SidCollection.cpp
@@ -12,16 +12,14 @@ namespace UKControllerPlugin::Sid {
     {
         return this->sids.size();
     }
-    
+
     auto SidCollection::GetById(int id) const -> std::shared_ptr<StandardInstrumentDeparture>
     {
         auto sid = std::find_if(
             this->sids.cbegin(),
             this->sids.cend(),
-            [&id](const std::shared_ptr<StandardInstrumentDeparture>& sid) -> bool {
-                return sid->Id() == id;
-            });
-        
+            [&id](const std::shared_ptr<StandardInstrumentDeparture>& sid) -> bool { return sid->Id() == id; });
+
         return sid == this->sids.cend() ? nullptr : *sid;
     }
 

--- a/src/plugin/sid/SidCollection.cpp
+++ b/src/plugin/sid/SidCollection.cpp
@@ -12,25 +12,31 @@ namespace UKControllerPlugin::Sid {
     {
         return this->sids.size();
     }
+    
+    auto SidCollection::GetById(int id) const -> std::shared_ptr<StandardInstrumentDeparture>
+    {
+        auto sid = std::find_if(
+            this->sids.cbegin(),
+            this->sids.cend(),
+            [&id](const std::shared_ptr<StandardInstrumentDeparture>& sid) -> bool {
+                return sid->Id() == id;
+            });
+        
+        return sid == this->sids.cend() ? nullptr : *sid;
+    }
 
-    auto SidCollection::GetByAirfieldAndIdentifier(const std::string& airfield, const std::string& identifier) const
+    auto SidCollection::GetByRunwayIdAndIdentifier(int runwayId, const std::string& identifier) const
         -> std::shared_ptr<StandardInstrumentDeparture>
     {
         const auto normalisedIdentifier = NormaliseIdentifier(identifier);
         auto sid = std::find_if(
             this->sids.cbegin(),
             this->sids.cend(),
-            [&airfield, &normalisedIdentifier](const std::shared_ptr<StandardInstrumentDeparture>& sid) -> bool {
-                return sid->Airfield() == airfield && sid->Identifier() == normalisedIdentifier;
+            [&runwayId, &normalisedIdentifier](const std::shared_ptr<StandardInstrumentDeparture>& sid) -> bool {
+                return sid->RunwayId() == runwayId && sid->Identifier() == normalisedIdentifier;
             });
 
         return sid == this->sids.cend() ? nullptr : *sid;
-    }
-
-    auto SidCollection::GetForFlightplan(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
-        -> std::shared_ptr<StandardInstrumentDeparture>
-    {
-        return this->GetByAirfieldAndIdentifier(flightplan.GetOrigin(), flightplan.GetSidName());
     }
 
     /**

--- a/src/plugin/sid/SidCollection.h
+++ b/src/plugin/sid/SidCollection.h
@@ -16,9 +16,8 @@ namespace UKControllerPlugin::Sid {
         public:
         void AddSid(const std::shared_ptr<StandardInstrumentDeparture>& sid);
         [[nodiscard]] auto CountSids() const -> size_t;
-        [[nodiscard]] auto GetByAirfieldAndIdentifier(const std::string& airfield, const std::string& identifier) const
-            -> std::shared_ptr<StandardInstrumentDeparture>;
-        [[nodiscard]] auto GetForFlightplan(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
+        [[nodiscard]] auto GetById(int id) const -> std::shared_ptr<StandardInstrumentDeparture>;
+        [[nodiscard]] auto GetByRunwayIdAndIdentifier(int runwayId, const std::string& identifier) const
             -> std::shared_ptr<StandardInstrumentDeparture>;
 
         private:

--- a/src/plugin/sid/SidCollectionFactory.cpp
+++ b/src/plugin/sid/SidCollectionFactory.cpp
@@ -15,7 +15,8 @@ namespace UKControllerPlugin::Sid {
 
         for (auto sid : sidData) {
             sids->AddSid(std::make_shared<StandardInstrumentDeparture>(
-                sid.at("airfield").get<std::string>(),
+                sid.at("id").get<int>(),
+                sid.at("runway_id").get<int>(),
                 sid.at("identifier").get<std::string>(),
                 sid.at("initial_altitude").get<int>(),
                 sid.at("initial_heading").is_number_integer() ? sid.at("initial_heading").get<int>() : 0,
@@ -31,7 +32,8 @@ namespace UKControllerPlugin::Sid {
     {
         return sidData.is_array() &&
                std::find_if_not(sidData.cbegin(), sidData.cend(), [](const nlohmann::json& sid) -> bool {
-                   return sid.is_object() && sid.contains("airfield") && sid.at("airfield").is_string() &&
+                   return sid.is_object() && sid.contains("id") && sid.at("id").is_number_integer() &&
+                          sid.contains("runway_id") && sid.at("runway_id").is_number_integer() &&
                           sid.contains("identifier") && sid.at("identifier").is_string() &&
                           sid.contains("initial_altitude") && sid.at("initial_altitude").is_number_integer() &&
                           sid.contains("initial_heading") && InitialHeadingValid(sid) && sid.contains("handoff") &&

--- a/src/plugin/sid/SidMapperInterface.h
+++ b/src/plugin/sid/SidMapperInterface.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace UKControllerPlugin::Euroscope {
+    class EuroScopeCFlightPlanInterface;
+} // namespace UKControllerPlugin::Euroscope
+
+namespace UKControllerPlugin::Sid {
+    class StandardInstrumentDeparture;
+
+    /**
+     * An interface for a class that maps flightplans to their respective SIDs.
+     *
+     * This saves us having to build up the relatively complicated mapper class
+     * in all our tests.
+     */
+    class SidMapperInterface
+    {
+        public:
+        virtual ~SidMapperInterface() = default;
+        [[nodiscard]] virtual auto MapFlightplanToSid(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
+            -> std::shared_ptr<StandardInstrumentDeparture> = 0;
+    };
+} // namespace UKControllerPlugin::Sid

--- a/src/plugin/sid/SidModule.cpp
+++ b/src/plugin/sid/SidModule.cpp
@@ -1,3 +1,4 @@
+#include "FlightplanSidMapper.h"
 #include "SidCollection.h"
 #include "SidCollectionFactory.h"
 #include "SidModule.h"
@@ -11,5 +12,7 @@ namespace UKControllerPlugin::Sid {
     {
         nlohmann::json sidData = dependencyProvider.LoadDependency("DEPENDENCY_SIDS", nlohmann::json::array());
         container.sids = MakeSidCollection(sidData);
+        container.sidMapper =
+            std::make_unique<FlightplanSidMapper>(*container.airfields, *container.runwayCollection, *container.sids);
     }
 } // namespace UKControllerPlugin::Sid

--- a/src/plugin/sid/StandardInstrumentDeparture.cpp
+++ b/src/plugin/sid/StandardInstrumentDeparture.cpp
@@ -3,20 +3,26 @@
 namespace UKControllerPlugin::Sid {
 
     StandardInstrumentDeparture::StandardInstrumentDeparture(
-        std::string airfield,
+        int id,
+        int runwayId,
         std::string identifier,
         int initialAltitude,
         int initialHeading,
         int handoffId,
         std::set<int> prenotes)
-        : airfield(std::move(airfield)), identifier(std::move(identifier)), initialAltitude(initialAltitude),
+        : id(id), runwayId(runwayId), identifier(std::move(identifier)), initialAltitude(initialAltitude),
           initialHeading(initialHeading), handoffId(handoffId), prenotes(std::move(prenotes))
     {
     }
 
-    auto StandardInstrumentDeparture::Airfield() const -> std::string
+    auto StandardInstrumentDeparture::Id() const -> int
     {
-        return this->airfield;
+        return this->id;
+    }
+
+    auto StandardInstrumentDeparture::RunwayId() const -> int
+    {
+        return this->runwayId;
     }
 
     auto StandardInstrumentDeparture::Identifier() const -> std::string

--- a/src/plugin/sid/StandardInstrumentDeparture.h
+++ b/src/plugin/sid/StandardInstrumentDeparture.h
@@ -8,14 +8,16 @@ namespace UKControllerPlugin::Sid {
     {
         public:
         StandardInstrumentDeparture(
-            std::string airfield,
+            int id,
+            int runwayId,
             std::string identifier,
             int initialAltitude,
             int initialHeading,
             int handoffId,
             std::set<int> prenotes = {});
 
-        [[nodiscard]] auto Airfield() const -> std::string;
+        [[nodiscard]] auto Id() const -> int;
+        [[nodiscard]] auto RunwayId() const -> int;
         [[nodiscard]] auto Identifier() const -> std::string;
         [[nodiscard]] auto InitialAltitude() const -> int;
         [[nodiscard]] auto InitialHeading() const -> int;
@@ -24,7 +26,8 @@ namespace UKControllerPlugin::Sid {
         [[nodiscard]] auto Prenotes() const -> const std::set<int>&;
 
         private:
-        const std::string airfield;
+        const int id;
+        const int runwayId;
         const std::string identifier;
         const int initialAltitude;
         const int initialHeading;

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -458,7 +458,7 @@ set(test__sid
     "sid/SidCollectionTest.cpp"
     "sid/SidModuleTest.cpp"
     "sid/StandardInstrumentDepartureTest.cpp"
-)
+        sid/FlightplanSidMapperTest.cpp mock/MockSidMapperInterface.h)
 source_group("test\\sid" FILES ${test__sid})
 
 set(test__squawk

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -437,7 +437,7 @@ set(test__releases
 source_group("test\\releases" FILES ${test__releases})
 
 set(test__runway
-        runway/RunwayTest.cpp runway/RunwayCollectionTest.cpp)
+        runway/RunwayTest.cpp runway/RunwayCollectionTest.cpp runway/RunwayCollectionFactoryTest.cpp runway/RunwayModuleTest.cpp)
 source_group("test\\runway" FILES ${test__runway})
 
 set(test__sectorfile

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -437,12 +437,12 @@ set(test__releases
 source_group("test\\releases" FILES ${test__releases})
 
 set(test__runway
-        runway/RunwayTest.cpp)
+        runway/RunwayTest.cpp runway/RunwayCollectionTest.cpp)
 source_group("test\\runway" FILES ${test__runway})
 
 set(test__sectorfile
-    "sectorfile/RunwayCollectionTest.cpp"
-    "sectorfile/RunwayTest.cpp"
+    "sectorfile/SectorfileRunwayCollectionTest.cpp"
+    "sectorfile/SectorfileRunwayTest.cpp"
     "sectorfile/SectorFileBootstrapTest.cpp"
     "sectorfile/SectorFileCoordinatesTest.cpp"
 )

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -436,6 +436,10 @@ set(test__releases
         releases/ReleaseApprovalRemarksUserMessageTest.cpp releases/ReleaseRejectionRemarksUserMessageTest.cpp)
 source_group("test\\releases" FILES ${test__releases})
 
+set(test__runway
+        runway/RunwayTest.cpp)
+source_group("test\\runway" FILES ${test__runway})
+
 set(test__sectorfile
     "sectorfile/RunwayCollectionTest.cpp"
     "sectorfile/RunwayTest.cpp"
@@ -554,6 +558,7 @@ set(ALL_FILES
     ${test__radarscreen}
     ${test__regional}
     ${test__releases}
+    ${test__runway}
     ${test__sectorfile}
     ${test__selcal}
     ${test__sid}

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -437,7 +437,10 @@ set(test__releases
 source_group("test\\releases" FILES ${test__releases})
 
 set(test__runway
-        runway/RunwayTest.cpp runway/RunwayCollectionTest.cpp runway/RunwayCollectionFactoryTest.cpp runway/RunwayModuleTest.cpp)
+    runway/RunwayTest.cpp
+    runway/RunwayCollectionTest.cpp
+    runway/RunwayCollectionFactoryTest.cpp
+    runway/RunwayModuleTest.cpp)
 source_group("test\\runway" FILES ${test__runway})
 
 set(test__sectorfile
@@ -458,7 +461,8 @@ set(test__sid
     "sid/SidCollectionTest.cpp"
     "sid/SidModuleTest.cpp"
     "sid/StandardInstrumentDepartureTest.cpp"
-        sid/FlightplanSidMapperTest.cpp mock/MockSidMapperInterface.h)
+    sid/FlightplanSidMapperTest.cpp
+    mock/MockSidMapperInterface.h)
 source_group("test\\sid" FILES ${test__sid})
 
 set(test__squawk

--- a/test/plugin/handoff/FlightplanSidHandoffMapperTest.cpp
+++ b/test/plugin/handoff/FlightplanSidHandoffMapperTest.cpp
@@ -14,17 +14,21 @@ namespace UKControllerPluginTest::Handoff {
     class FlightplanSidHandoffMapperTest : public testing::Test
     {
         public:
-        FlightplanSidHandoffMapperTest() : mapper(handoffs, sids)
+        FlightplanSidHandoffMapperTest() : mapper(handoffs, sidMapper)
         {
             ON_CALL(mockFlightplan, GetOrigin).WillByDefault(testing::Return("EGKK"));
 
-            sids.AddSid(std::make_shared<StandardInstrumentDeparture>("EGKK", "CLN3X", 5000, 200, 1));
-            sids.AddSid(std::make_shared<StandardInstrumentDeparture>("EGKK", "CLN3Y", 5000, 200, 55));
-            sids.AddSid(std::make_shared<StandardInstrumentDeparture>("EGKK", "CLN3Z", 5000, 200, 0));
+            sid1 = std::make_shared<StandardInstrumentDeparture>(1, 2, "CLN3X", 5000, 200, 1);
+            sid2 = std::make_shared<StandardInstrumentDeparture>(2, 3, "CLN3Y", 5000, 200, 55);
+            sid3 = std::make_shared<StandardInstrumentDeparture>(3, 4, "CLN3Z", 5000, 200, 0);
             handoffs.Add(std::make_shared<HandoffOrder>(1, nullptr));
             handoffs.Add(std::make_shared<HandoffOrder>(2, nullptr));
         }
 
+        std::shared_ptr<StandardInstrumentDeparture> sid1;
+        std::shared_ptr<StandardInstrumentDeparture> sid2;
+        std::shared_ptr<StandardInstrumentDeparture> sid3;
+        testing::NiceMock<Sid::MockSidMapperInterface> sidMapper;
         testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface> mockFlightplan;
         SidCollection sids;
         HandoffCollection handoffs;
@@ -33,25 +37,38 @@ namespace UKControllerPluginTest::Handoff {
 
     TEST_F(FlightplanSidHandoffMapperTest, ItReturnsNullptrIfNoSidFound)
     {
-        ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("LAM5M"));
+        EXPECT_CALL(sidMapper, MapFlightplanToSid(testing::Ref(mockFlightplan)))
+            .Times(1)
+            .WillOnce(testing::Return(nullptr));
+
         EXPECT_EQ(nullptr, mapper.MapForFlightplan(mockFlightplan));
     }
 
     TEST_F(FlightplanSidHandoffMapperTest, ItReturnsNullptrIfSidDoesntHaveHandoff)
     {
+        EXPECT_CALL(sidMapper, MapFlightplanToSid(testing::Ref(mockFlightplan)))
+            .Times(1)
+            .WillOnce(testing::Return(sid3));
+
         ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("CLN3Z"));
         EXPECT_EQ(nullptr, mapper.MapForFlightplan(mockFlightplan));
     }
 
     TEST_F(FlightplanSidHandoffMapperTest, ItReturnsNullptrIfHandoffDoesntExist)
     {
-        ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("CLN3Y"));
+        EXPECT_CALL(sidMapper, MapFlightplanToSid(testing::Ref(mockFlightplan)))
+            .Times(1)
+            .WillOnce(testing::Return(sid2));
+
         EXPECT_EQ(nullptr, mapper.MapForFlightplan(mockFlightplan));
     }
 
     TEST_F(FlightplanSidHandoffMapperTest, ItReturnsMappedHandoff)
     {
-        ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("CLN3X"));
+        EXPECT_CALL(sidMapper, MapFlightplanToSid(testing::Ref(mockFlightplan)))
+            .Times(1)
+            .WillOnce(testing::Return(sid1));
+
         EXPECT_EQ(handoffs.Get(1), mapper.MapForFlightplan(mockFlightplan));
     }
 } // namespace UKControllerPluginTest::Handoff

--- a/test/plugin/handoff/HandoffEventHandlerTest.cpp
+++ b/test/plugin/handoff/HandoffEventHandlerTest.cpp
@@ -11,7 +11,6 @@
 #include "handoff/HandoffFrequencyUpdatedMessage.h"
 #include "handoff/HandoffOrder.h"
 #include "handoff/ResolvedHandoff.h"
-#include "sid/SidCollection.h"
 #include "sid/StandardInstrumentDeparture.h"
 #include "tag/TagData.h"
 
@@ -32,7 +31,6 @@ using UKControllerPlugin::Handoff::HandoffEventHandler;
 using UKControllerPlugin::Handoff::HandoffFrequencyUpdatedMessage;
 using UKControllerPlugin::Handoff::HandoffOrder;
 using UKControllerPlugin::Handoff::ResolvedHandoff;
-using UKControllerPlugin::Sid::SidCollection;
 using UKControllerPlugin::Sid::StandardInstrumentDeparture;
 using UKControllerPlugin::Tag::TagData;
 using UKControllerPluginTest::Euroscope::MockEuroScopeCFlightPlanInterface;
@@ -58,15 +56,12 @@ namespace UKControllerPluginTest::Handoff {
                   &euroscopeColourCode,
                   &tagColour,
                   &fontSize),
-              handoffMapper(handoffs, sids), airfieldMapper(handoffs, airfields),
+              handoffMapper(handoffs, sidMapper), airfieldMapper(handoffs, airfields),
               resolver(std::make_shared<DepartureHandoffResolver>(handoffMapper, airfieldMapper, activeCallsigns)),
               cache(std::make_shared<HandoffCache>()), handler(resolver, cache, mockIntegration)
         {
             ON_CALL(this->mockFlightplan, GetCallsign()).WillByDefault(Return("BAW123"));
-
             ON_CALL(this->mockFlightplan, GetOrigin()).WillByDefault(Return("EGKK"));
-
-            ON_CALL(this->mockFlightplan, GetSidName()).WillByDefault(Return("ADMAG2X"));
 
             this->hierarchy = std::make_shared<ControllerPositionHierarchy>();
             this->hierarchy->AddPosition(this->position1);
@@ -74,11 +69,16 @@ namespace UKControllerPluginTest::Handoff {
 
             this->hierarchy2 = std::make_shared<ControllerPositionHierarchy>();
             this->hierarchy2->AddPosition(this->position1);
+
+            ON_CALL(sidMapper, MapFlightplanToSid).WillByDefault(testing::Return(nullptr));
         }
 
         void AddHandoffOrders()
         {
-            this->sids.AddSid(std::make_shared<StandardInstrumentDeparture>("EGKK", "ADMAG2X", 1000, 300, 1));
+            ON_CALL(sidMapper, MapFlightplanToSid)
+                .WillByDefault(
+                    testing::Return(std::make_shared<StandardInstrumentDeparture>(1, 2, "ADMAG2X", 1000, 300, 1)));
+
             this->handoffs.Add(std::make_shared<HandoffOrder>(1, this->hierarchy));
         }
 
@@ -86,6 +86,7 @@ namespace UKControllerPluginTest::Handoff {
         COLORREF tagColour = RGB(255, 255, 255);
         int euroscopeColourCode = EuroScopePlugIn::TAG_COLOR_ASSUMED;
         char itemString[16] = "Foooooo";
+        NiceMock<Sid::MockSidMapperInterface> sidMapper;
         std::shared_ptr<ControllerPosition> position1;
         std::shared_ptr<ControllerPosition> position2;
         std::shared_ptr<ControllerPositionHierarchy> hierarchy;
@@ -95,7 +96,6 @@ namespace UKControllerPluginTest::Handoff {
         NiceMock<MockEuroScopeCRadarTargetInterface> mockRadarTarget;
         AirfieldCollection airfields;
         ActiveCallsignCollection activeCallsigns;
-        SidCollection sids;
         TagData tagData;
         HandoffCollection handoffs;
         FlightplanSidHandoffMapper handoffMapper;

--- a/test/plugin/initialaltitude/InitialAltitudeEventHandlerTest.cpp
+++ b/test/plugin/initialaltitude/InitialAltitudeEventHandlerTest.cpp
@@ -603,7 +603,7 @@ namespace UKControllerPluginTest {
             EXPECT_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplanPointer)))
                 .Times(1)
                 .WillOnce(testing::Return(sid1));
-            
+
             callsigns.AddUserCallsign(userCallsign);
 
             this->SetServiceProvision(true);
@@ -657,7 +657,7 @@ namespace UKControllerPluginTest {
             EXPECT_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplanPointer)))
                 .Times(1)
                 .WillOnce(testing::Return(sid1));
-            
+
             callsigns.AddUserCallsign(userCallsign);
 
             this->SetServiceProvision(true);

--- a/test/plugin/mock/MockEuroScopeCFlightplanInterface.h
+++ b/test/plugin/mock/MockEuroScopeCFlightplanInterface.h
@@ -28,6 +28,7 @@ namespace UKControllerPluginTest {
             MOCK_CONST_METHOD0(GetSidName, std::string(void));
             MOCK_CONST_METHOD0(GetAssignedSquawk, std::string(void));
             MOCK_CONST_METHOD0(GetRemarks, std::string());
+            MOCK_CONST_METHOD0(GetDepartureRunway, std::string());
             MOCK_CONST_METHOD0(HasControllerClearedAltitude, bool(void));
             MOCK_CONST_METHOD0(HasControllerAssignedHeading, bool(void));
             MOCK_CONST_METHOD0(HasAssignedSquawk, bool(void));

--- a/test/plugin/mock/MockSidMapperInterface.h
+++ b/test/plugin/mock/MockSidMapperInterface.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "sid/SidMapperInterface.h"
+
+using UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface;
+using UKControllerPlugin::Sid::SidMapperInterface;
+using UKControllerPlugin::Sid::StandardInstrumentDeparture;
+
+namespace UKControllerPlugin {
+    namespace Euroscope {
+        class EuroScopeCFlightPlanInterface;
+    } // namespace Euroscope
+    namespace Sid {
+        class StandardInstrumentDeparture;
+    } // namespace Sid
+} // namespace UKControllerPlugin
+
+namespace UKControllerPluginTest::Sid {
+    class MockSidMapperInterface : public SidMapperInterface
+    {
+        public:
+        MOCK_METHOD(
+            std::shared_ptr<StandardInstrumentDeparture>,
+            MapFlightplanToSid,
+            (const EuroScopeCFlightPlanInterface&),
+            (const, override));
+    };
+} // namespace UKControllerPluginTest::Sid

--- a/test/plugin/ownership/AirfieldOwnershipHandlerTest.cpp
+++ b/test/plugin/ownership/AirfieldOwnershipHandlerTest.cpp
@@ -6,11 +6,8 @@
 #include "controller/ControllerPositionHierarchy.h"
 #include "ownership/AirfieldOwnershipManager.h"
 #include "flightplan/StoredFlightplanCollection.h"
-#include "initialaltitude/InitialAltitudeEventHandler.h"
 #include "message/UserMessager.h"
 #include "controller/ControllerStatusEventHandlerCollection.h"
-#include "sid/SidCollection.h"
-#include "sid/StandardInstrumentDeparture.h"
 #include "login/Login.h"
 #include "ownership/AirfieldServiceProviderCollection.h"
 #include "ownership/ServiceProvision.h"
@@ -26,13 +23,10 @@ using UKControllerPlugin::Controller::ControllerStatusEventHandlerCollection;
 using UKControllerPlugin::Controller::Login;
 using UKControllerPlugin::Flightplan::StoredFlightplan;
 using UKControllerPlugin::Flightplan::StoredFlightplanCollection;
-using UKControllerPlugin::InitialAltitude::InitialAltitudeEventHandler;
 using UKControllerPlugin::Message::UserMessager;
 using UKControllerPlugin::Ownership::AirfieldOwnershipHandler;
 using UKControllerPlugin::Ownership::AirfieldOwnershipManager;
 using UKControllerPlugin::Ownership::AirfieldServiceProviderCollection;
-using UKControllerPlugin::Sid::SidCollection;
-using UKControllerPlugin::Sid::StandardInstrumentDeparture;
 using UKControllerPluginTest::Euroscope::MockEuroScopeCControllerInterface;
 using UKControllerPluginTest::Euroscope::MockEuroScopeCFlightPlanInterface;
 using UKControllerPluginTest::Euroscope::MockEuroScopeCRadarTargetInterface;
@@ -51,8 +45,6 @@ namespace UKControllerPluginTest::Ownership {
         ControllerAirfieldOwnershipHandlerTest()
             : serviceProviders(std::make_shared<AirfieldServiceProviderCollection>()),
               ownership(serviceProviders, this->airfieldCollection, this->activeCallsigns),
-              initialAltitudes(new InitialAltitudeEventHandler(
-                  this->sids, this->activeCallsigns, *serviceProviders, this->login, this->plugin)),
               login(plugin, ControllerStatusEventHandlerCollection()), userMessager(this->plugin),
               handler(this->ownership, this->userMessager)
         {
@@ -91,7 +83,6 @@ namespace UKControllerPluginTest::Ownership {
             this->ownership.RefreshOwner("EGKK");
 
             // Create a dummy initial altitude
-            sids.AddSid(std::make_shared<StandardInstrumentDeparture>("EGKK", "ADMAG2X", 6000, 0, 1));
             this->login.SetLoginTime(std::chrono::system_clock::now() - std::chrono::minutes(15));
 
             // Add airfields to the collection
@@ -126,8 +117,6 @@ namespace UKControllerPluginTest::Ownership {
         std::shared_ptr<AirfieldServiceProviderCollection> serviceProviders;
         AirfieldOwnershipManager ownership;
         StoredFlightplanCollection flightplans;
-        SidCollection sids;
-        std::shared_ptr<InitialAltitudeEventHandler> initialAltitudes;
         NiceMock<MockEuroscopePluginLoopbackInterface> plugin;
         Login login;
         UserMessager userMessager;

--- a/test/plugin/pch/pch.h
+++ b/test/plugin/pch/pch.h
@@ -47,6 +47,7 @@
 #include "../mock/MockRadarTargetEventHandlerInterface.h"
 #include "../mock/MockRunwayDialogAwareInterface.h"
 #include "../mock/MockSectorFileProviderInterface.h"
+#include "../mock/MockSidMapperInterface.h"
 #include "../mock/MockSocket.h"
 #include "mock/MockTaskRunnerInterface.h"
 #include "../mock/MockUserSettingAwareInterface.h"

--- a/test/plugin/prenote/PrenoteEventHandlerTest.cpp
+++ b/test/plugin/prenote/PrenoteEventHandlerTest.cpp
@@ -8,7 +8,6 @@
 #include "message/UserMessager.h"
 #include "euroscope/GeneralSettingsEntries.h"
 #include "ownership/AirfieldServiceProviderCollection.h"
-#include "sid/SidCollection.h"
 
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -24,7 +23,6 @@ using UKControllerPlugin::Prenote::PrenoteEventHandler;
 using UKControllerPlugin::Prenote::PrenoteService;
 using UKControllerPlugin::Prenote::PublishedPrenoteCollection;
 using UKControllerPlugin::Prenote::PublishedPrenoteMapper;
-using UKControllerPlugin::Sid::SidCollection;
 using UKControllerPluginTest::Euroscope::MockEuroScopeCFlightPlanInterface;
 using UKControllerPluginTest::Euroscope::MockEuroScopeCRadarTargetInterface;
 using UKControllerPluginTest::Euroscope::MockEuroscopePluginLoopbackInterface;
@@ -34,7 +32,7 @@ namespace UKControllerPluginTest::Prenote {
     class PrenoteEventHandlerTest : public Test
     {
         public:
-        PrenoteEventHandlerTest() : mapper(prenotes, airfields, sids, flightRules)
+        PrenoteEventHandlerTest() : mapper(prenotes, airfields, sidMapper, flightRules)
         {
             this->airfieldOwnership = std::make_unique<AirfieldServiceProviderCollection>();
 
@@ -55,7 +53,7 @@ namespace UKControllerPluginTest::Prenote {
         NiceMock<MockEuroscopePluginLoopbackInterface> mockPlugin;
         NiceMock<MockEuroScopeCRadarTargetInterface> mockRadarTarget;
         AirfieldCollection airfields;
-        SidCollection sids;
+        testing::NiceMock<Sid::MockSidMapperInterface> sidMapper;
         FlightRuleCollection flightRules;
         PublishedPrenoteCollection prenotes;
         PublishedPrenoteMapper mapper;

--- a/test/plugin/runway/RunwayCollectionFactoryTest.cpp
+++ b/test/plugin/runway/RunwayCollectionFactoryTest.cpp
@@ -1,0 +1,166 @@
+#include "runway/Runway.h"
+#include "runway/RunwayCollection.h"
+#include "runway/RunwayCollectionFactory.h"
+
+using UKControllerPlugin::Runway::BuildRunwayCollection;
+using UKControllerPlugin::Runway::RunwayValid;
+
+namespace UKControllerPluginTest::Runway {
+    class RunwayCollectionFactoryTest : public testing::Test
+    {
+        public:
+        static auto
+        MakeRunway(const nlohmann::json& overridingData = nlohmann::json::object(), const std::string& keyToRemove = "")
+            -> const nlohmann::json
+        {
+            nlohmann::json runway{
+                {"id", 1},
+                {"airfield_id", 2},
+                {"identifier", "27L"},
+                {"heading", 123},
+                {"threshold_latitude", 1.2},
+                {"threshold_longitude", 3.4},
+            };
+            runway.update(overridingData);
+
+            if (!keyToRemove.empty()) {
+                runway.erase(runway.find(keyToRemove));
+            }
+
+            return runway;
+        };
+    };
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsValid)
+    {
+        EXPECT_TRUE(RunwayValid(MakeRunway()));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsValidIntegerThreshold)
+    {
+        EXPECT_TRUE(RunwayValid(MakeRunway(nlohmann::json{{"threshold_latitude", 1}, {"threshold_longitude", 2}})));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfIdMissing)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json::object(), "id")));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfIdNotInteger)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json{{"id", "abc"}})));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfAirfieldIdMissing)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json::object(), "airfield_id")));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfAirfieldIdNotInteger)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json{{"airfield_id", "abc"}})));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIdentifierMissing)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json::object(), "identifier")));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfIdentifierNotString)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json{{"identifier", 123}})));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfThresholdLatitudeMissing)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json::object(), "threshold_latitude")));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfThresholdLatitudeNotANumber)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json{{"threshold_latitude", "abc"}})));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfThresholdLongitudeMissing)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json::object(), "threshold_longitude")));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfThresholdLongitudeNotANumber)
+    {
+        EXPECT_FALSE(RunwayValid(MakeRunway(nlohmann::json{{"threshold_longitude", "abc"}})));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, RunwayIsInvalidIfNotAnObject)
+    {
+        EXPECT_FALSE(RunwayValid(nlohmann::json::array()));
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, ItReturnsEmptyCollectionIfDependencyNotArray)
+    {
+        EXPECT_EQ(0, BuildRunwayCollection(nlohmann::json::object())->Count());
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, ItReturnsACollection)
+    {
+        auto dependency = nlohmann::json::array();
+        dependency.push_back(nlohmann::json{
+            {"id", 1},
+            {"airfield_id", 2},
+            {"identifier", "27L"},
+            {"heading", 123},
+            {"threshold_latitude", 1.2},
+            {"threshold_longitude", 3.4},
+        });
+        dependency.push_back(nlohmann::json{
+            {"id", 2},
+            {"airfield_id", 3},
+            {"identifier", "04"},
+            {"heading", 234},
+            {"threshold_latitude", 3.4},
+            {"threshold_longitude", 4.5},
+        });
+
+        auto collection = BuildRunwayCollection(dependency);
+        EXPECT_EQ(2, collection->Count());
+
+        auto runway1 = collection->GetById(1);
+        EXPECT_EQ(1, runway1->Id());
+        EXPECT_EQ(2, runway1->AirfieldId());
+        EXPECT_EQ("27L", runway1->Identifier());
+        EXPECT_EQ(123, runway1->Heading());
+        EXPECT_FLOAT_EQ(1.2, runway1->Threshold().m_Latitude);
+        EXPECT_FLOAT_EQ(3.4, runway1->Threshold().m_Longitude);
+
+        auto runway2 = collection->GetById(2);
+        EXPECT_EQ(2, runway2->Id());
+        EXPECT_EQ(3, runway2->AirfieldId());
+        EXPECT_EQ("04", runway2->Identifier());
+        EXPECT_EQ(234, runway2->Heading());
+        EXPECT_FLOAT_EQ(3.4, runway2->Threshold().m_Latitude);
+        EXPECT_FLOAT_EQ(4.5, runway2->Threshold().m_Longitude);
+    }
+
+    TEST_F(RunwayCollectionFactoryTest, ItIgnoresInvalidRunways)
+    {
+        auto dependency = nlohmann::json::array();
+        dependency.push_back(nlohmann::json{
+            {"id", "abc"}, // Invalid
+            {"airfield_id", 2},
+            {"identifier", "27L"},
+            {"heading", 123},
+            {"threshold_latitude", 1.2},
+            {"threshold_longitude", 3.4},
+        });
+        dependency.push_back(nlohmann::json{
+            {"id", 2},
+            {"airfield_id", 3},
+            {"identifier", "04"},
+            {"heading", 234},
+            {"threshold_latitude", "abc"}, // Invalid
+            {"threshold_longitude", 4.5},
+        });
+
+        EXPECT_EQ(0, BuildRunwayCollection(nlohmann::json::object())->Count());
+    }
+} // namespace UKControllerPluginTest::Runway

--- a/test/plugin/runway/RunwayCollectionTest.cpp
+++ b/test/plugin/runway/RunwayCollectionTest.cpp
@@ -1,0 +1,104 @@
+#include "runway/Runway.h"
+#include "runway/RunwayCollection.h"
+
+using UKControllerPlugin::Runway::Runway;
+using UKControllerPlugin::Runway::RunwayCollection;
+
+namespace UKControllerPluginTest::Runway {
+    class RunwayCollectionTest : public testing::Test
+    {
+        public:
+        RunwayCollectionTest()
+            : runway1(std::make_shared<class Runway>(1, 2, "05", 50, GetPosition())),
+              runway2(std::make_shared<class Runway>(2, 2, "27L", 270, GetPosition())),
+              runway3(std::make_shared<class Runway>(3, 3, "27L", 275, GetPosition()))
+        {
+        }
+
+        std::shared_ptr<class Runway> runway1;
+        std::shared_ptr<class Runway> runway2;
+        std::shared_ptr<class Runway> runway3;
+        RunwayCollection collection;
+
+        private:
+        auto GetPosition() -> EuroScopePlugIn::CPosition
+        {
+            EuroScopePlugIn::CPosition position;
+            position.m_Latitude = 3;
+            position.m_Longitude = 4;
+            return position;
+        }
+    };
+
+    TEST_F(RunwayCollectionTest, ItStartsEmpty)
+    {
+        EXPECT_EQ(0, collection.Count());
+    }
+
+    TEST_F(RunwayCollectionTest, ItAddsRunways)
+    {
+        collection.Add(runway1);
+        collection.Add(runway2);
+        collection.Add(runway3);
+        EXPECT_EQ(3, collection.Count());
+    }
+
+    TEST_F(RunwayCollectionTest, ItDoesntAddDuplicateRunways)
+    {
+        collection.Add(runway1);
+        collection.Add(runway1);
+        collection.Add(runway1);
+        collection.Add(runway2);
+        collection.Add(runway2);
+        collection.Add(runway2);
+        collection.Add(runway3);
+        collection.Add(runway3);
+        collection.Add(runway3);
+        EXPECT_EQ(3, collection.Count());
+    }
+
+    TEST_F(RunwayCollectionTest, ItFetchesARunwayById)
+    {
+        collection.Add(runway1);
+        collection.Add(runway2);
+        collection.Add(runway3);
+
+        EXPECT_EQ(runway2, collection.GetById(2));
+    }
+
+    TEST_F(RunwayCollectionTest, ItReturnsNullptrIfInvalidId)
+    {
+        collection.Add(runway1);
+        collection.Add(runway2);
+        collection.Add(runway3);
+
+        EXPECT_EQ(nullptr, collection.GetById(5));
+    }
+
+    TEST_F(RunwayCollectionTest, ItFetchesARunwayByIdentifierAndAirfild)
+    {
+        collection.Add(runway1);
+        collection.Add(runway2);
+        collection.Add(runway3);
+
+        EXPECT_EQ(runway1, collection.GetByAirfieldAndIdentifier(2, "05"));
+    }
+
+    TEST_F(RunwayCollectionTest, ItReturnsNullptrIfAirfieldIdDoesntMatch)
+    {
+        collection.Add(runway1);
+        collection.Add(runway2);
+        collection.Add(runway3);
+
+        EXPECT_EQ(nullptr, collection.GetByAirfieldAndIdentifier(3, "05"));
+    }
+
+    TEST_F(RunwayCollectionTest, ItReturnsNullptrIfIdentifierDoesntMatch)
+    {
+        collection.Add(runway1);
+        collection.Add(runway2);
+        collection.Add(runway3);
+
+        EXPECT_EQ(nullptr, collection.GetByAirfieldAndIdentifier(2, "27R"));
+    }
+} // namespace UKControllerPluginTest::Runway

--- a/test/plugin/runway/RunwayModuleTest.cpp
+++ b/test/plugin/runway/RunwayModuleTest.cpp
@@ -1,0 +1,29 @@
+#include "bootstrap/PersistenceContainer.h"
+#include "runway/RunwayCollection.h"
+#include "runway/RunwayModule.h"
+
+using UKControllerPlugin::Bootstrap::PersistenceContainer;
+using UKControllerPlugin::Runway::BootstrapPlugin;
+
+namespace UKControllerPluginTest::Runway {
+    class RunwayModuleTest : public testing::Test
+    {
+        public:
+        RunwayModuleTest()
+        {
+        }
+
+        testing::NiceMock<Dependency::MockDependencyLoader> dependencyLoader;
+        PersistenceContainer container;
+    };
+
+    TEST_F(RunwayModuleTest, BootstrapPluginCreatesRunwayCollection)
+    {
+        EXPECT_CALL(dependencyLoader, LoadDependency("DEPENDENCY_RUNWAYS", nlohmann::json::array()))
+            .Times(1)
+            .WillOnce(testing::Return(nlohmann::json::array()));
+
+        BootstrapPlugin(container, dependencyLoader);
+        EXPECT_EQ(0, container.runwayCollection->Count());
+    }
+} // namespace UKControllerPluginTest::Runway

--- a/test/plugin/runway/RunwayTest.cpp
+++ b/test/plugin/runway/RunwayTest.cpp
@@ -1,0 +1,50 @@
+#include "runway/Runway.h"
+
+using UKControllerPlugin::Runway::Runway;
+
+namespace UKControllerPluginTest::Runway {
+    class RunwayTest : public testing::Test
+    {
+        public:
+        RunwayTest() : runway(1, 2, "27L", 123, GetPosition())
+        {
+        }
+
+        class Runway runway;
+
+        private:
+        auto GetPosition() -> EuroScopePlugIn::CPosition
+        {
+            EuroScopePlugIn::CPosition position;
+            position.m_Latitude = 3;
+            position.m_Longitude = 4;
+            return position;
+        }
+    };
+
+    TEST_F(RunwayTest, ItHasAnId)
+    {
+        EXPECT_EQ(1, runway.Id());
+    }
+
+    TEST_F(RunwayTest, ItHasAnAirfieldId)
+    {
+        EXPECT_EQ(2, runway.AirfieldId());
+    }
+
+    TEST_F(RunwayTest, ItHasAnIdentifier)
+    {
+        EXPECT_EQ("27L", runway.Identifier());
+    }
+
+    TEST_F(RunwayTest, ItHasAHeading)
+    {
+        EXPECT_EQ(123, runway.Heading());
+    }
+
+    TEST_F(RunwayTest, ItHasAThreshold)
+    {
+        EXPECT_EQ(3, runway.Threshold().m_Latitude);
+        EXPECT_EQ(4, runway.Threshold().m_Longitude);
+    }
+} // namespace UKControllerPluginTest::Runway

--- a/test/plugin/sectorfile/SectorfileRunwayCollectionTest.cpp
+++ b/test/plugin/sectorfile/SectorfileRunwayCollectionTest.cpp
@@ -16,10 +16,10 @@ using UKControllerPluginTest::SectorFile::MockSectorFileProviderInterface;
 namespace UKControllerPluginTest {
     namespace SectorFile {
 
-        class RunwayCollectionTest : public Test
+        class SectorfileRunwayCollectionTest : public Test
         {
             public:
-            RunwayCollectionTest() : userSetting(mockUserSettings), collection(mockSectorFile)
+            SectorfileRunwayCollectionTest() : userSetting(mockUserSettings), collection(mockSectorFile)
             {
                 element1.reset(new NiceMock<MockEuroscopeSectorFileElementInterface>);
                 element2.reset(new NiceMock<MockEuroscopeSectorFileElementInterface>);
@@ -114,19 +114,19 @@ namespace UKControllerPluginTest {
             RunwayCollection collection;
         };
 
-        TEST_F(RunwayCollectionTest, ItStartsEmpty)
+        TEST_F(SectorfileRunwayCollectionTest, ItStartsEmpty)
         {
             EXPECT_EQ(0, collection.Count());
         }
 
-        TEST_F(RunwayCollectionTest, ItAddsRunwaysOnAsrLoad)
+        TEST_F(SectorfileRunwayCollectionTest, ItAddsRunwaysOnAsrLoad)
         {
             this->SetUpDefaultElements();
             this->collection.AsrLoadedEvent(this->userSetting);
             EXPECT_EQ(4, collection.Count());
         }
 
-        TEST_F(RunwayCollectionTest, ItLoadsRunwayData)
+        TEST_F(SectorfileRunwayCollectionTest, ItLoadsRunwayData)
         {
             this->SetUpDefaultElements();
             this->collection.AsrLoadedEvent(this->userSetting);
@@ -160,14 +160,14 @@ namespace UKControllerPluginTest {
             EXPECT_TRUE(runway08L.ActiveForArrivals());
         }
 
-        TEST_F(RunwayCollectionTest, ItReturnsInvalidIfNotFoundByAirfield)
+        TEST_F(SectorfileRunwayCollectionTest, ItReturnsInvalidIfNotFoundByAirfield)
         {
             this->SetUpDefaultElements();
             this->collection.AsrLoadedEvent(this->userSetting);
             EXPECT_EQ(this->collection.invalidRunway, this->collection.FetchByIdentifierAndAirfield("27L", "EGKK"));
         }
 
-        TEST_F(RunwayCollectionTest, ItUpdatesRunwayActivity)
+        TEST_F(SectorfileRunwayCollectionTest, ItUpdatesRunwayActivity)
         {
             std::shared_ptr<NiceMock<MockEuroscopeSectorFileElementInterface>> element =
                 std::make_shared<NiceMock<MockEuroscopeSectorFileElementInterface>>();

--- a/test/plugin/sectorfile/SectorfileRunwayTest.cpp
+++ b/test/plugin/sectorfile/SectorfileRunwayTest.cpp
@@ -1,8 +1,8 @@
 #include "pch/pch.h"
 #include "sectorfile/Runway.h"
 
-using UKControllerPlugin::SectorFile::Runway;
 using testing::Test;
+using UKControllerPlugin::SectorFile::Runway;
 
 namespace UKControllerPluginTest {
     namespace SectorFile {
@@ -10,12 +10,9 @@ namespace UKControllerPluginTest {
         class SectorfileRunwayTest : public Test
         {
             public:
-
-                SectorfileRunwayTest()
-                    : runway ("EGCC", "23L", 123, false, false)
-                {
-
-                }
+            SectorfileRunwayTest() : runway("EGCC", "23L", 123, false, false)
+            {
+            }
 
             Runway runway;
         };
@@ -52,5 +49,5 @@ namespace UKControllerPluginTest {
             this->runway.SetActiveForArrivals(true);
             EXPECT_TRUE(this->runway.Active());
         }
-    }  // namespace SectorFile
-}  // namespace UKControllerPluginTest
+    } // namespace SectorFile
+} // namespace UKControllerPluginTest

--- a/test/plugin/sectorfile/SectorfileRunwayTest.cpp
+++ b/test/plugin/sectorfile/SectorfileRunwayTest.cpp
@@ -7,11 +7,11 @@ using testing::Test;
 namespace UKControllerPluginTest {
     namespace SectorFile {
 
-        class RunwayTest : public Test
+        class SectorfileRunwayTest : public Test
         {
             public:
 
-                RunwayTest()
+                SectorfileRunwayTest()
                     : runway ("EGCC", "23L", 123, false, false)
                 {
 
@@ -20,7 +20,7 @@ namespace UKControllerPluginTest {
             Runway runway;
         };
 
-        TEST_F(RunwayTest, ItSetsBaseProperties)
+        TEST_F(SectorfileRunwayTest, ItSetsBaseProperties)
         {
             EXPECT_EQ("EGCC", this->runway.airfield);
             EXPECT_EQ("23L", this->runway.identifier);
@@ -29,25 +29,25 @@ namespace UKControllerPluginTest {
             EXPECT_FALSE(this->runway.ActiveForArrivals());
         }
 
-        TEST_F(RunwayTest, ItCanBeMadeActiveForDepartures)
+        TEST_F(SectorfileRunwayTest, ItCanBeMadeActiveForDepartures)
         {
             this->runway.SetActiveForDepartures(true);
             EXPECT_TRUE(this->runway.Active());
         }
 
-        TEST_F(RunwayTest, IsActiveIfActiveForDepartures)
+        TEST_F(SectorfileRunwayTest, IsActiveIfActiveForDepartures)
         {
             this->runway.SetActiveForDepartures(true);
             EXPECT_TRUE(this->runway.Active());
         }
 
-        TEST_F(RunwayTest, ItCanBeMadeActiveForArrivals)
+        TEST_F(SectorfileRunwayTest, ItCanBeMadeActiveForArrivals)
         {
             this->runway.SetActiveForArrivals(true);
             EXPECT_TRUE(this->runway.Active());
         }
 
-        TEST_F(RunwayTest, IsActiveIfActiveForArrivals)
+        TEST_F(SectorfileRunwayTest, IsActiveIfActiveForArrivals)
         {
             this->runway.SetActiveForArrivals(true);
             EXPECT_TRUE(this->runway.Active());

--- a/test/plugin/sid/FlightplanSidMapperTest.cpp
+++ b/test/plugin/sid/FlightplanSidMapperTest.cpp
@@ -1,0 +1,72 @@
+#include "airfield/AirfieldCollection.h"
+#include "airfield/AirfieldModel.h"
+#include "controller/ControllerPositionHierarchy.h"
+#include "runway/Runway.h"
+#include "runway/RunwayCollection.h"
+#include "sid/FlightplanSidMapper.h"
+#include "sid/SidCollection.h"
+#include "sid/StandardInstrumentDeparture.h"
+
+using ::testing::Test;
+using UKControllerPlugin::Airfield::AirfieldCollection;
+using UKControllerPlugin::Airfield::AirfieldModel;
+using UKControllerPlugin::Prenote::PairedAirfieldPrenote;
+using UKControllerPlugin::Runway::Runway;
+using UKControllerPlugin::Runway::RunwayCollection;
+using UKControllerPlugin::Sid::FlightplanSidMapper;
+using UKControllerPlugin::Sid::SidCollection;
+using UKControllerPlugin::Sid::StandardInstrumentDeparture;
+
+namespace UKControllerPluginTest::Sid {
+
+    class FlightplanSidMapperTest : public Test
+    {
+        public:
+        FlightplanSidMapperTest() : mapper(airfields, runways, sids)
+        {
+            this->airfields.AddAirfield(std::make_shared<AirfieldModel>(
+                2, "EGLL", nullptr, std::vector<std::shared_ptr<PairedAirfieldPrenote>>{}, 1));
+            EuroScopePlugIn::CPosition threshold;
+            threshold.m_Latitude = 1;
+            threshold.m_Latitude = 2;
+            this->runways.Add(std::make_shared<class Runway>(2, 2, "27L", 123, threshold));
+            this->sids.AddSid(std::make_shared<StandardInstrumentDeparture>(1, 1, "TEST1A", 1, 2, 3));
+            this->sids.AddSid(std::make_shared<StandardInstrumentDeparture>(2, 2, "TEST1B", 3, 4, 5));
+
+            ON_CALL(mockFlightplan, GetOrigin()).WillByDefault(testing::Return("EGLL"));
+
+            ON_CALL(mockFlightplan, GetDepartureRunway()).WillByDefault(testing::Return("27L"));
+
+            ON_CALL(mockFlightplan, GetSidName()).WillByDefault(testing::Return("TEST1B"));
+        }
+
+        testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface> mockFlightplan;
+        AirfieldCollection airfields;
+        RunwayCollection runways;
+        SidCollection sids;
+        FlightplanSidMapper mapper;
+    };
+
+    TEST_F(FlightplanSidMapperTest, ItMapsFlightplansToSids)
+    {
+        EXPECT_EQ(this->sids.GetById(2), this->mapper.MapFlightplanToSid(mockFlightplan));
+    }
+
+    TEST_F(FlightplanSidMapperTest, ItReturnsNullptrIfSidNotFound)
+    {
+        ON_CALL(mockFlightplan, GetSidName()).WillByDefault(testing::Return("TEST1C"));
+        EXPECT_EQ(nullptr, this->mapper.MapFlightplanToSid(mockFlightplan));
+    }
+
+    TEST_F(FlightplanSidMapperTest, ItReturnsNullptrIfRunwayNotFound)
+    {
+        ON_CALL(mockFlightplan, GetDepartureRunway()).WillByDefault(testing::Return("27R"));
+        EXPECT_EQ(nullptr, this->mapper.MapFlightplanToSid(mockFlightplan));
+    }
+
+    TEST_F(FlightplanSidMapperTest, ItReturnsNullptrIfAirfieldNotFound)
+    {
+        ON_CALL(mockFlightplan, GetOrigin()).WillByDefault(testing::Return("EGKK"));
+        EXPECT_EQ(nullptr, this->mapper.MapFlightplanToSid(mockFlightplan));
+    }
+} // namespace UKControllerPluginTest::Sid

--- a/test/plugin/sid/SidCollectionFactoryTest.cpp
+++ b/test/plugin/sid/SidCollectionFactoryTest.cpp
@@ -18,14 +18,17 @@ namespace UKControllerPluginTest::Sid {
     {
         nlohmann::json sidData = nlohmann::json::array(
             {nlohmann::json::object(
-                 {{"airfield", "EGGD"},
+                 {{"id", 1},
+                  {"runway_id", 1},
                   {"identifier", "TEST1Y"},
                   {"initial_altitude", 6000},
                   {"initial_heading", 350},
                   {"handoff", 5},
                   {"prenotes", nlohmann::json::array({1, 2})}}),
              nlohmann::json::object(
-                 {{"airfield", "EGGD"},
+
+                 {{"id", 1},
+                  {"runway_id", 2},
                   {"identifier", "TEST1Y"},
                   {"initial_altitude", 6000},
                   {"initial_heading", nlohmann::json::value_t::null},
@@ -35,7 +38,34 @@ namespace UKControllerPluginTest::Sid {
         EXPECT_TRUE(SidDataValid(sidData));
     }
 
-    TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseNoAirfield)
+    TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseNoId)
+    {
+        nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
+            {{"runway_id", 2},
+             {"identifier", "TEST1Y"},
+             {"initial_altitude", 6000},
+             {"initial_heading", nlohmann::json::value_t::null},
+             {"handoff", 5},
+             {"prenotes", nlohmann::json::array({1, 2})}})});
+
+        EXPECT_FALSE(SidDataValid(sidData));
+    }
+
+    TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseIdNotInteger)
+    {
+        nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
+            {{"id", "abc"},
+             {"runway_id", 2},
+             {"identifier", "TEST1Y"},
+             {"initial_altitude", 6000},
+             {"initial_heading", nlohmann::json::value_t::null},
+             {"handoff", 5},
+             {"prenotes", nlohmann::json::array({1, 2})}})});
+
+        EXPECT_FALSE(SidDataValid(sidData));
+    }
+
+    TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseNoRunway)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
             {{"identifier", "TEST1Y"},
@@ -47,10 +77,10 @@ namespace UKControllerPluginTest::Sid {
         EXPECT_FALSE(SidDataValid(sidData));
     }
 
-    TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseInvalidAirfield)
+    TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseInvalidRunwayId)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", 123},
+            {{"runway_id", "abc"},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"initial_heading", nlohmann::json::value_t::null},
@@ -63,7 +93,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseNoIdentifier)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"initial_altitude", 6000},
              {"initial_heading", nlohmann::json::value_t::null},
              {"handoff", 5},
@@ -75,7 +105,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseInvalidIdentifier)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", 123},
              {"initial_altitude", 6000},
              {"initial_heading", nlohmann::json::value_t::null},
@@ -88,7 +118,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseNoInitialAltitude)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_heading", nlohmann::json::value_t::null},
              {"handoff", 5},
@@ -100,7 +130,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseInvalidInitialAltitude)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", "6000"},
              {"initial_heading", nlohmann::json::value_t::null},
@@ -113,7 +143,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseNoInitialHeading)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"handoff", 5},
@@ -125,7 +155,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseInvalidInitialHeading)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"initial_heading", "abc"},
@@ -138,7 +168,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseInitialHeadingTooSmall)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"initial_heading", 0},
@@ -151,7 +181,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseInitialHeadingTooBig)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"initial_heading", 361},
@@ -164,7 +194,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseNoHandoffId)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"initial_heading", 15},
@@ -176,7 +206,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalseHandoffIdInvalid)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"initial_heading", 15},
@@ -189,7 +219,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalsePrenotesMissing)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object({
-            {"airfield", "EGGD"},
+            {"runway_id", 1},
             {"identifier", "TEST1Y"},
             {"initial_altitude", 6000},
             {"initial_heading", 15},
@@ -202,7 +232,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalsePrenotesNotArray)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"initial_heading", 15},
@@ -215,7 +245,7 @@ namespace UKControllerPluginTest::Sid {
     TEST_F(SidCollectionFactoryTest, SidDataValidReturnsFalsePrenoteNotInteger)
     {
         nlohmann::json sidData = nlohmann::json::array({nlohmann::json::object(
-            {{"airfield", "EGGD"},
+            {{"runway_id", 1},
              {"identifier", "TEST1Y"},
              {"initial_altitude", 6000},
              {"initial_heading", 15},
@@ -239,7 +269,7 @@ namespace UKControllerPluginTest::Sid {
                   {"initial_heading", 350},
                   {"prenotes", nlohmann::json::array({1, 2})}}),
              nlohmann::json::object(
-                 {{"airfield", "EGGD"},
+                 {{"runway_id", 1},
                   {"identifier", "TEST1Y"},
                   {"initial_altitude", 6000},
                   {"initial_heading", nlohmann::json::value_t::null},
@@ -253,14 +283,16 @@ namespace UKControllerPluginTest::Sid {
     {
         nlohmann::json sidData = nlohmann::json::array(
             {nlohmann::json::object(
-                 {{"airfield", "EGGD"},
+                 {{"id", 1},
+                  {"runway_id", 1},
                   {"identifier", "TEST1Y"},
                   {"initial_altitude", 6000},
                   {"initial_heading", 350},
                   {"handoff", 55},
                   {"prenotes", nlohmann::json::array({1, 2})}}),
              nlohmann::json::object(
-                 {{"airfield", "EGLL"},
+                 {{"id", 2},
+                  {"runway_id", 2},
                   {"identifier", "TEST1Z"},
                   {"initial_altitude", 5000},
                   {"initial_heading", nlohmann::json::value_t::null},
@@ -269,16 +301,18 @@ namespace UKControllerPluginTest::Sid {
 
         std::unique_ptr<SidCollection> collection = MakeSidCollection(sidData);
         EXPECT_EQ(2, collection->CountSids());
-        std::shared_ptr<StandardInstrumentDeparture> sid1 = collection->GetByAirfieldAndIdentifier("EGGD", "TEST1Y");
-        EXPECT_EQ("EGGD", sid1->Airfield());
+        std::shared_ptr<StandardInstrumentDeparture> sid1 = collection->GetByRunwayIdAndIdentifier(1, "TEST1Y");
+        EXPECT_EQ(1, sid1->Id());
+        EXPECT_EQ(1, sid1->RunwayId());
         EXPECT_EQ("TEST1Y", sid1->Identifier());
         EXPECT_EQ(6000, sid1->InitialAltitude());
         EXPECT_EQ(350, sid1->InitialHeading());
         EXPECT_EQ(55, sid1->HandoffId());
         EXPECT_EQ(std::set<int>({1, 2}), sid1->Prenotes());
 
-        std::shared_ptr<StandardInstrumentDeparture> sid2 = collection->GetByAirfieldAndIdentifier("EGLL", "TEST1Z");
-        EXPECT_EQ("EGLL", sid2->Airfield());
+        std::shared_ptr<StandardInstrumentDeparture> sid2 = collection->GetByRunwayIdAndIdentifier(2, "TEST1Z");
+        EXPECT_EQ(2, sid2->Id());
+        EXPECT_EQ(2, sid2->RunwayId());
         EXPECT_EQ("TEST1Z", sid2->Identifier());
         EXPECT_EQ(5000, sid2->InitialAltitude());
         EXPECT_EQ(0, sid2->InitialHeading());

--- a/test/plugin/sid/SidCollectionTest.cpp
+++ b/test/plugin/sid/SidCollectionTest.cpp
@@ -1,6 +1,5 @@
 #include "sid/SidCollection.h"
 #include "sid/StandardInstrumentDeparture.h"
-#include "memory"
 
 using ::testing::Test;
 using UKControllerPlugin::Sid::SidCollection;
@@ -13,9 +12,9 @@ namespace UKControllerPluginTest::Sid {
         public:
         SidCollectionTest()
         {
-            this->sid1 = std::make_shared<StandardInstrumentDeparture>("EGLL", "TEST1A", 1, 2, 3);
-            this->sid2 = std::make_shared<StandardInstrumentDeparture>("EGLL", "TEST1B", 3, 4, 5);
-            this->sid3 = std::make_shared<StandardInstrumentDeparture>("EGBB", "TEST1A", 5, 6, 7);
+            this->sid1 = std::make_shared<StandardInstrumentDeparture>(1, 1, "TEST1A", 1, 2, 3);
+            this->sid2 = std::make_shared<StandardInstrumentDeparture>(2, 1, "TEST1B", 3, 4, 5);
+            this->sid3 = std::make_shared<StandardInstrumentDeparture>(3, 2, "TEST1A", 5, 6, 7);
         }
 
         std::shared_ptr<StandardInstrumentDeparture> sid1;
@@ -50,7 +49,7 @@ namespace UKControllerPluginTest::Sid {
         this->sids.AddSid(this->sid1);
         this->sids.AddSid(this->sid2);
         this->sids.AddSid(this->sid3);
-        EXPECT_EQ(nullptr, this->sids.GetByAirfieldAndIdentifier("EGLL", "TEST1X"));
+        EXPECT_EQ(nullptr, this->sids.GetByRunwayIdAndIdentifier(1, "TEST1X"));
     }
 
     TEST_F(SidCollectionTest, ItReturnsASid)
@@ -58,7 +57,7 @@ namespace UKControllerPluginTest::Sid {
         this->sids.AddSid(this->sid1);
         this->sids.AddSid(this->sid2);
         this->sids.AddSid(this->sid3);
-        EXPECT_EQ(this->sid2, this->sids.GetByAirfieldAndIdentifier("EGLL", "TEST1B"));
+        EXPECT_EQ(this->sid2, this->sids.GetByRunwayIdAndIdentifier(1, "TEST1B"));
     }
 
     TEST_F(SidCollectionTest, ItReturnsASidHandlingDeprecationsInTheSectorfile)
@@ -66,7 +65,7 @@ namespace UKControllerPluginTest::Sid {
         this->sids.AddSid(this->sid1);
         this->sids.AddSid(this->sid2);
         this->sids.AddSid(this->sid3);
-        EXPECT_EQ(this->sid2, this->sids.GetByAirfieldAndIdentifier("EGLL", "#TEST1B"));
+        EXPECT_EQ(this->sid2, this->sids.GetByRunwayIdAndIdentifier(1, "#TEST1B"));
     }
 
     TEST_F(SidCollectionTest, ItReturnsNullPtrIfNoEuroscopeSid)
@@ -74,34 +73,22 @@ namespace UKControllerPluginTest::Sid {
         this->sids.AddSid(this->sid1);
         this->sids.AddSid(this->sid2);
         this->sids.AddSid(this->sid3);
-        EXPECT_EQ(nullptr, this->sids.GetByAirfieldAndIdentifier("EGLL", ""));
+        EXPECT_EQ(nullptr, this->sids.GetByRunwayIdAndIdentifier(1, ""));
     }
 
-    TEST_F(SidCollectionTest, ItReturnsASidByFlightplan)
+    TEST_F(SidCollectionTest, ItReturnsASidById)
     {
-        testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface> mockFlightplan;
-
-        ON_CALL(mockFlightplan, GetOrigin).WillByDefault(testing::Return("EGLL"));
-
-        ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("TEST1B"));
-
         this->sids.AddSid(this->sid1);
         this->sids.AddSid(this->sid2);
         this->sids.AddSid(this->sid3);
-        EXPECT_EQ(this->sid2, this->sids.GetForFlightplan(mockFlightplan));
+        EXPECT_EQ(this->sid2, this->sids.GetById(2));
     }
 
-    TEST_F(SidCollectionTest, ItReturnsNullptrIfSidNotFoundByFlightplan)
+    TEST_F(SidCollectionTest, ItReturnsNullptrIfSidNotFoundById)
     {
-        testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface> mockFlightplan;
-
-        ON_CALL(mockFlightplan, GetOrigin).WillByDefault(testing::Return("EGLL"));
-
-        ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("TEST1Z"));
-
         this->sids.AddSid(this->sid1);
         this->sids.AddSid(this->sid2);
         this->sids.AddSid(this->sid3);
-        EXPECT_EQ(nullptr, this->sids.GetForFlightplan(mockFlightplan));
+        EXPECT_EQ(nullptr, this->sids.GetById(55));
     }
 } // namespace UKControllerPluginTest::Sid

--- a/test/plugin/sid/SidModuleTest.cpp
+++ b/test/plugin/sid/SidModuleTest.cpp
@@ -22,7 +22,8 @@ namespace UKControllerPluginTest::Sid {
     {
         nlohmann::json sidData = nlohmann::json::array(
             {nlohmann::json::object({
-                 {"airfield", "EGGD"},
+                 {"id", 1},
+                 {"runway_id", 2},
                  {"identifier", "TEST1Y"},
                  {"initial_altitude", 6000},
                  {"initial_heading", 350},
@@ -30,8 +31,9 @@ namespace UKControllerPluginTest::Sid {
                  {"prenotes", nlohmann::json::array({1, 2})},
              }),
              nlohmann::json::object(
-                 {{"airfield", "EGGD"},
-                  {"identifier", "TEST1Y"},
+                 {{"id", 2},
+                  {"runway_id", 2},
+                  {"identifier", "TEST1Z"},
                   {"initial_altitude", 6000},
                   {"initial_heading", nlohmann::json::value_t::null},
                   {"handoff", 5},
@@ -43,5 +45,11 @@ namespace UKControllerPluginTest::Sid {
 
         BootstrapPlugin(container, dependencyLoader);
         EXPECT_EQ(2, container.sids->CountSids());
+    }
+
+    TEST_F(SidModuleTest, ItSetsMapperOnContainer)
+    {
+        BootstrapPlugin(container, dependencyLoader);
+        EXPECT_NE(nullptr, container.sidMapper);
     }
 } // namespace UKControllerPluginTest::Sid

--- a/test/plugin/sid/StandardInstrumentDepartureTest.cpp
+++ b/test/plugin/sid/StandardInstrumentDepartureTest.cpp
@@ -9,7 +9,7 @@ namespace UKControllerPluginTest::Sid {
     {
         public:
         StandardInstrumentDepartureTest()
-            : sid("EGGD", "WOTAN1Z", 6000, 55, 3, {1, 2}), sidWithDefaults("EGGD", "WOTAN1Z", 6000, 55, 3)
+            : sid(1, 2, "WOTAN1Z", 6000, 55, 3, {1, 2}), sidWithDefaults(2, 2, "WOTAN1Z", 6000, 55, 3)
         {
         }
 
@@ -17,9 +17,14 @@ namespace UKControllerPluginTest::Sid {
         StandardInstrumentDeparture sidWithDefaults;
     };
 
-    TEST_F(StandardInstrumentDepartureTest, ItHasAnAirfield)
+    TEST_F(StandardInstrumentDepartureTest, ItHasANId)
     {
-        EXPECT_EQ("EGGD", sid.Airfield());
+        EXPECT_EQ(1, sid.Id());
+    }
+
+    TEST_F(StandardInstrumentDepartureTest, ItHasARunwayId)
+    {
+        EXPECT_EQ(2, sid.RunwayId());
     }
 
     TEST_F(StandardInstrumentDepartureTest, ItHasAnIdentifier)
@@ -49,7 +54,7 @@ namespace UKControllerPluginTest::Sid {
 
     TEST_F(StandardInstrumentDepartureTest, ItDoesntHaveAHandoff)
     {
-        StandardInstrumentDeparture sid2("EGGD", "WOTAN1Z", 6000, 55, 0);
+        StandardInstrumentDeparture sid2(3, 3, "WOTAN1Z", 6000, 55, 0);
         EXPECT_FALSE(sid2.HasHandoff());
     }
 


### PR DESCRIPTION
At the moment, the sectorfile team have to declare some SIDs with unique identifiers where they would normally have the same identifier but different parameters so the plugin can tell them apart for initial altitudes. The plugin matches SIDs by airfield and identifier.

This changes the SID matching algorithm to take runways into account.

Resolves #401 