### PR TITLE
fix(intentioncode): add GOREV as exit fix for K2 intention code

### DIFF
--- a/src/plugin/intention/SectorExitRepositoryFactory.cpp
+++ b/src/plugin/intention/SectorExitRepositoryFactory.cpp
@@ -43,6 +43,8 @@ namespace UKControllerPlugin {
                 "VAXIT", "K1", SectorExitPoint::outEast | SectorExitPoint::outNorthEast);
             points["TINAC"] = std::make_unique<SectorExitPoint>(
                 "TINAC", "K2", SectorExitPoint::outEast | SectorExitPoint::outNorthEast);
+            points["GOREV"] = std::make_unique<SectorExitPoint>(
+                "GOREV", "K2", SectorExitPoint::outEast | SectorExitPoint::outNorthEast);
             points["PETIL"] = std::make_unique<SectorExitPoint>(
                 "PETIL", "K2", SectorExitPoint::outEast | SectorExitPoint::outNorthEast);
             points["INBOB"] = std::make_unique<SectorExitPoint>(

--- a/test/plugin/intention/SectorExitRepositoryTest.cpp
+++ b/test/plugin/intention/SectorExitRepositoryTest.cpp
@@ -106,8 +106,8 @@ namespace UKControllerPluginTest {
             ASSERT_TRUE(repo->GetSectorExitPoint("TINAC").GetName().compare("TINAC") == 0);
             ASSERT_TRUE(repo->GetSectorExitPoint("TINAC").GetIntentionCode(mockRoute, 0, 37000).compare("K2") == 0);
             ASSERT_EQ(repo->outEast | repo->outNorthEast, repo->GetSectorExitPoint("TINAC").GetOutDirection());
-			
-			// GOREV
+
+            // GOREV
             ASSERT_TRUE(repo->GetSectorExitPoint("GOREV").GetName().compare("GOREV") == 0);
             ASSERT_TRUE(repo->GetSectorExitPoint("GOREV").GetIntentionCode(mockRoute, 0, 37000).compare("K2") == 0);
             ASSERT_EQ(repo->outEast | repo->outNorthEast, repo->GetSectorExitPoint("GOREV").GetOutDirection());

--- a/test/plugin/intention/SectorExitRepositoryTest.cpp
+++ b/test/plugin/intention/SectorExitRepositoryTest.cpp
@@ -106,6 +106,11 @@ namespace UKControllerPluginTest {
             ASSERT_TRUE(repo->GetSectorExitPoint("TINAC").GetName().compare("TINAC") == 0);
             ASSERT_TRUE(repo->GetSectorExitPoint("TINAC").GetIntentionCode(mockRoute, 0, 37000).compare("K2") == 0);
             ASSERT_EQ(repo->outEast | repo->outNorthEast, repo->GetSectorExitPoint("TINAC").GetOutDirection());
+			
+			// GOREV
+            ASSERT_TRUE(repo->GetSectorExitPoint("GOREV").GetName().compare("GOREV") == 0);
+            ASSERT_TRUE(repo->GetSectorExitPoint("GOREV").GetIntentionCode(mockRoute, 0, 37000).compare("K2") == 0);
+            ASSERT_EQ(repo->outEast | repo->outNorthEast, repo->GetSectorExitPoint("GOREV").GetOutDirection());
 
             // PETIL
             ASSERT_TRUE(repo->GetSectorExitPoint("PETIL").GetName().compare("PETIL") == 0);


### PR DESCRIPTION
K2 is for TYNE exit - GOREV is between TINAC and PETIL so also K2