### PR TITLE
fix(pressuremonitor): Trigger pressure monitor updates correctly

### DIFF
--- a/src/plugin/metar/MetarModule.cpp
+++ b/src/plugin/metar/MetarModule.cpp
@@ -27,8 +27,8 @@ namespace UKControllerPlugin::Metar {
         container.metarEventHandler = std::make_unique<MetarEventHandlerCollection>();
 
         // Handle all the push events for METARs
-        container.pushEventProcessors->AddProcessor(
-            std::make_shared<MetarsUpdatedPushEventProcessor>(*parsedMetars, *parsedMetarFactory, *container.api));
+        container.pushEventProcessors->AddProcessor(std::make_shared<MetarsUpdatedPushEventProcessor>(
+            *parsedMetars, *parsedMetarFactory, *container.api, *container.metarEventHandler));
 
         // Handler for the pressure query command
         container.commandHandlers->RegisterHandler(

--- a/src/plugin/metar/MetarsUpdatedPushEventProcessor.cpp
+++ b/src/plugin/metar/MetarsUpdatedPushEventProcessor.cpp
@@ -1,3 +1,4 @@
+#include "MetarEventHandlerCollection.h"
 #include "MetarsUpdatedPushEventProcessor.h"
 #include "ParsedMetarCollection.h"
 #include "ParsedMetar.h"
@@ -9,8 +10,11 @@
 namespace UKControllerPlugin::Metar {
 
     MetarsUpdatedPushEventProcessor::MetarsUpdatedPushEventProcessor(
-        ParsedMetarCollection& metars, const ParsedMetarFactory& factory, const Api::ApiInterface& api)
-        : metars(metars), factory(factory), api(api)
+        ParsedMetarCollection& metars,
+        const ParsedMetarFactory& factory,
+        const Api::ApiInterface& api,
+        const MetarEventHandlerCollection& eventHandlers)
+        : metars(metars), factory(factory), api(api), eventHandlers(eventHandlers)
     {
     }
 
@@ -54,6 +58,7 @@ namespace UKControllerPlugin::Metar {
             }
 
             metars.UpdateMetar(parsed);
+            eventHandlers.UpdatedMetarEvent(*parsed);
             LogInfo("Received updated METAR: " + parsed->Raw());
         }
     }

--- a/src/plugin/metar/MetarsUpdatedPushEventProcessor.h
+++ b/src/plugin/metar/MetarsUpdatedPushEventProcessor.h
@@ -6,6 +6,7 @@ namespace UKControllerPlugin::Api {
 } // namespace UKControllerPlugin::Api
 
 namespace UKControllerPlugin::Metar {
+    class MetarEventHandlerCollection;
     class ParsedMetarCollection;
     class ParsedMetarFactory;
 
@@ -16,7 +17,10 @@ namespace UKControllerPlugin::Metar {
     {
         public:
         MetarsUpdatedPushEventProcessor(
-            ParsedMetarCollection& metars, const ParsedMetarFactory& factory, const Api::ApiInterface& api);
+            ParsedMetarCollection& metars,
+            const ParsedMetarFactory& factory,
+            const Api::ApiInterface& api,
+            const MetarEventHandlerCollection& eventHandlers);
         void ProcessPushEvent(const Push::PushEvent& message) override;
         [[nodiscard]] auto GetPushEventSubscriptions() const -> std::set<Push::PushEventSubscription> override;
         void PluginEventsSynced() override;
@@ -32,6 +36,9 @@ namespace UKControllerPlugin::Metar {
 
         // The API for pulling all METAR updates
         const Api::ApiInterface& api;
+
+        // Things that care about knowing when METARS update
+        const MetarEventHandlerCollection& eventHandlers;
     };
 
 } // namespace UKControllerPlugin::Metar

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -241,7 +241,7 @@ set(test__metar
     metar/MetarModuleTest.cpp
     metar/PressureQueryMessageTest.cpp
     metar/PressureNotFoundMessageTest.cpp
-    metar/PressureQueryCommandHandlerTest.cpp)
+    metar/PressureQueryCommandHandlerTest.cpp mock/MockMetarEventHandler.h)
 source_group("test\\metar" FILES ${test__metar})
 
 set(test__minstack

--- a/test/plugin/mock/MockMetarEventHandler.h
+++ b/test/plugin/mock/MockMetarEventHandler.h
@@ -1,0 +1,12 @@
+#include "metar/MetarEventHandlerInterface.h"
+
+using UKControllerPlugin::Metar::MetarEventHandlerInterface;
+using UKControllerPlugin::Metar::ParsedMetar;
+
+namespace UKControllerPluginTest::Metar {
+    class MockMetarEventHandler : public MetarEventHandlerInterface
+    {
+        public:
+        MOCK_METHOD(void, MetarUpdated, (const ParsedMetar&), (override));
+    };
+} // namespace UKControllerPluginTest::Metar

--- a/test/plugin/pch/pch.h
+++ b/test/plugin/pch/pch.h
@@ -40,6 +40,7 @@
 #include "../mock/MockHistoryTrailDialog.h"
 #include "../mock/MockHistoryTrailRepository.h"
 #include "../mock/MockIntegrationActionProcessor.h"
+#include "../mock/MockMetarEventHandler.h"
 #include "../mock/MockOutboundIntegrationEventHandler.h"
 #include "../mock/MockPushEventConnection.h"
 #include "../mock/MockPushEventProcessor.h"


### PR DESCRIPTION
Previously, the metar events weren't hooked up properly so the pressure
monitor wasn't firing. This fixes that.

Fix #409