### PR TITLE
fix(handoffs): Handoffs not repopulating when controllers log on

### DIFF
--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -242,7 +242,7 @@ set(src__handoff
     "handoff/HandoffModule.cpp"
     "handoff/HandoffModule.h"
     controller/HandoffEventHandler.cpp
-    handoff/HandoffOrder.h handoff/HandoffOrder.cpp handoff/FlightplanSidHandoffMapper.cpp handoff/FlightplanSidHandoffMapper.h handoff/HandoffCache.cpp handoff/HandoffCache.h handoff/DepartureHandoffResolver.cpp handoff/DepartureHandoffResolver.h handoff/FlightplanAirfieldHandoffMapper.cpp handoff/FlightplanAirfieldHandoffMapper.h)
+    handoff/HandoffOrder.h handoff/HandoffOrder.cpp handoff/FlightplanSidHandoffMapper.cpp handoff/FlightplanSidHandoffMapper.h handoff/HandoffCache.cpp handoff/HandoffCache.h handoff/DepartureHandoffResolver.cpp handoff/DepartureHandoffResolver.h handoff/FlightplanAirfieldHandoffMapper.cpp handoff/FlightplanAirfieldHandoffMapper.h handoff/ClearCacheOnActiveCallsignChanges.cpp handoff/ClearCacheOnActiveCallsignChanges.h)
 source_group("src\\handoff" FILES ${src__handoff})
 
 set(src__headings headings/Heading.h headings/Heading.cpp)

--- a/src/plugin/controller/ControllerPositionHierarchy.cpp
+++ b/src/plugin/controller/ControllerPositionHierarchy.cpp
@@ -7,7 +7,7 @@ namespace UKControllerPlugin::Controller {
     /*
         Adds a position to the hierarchy.
     */
-    void ControllerPositionHierarchy::AddPosition(const std::shared_ptr<const ControllerPosition>& position)
+    void ControllerPositionHierarchy::AddPosition(std::shared_ptr<ControllerPosition> position)
     {
         this->positions.push_back(position);
     }
@@ -54,5 +54,26 @@ namespace UKControllerPlugin::Controller {
         }
 
         return true;
+    }
+
+    /**
+     * Does the position in a given hierarchy preceed another.
+     *
+     * If the position is not in the hierarchy, then the answer is no, it does not.
+     */
+    auto ControllerPositionHierarchy::PositionPreceeds(
+        const ControllerPosition& position, const ControllerPosition& preceeds) const -> bool
+    {
+        for (const auto& hierarchyPosition : this->positions) {
+            if (*hierarchyPosition == position) {
+                return true;
+            }
+
+            if (*hierarchyPosition == preceeds) {
+                return false;
+            }
+        }
+
+        return false;
     }
 } // namespace UKControllerPlugin::Controller

--- a/src/plugin/controller/ControllerPositionHierarchy.h
+++ b/src/plugin/controller/ControllerPositionHierarchy.h
@@ -10,15 +10,18 @@ namespace UKControllerPlugin::Controller {
     {
         public:
         ControllerPositionHierarchy() = default;
-        void AddPosition(const std::shared_ptr<const ControllerPosition>& position);
+        void AddPosition(std::shared_ptr<ControllerPosition> position);
         [[nodiscard]] auto CountPositions() const -> size_t;
         [[nodiscard]] auto PositionInHierarchy(const UKControllerPlugin::Controller::ControllerPosition& position) const
             -> bool;
+        [[nodiscard]] auto PositionPreceeds(
+            const UKControllerPlugin::Controller::ControllerPosition& position,
+            const UKControllerPlugin::Controller::ControllerPosition& preceeds) const -> bool;
         [[nodiscard]] auto operator==(const UKControllerPlugin::Controller::ControllerPositionHierarchy& compare) const
             -> bool;
 
         // Public type definitions for a custom iterator over the class.
-        using PositionHierarchy = std::list<std::shared_ptr<const ControllerPosition>>;
+        using PositionHierarchy = std::list<std::shared_ptr<ControllerPosition>>;
         using const_iterator = PositionHierarchy::const_iterator;
         [[nodiscard]] const_iterator begin() const
         {

--- a/src/plugin/handoff/ClearCacheOnActiveCallsignChanges.cpp
+++ b/src/plugin/handoff/ClearCacheOnActiveCallsignChanges.cpp
@@ -28,8 +28,16 @@ namespace UKControllerPlugin::Handoff {
             }
 
             /*
+             * If the resolved controller isn't int he SID hierarchy, but the controller logging on is, then
+             * this takes precedence.
+             */
+            if (handoff->sidHierarchy->PositionInHierarchy(callsign.GetNormalisedPosition())) {
+                return true;
+            }
+
+            /*
              * If the resolved controller is in the airfield fallback hierarchy, then the controller coming online must
-             * preceed it in that.
+             * preceed them in that.
              */
             if (handoff->airfieldHierarchy->PositionInHierarchy(*handoff->resolvedController)) {
                 return handoff->airfieldHierarchy->PositionPreceeds(
@@ -38,10 +46,10 @@ namespace UKControllerPlugin::Handoff {
 
             /*
              * Finally, if the resolved controller isn't from a hierarchy, it must be unicom.
-             * Therefore, we need to evict from cache if the controller coming online is in either hierarchy.
+             *
+             * The last check here is to see if the controller in question is in the airfield hierarchy.
              */
-            return handoff->sidHierarchy->PositionInHierarchy(callsign.GetNormalisedPosition()) ||
-                   handoff->airfieldHierarchy->PositionInHierarchy(callsign.GetNormalisedPosition());
+            return handoff->airfieldHierarchy->PositionInHierarchy(callsign.GetNormalisedPosition());
         });
     }
 

--- a/src/plugin/handoff/ClearCacheOnActiveCallsignChanges.cpp
+++ b/src/plugin/handoff/ClearCacheOnActiveCallsignChanges.cpp
@@ -1,0 +1,66 @@
+#include "ClearCacheOnActiveCallsignChanges.h"
+#include "HandoffCache.h"
+#include "ResolvedHandoff.h"
+#include "controller/ActiveCallsign.h"
+#include "controller/ControllerPosition.h"
+#include "controller/ControllerPositionHierarchy.h"
+
+namespace UKControllerPlugin::Handoff {
+
+    ClearCacheOnActiveCallsignChanges::ClearCacheOnActiveCallsignChanges(HandoffCache& cache) : cache(cache)
+    {
+    }
+
+    /**
+     * When new controllers come online, we need to evict from the cache any controller who preceeds them
+     * in the hierarchy.
+     */
+    void ClearCacheOnActiveCallsignChanges::ActiveCallsignAdded(const Controller::ActiveCallsign& callsign)
+    {
+        this->cache.DeleteWhere([&callsign](const std::shared_ptr<ResolvedHandoff>& handoff) -> bool {
+            /*
+             * The SID hierarchy has the highest priority. So if the resolved controller is from the SIDs hierarchy,
+             * then the controller coming online must preceed it.
+             */
+            if (handoff->sidHierarchy->PositionInHierarchy(*handoff->resolvedController)) {
+                return handoff->sidHierarchy->PositionPreceeds(
+                    callsign.GetNormalisedPosition(), *handoff->resolvedController);
+            }
+
+            /*
+             * If the resolved controller is in the airfield fallback hierarchy, then the controller coming online must
+             * preceed it in that.
+             */
+            if (handoff->airfieldHierarchy->PositionInHierarchy(*handoff->resolvedController)) {
+                return handoff->airfieldHierarchy->PositionPreceeds(
+                    callsign.GetNormalisedPosition(), *handoff->resolvedController);
+            }
+
+            /*
+             * Finally, if the resolved controller isn't from a hierarchy, it must be unicom.
+             * Therefore, we need to evict from cache if the controller coming online is in either hierarchy.
+             */
+            return handoff->sidHierarchy->PositionInHierarchy(callsign.GetNormalisedPosition()) ||
+                   handoff->airfieldHierarchy->PositionInHierarchy(callsign.GetNormalisedPosition());
+        });
+    }
+
+    /**
+     * If we have a controller that logs off, we only need to evict from the cache instances where
+     * this controller is the resolved controller.
+     */
+    void ClearCacheOnActiveCallsignChanges::ActiveCallsignRemoved(const Controller::ActiveCallsign& callsign)
+    {
+        this->cache.DeleteWhere([&callsign](const std::shared_ptr<ResolvedHandoff>& handoff) -> bool {
+            return *handoff->resolvedController == callsign.GetNormalisedPosition();
+        });
+    }
+
+    /**
+     * If we lose track of who's online alltogether, time to clear the cache.
+     */
+    void ClearCacheOnActiveCallsignChanges::CallsignsFlushed()
+    {
+        this->cache.Clear();
+    }
+} // namespace UKControllerPlugin::Handoff

--- a/src/plugin/handoff/ClearCacheOnActiveCallsignChanges.h
+++ b/src/plugin/handoff/ClearCacheOnActiveCallsignChanges.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "controller/ActiveCallsignEventHandlerInterface.h"
+
+namespace UKControllerPlugin::Handoff {
+    class HandoffCache;
+    
+    class ClearCacheOnActiveCallsignChanges : public Controller::ActiveCallsignEventHandlerInterface
+    {
+        public:
+        ClearCacheOnActiveCallsignChanges(HandoffCache& cache);
+        void ActiveCallsignAdded(const Controller::ActiveCallsign& callsign) override;
+        void ActiveCallsignRemoved(const Controller::ActiveCallsign& callsign) override;
+        void CallsignsFlushed() override;
+
+        private:
+        
+        // The cache to clear
+        HandoffCache& cache;
+    };
+} //

--- a/src/plugin/handoff/ClearCacheOnActiveCallsignChanges.h
+++ b/src/plugin/handoff/ClearCacheOnActiveCallsignChanges.h
@@ -3,7 +3,7 @@
 
 namespace UKControllerPlugin::Handoff {
     class HandoffCache;
-    
+
     class ClearCacheOnActiveCallsignChanges : public Controller::ActiveCallsignEventHandlerInterface
     {
         public:
@@ -13,8 +13,7 @@ namespace UKControllerPlugin::Handoff {
         void CallsignsFlushed() override;
 
         private:
-        
         // The cache to clear
         HandoffCache& cache;
     };
-} //
+} // namespace UKControllerPlugin::Handoff

--- a/src/plugin/handoff/DepartureHandoffResolver.h
+++ b/src/plugin/handoff/DepartureHandoffResolver.h
@@ -34,17 +34,8 @@ namespace UKControllerPlugin::Handoff {
             -> std::shared_ptr<ResolvedHandoff>;
 
         private:
-        [[nodiscard]] auto
-        ResolveForHandoff(const Euroscope::EuroScopeCFlightPlanInterface& flightplan, const HandoffOrder& handoff) const
-            -> std::shared_ptr<ResolvedHandoff>;
         [[nodiscard]] auto ResolveController(const HandoffOrder& handoff) const
-            -> std::shared_ptr<const Controller::ControllerPosition>;
-        [[nodiscard]] auto ResolveHandoff(const Euroscope::EuroScopeCFlightPlanInterface& flightplan) const
-            -> std::shared_ptr<ResolvedHandoff>;
-        [[nodiscard]] static auto ResolveToUnicom(
-            const Euroscope::EuroScopeCFlightPlanInterface& flightplan,
-            std::shared_ptr<Controller::ControllerPositionHierarchy> handoffOrder) -> std::shared_ptr<ResolvedHandoff>;
-        [[nodiscard]] static auto ResolvedToUnicom(const ResolvedHandoff& resolved) -> bool;
+            -> std::shared_ptr<Controller::ControllerPosition>;
 
         // Maps flightplans to sids to handoffs
         const FlightplanSidHandoffMapper& sidMapper;
@@ -57,5 +48,8 @@ namespace UKControllerPlugin::Handoff {
 
         // The unicom frequency
         inline static const double UNICOM_FREQUENCY = 122.800;
+
+        // The unicom controller for default values
+        const std::shared_ptr<Controller::ControllerPosition> unicomController;
     };
 } // namespace UKControllerPlugin::Handoff

--- a/src/plugin/handoff/HandoffEventHandler.cpp
+++ b/src/plugin/handoff/HandoffEventHandler.cpp
@@ -65,34 +65,6 @@ namespace UKControllerPlugin::Handoff {
         // No change required here.
     }
 
-    /*
-        If a new callsign comes along, we have to clear the cache.
-    */
-    void HandoffEventHandler::ActiveCallsignAdded(const ActiveCallsign& callsign)
-    {
-        this->cache->DeleteWhere([&callsign](const std::shared_ptr<ResolvedHandoff>& handoff) -> bool {
-            return handoff->hierarchy->PositionInHierarchy(callsign.GetNormalisedPosition());
-        });
-    }
-
-    /*
-        If a callsign is removed, clear the cache for anything they were involved in.
-    */
-    void HandoffEventHandler::ActiveCallsignRemoved(const ActiveCallsign& callsign)
-    {
-        this->cache->DeleteWhere([&callsign](const std::shared_ptr<ResolvedHandoff>& handoff) -> bool {
-            return handoff->hierarchy->PositionInHierarchy(callsign.GetNormalisedPosition());
-        });
-    }
-
-    /*
-        If the callsigns are flushed, no cached values are valid
-    */
-    void HandoffEventHandler::CallsignsFlushed()
-    {
-        this->cache->Clear();
-    }
-
     void HandoffEventHandler::FireHandoffUpdatedEvent(const std::string& callsign)
     {
         this->outboundEvent.SendEvent(
@@ -106,8 +78,8 @@ namespace UKControllerPlugin::Handoff {
 
     auto HandoffEventHandler::FormatFrequency(const std::shared_ptr<ResolvedHandoff>& handoff) -> std::string
     {
-        char frequencyString[FREQUENCY_BUFFER_LENGTH];          // NOLINT
-        sprintf_s(frequencyString, "%.3f", handoff->frequency); // NOLINT
-        return frequencyString;                                 // NOLINT
+        char frequencyString[FREQUENCY_BUFFER_LENGTH];                                   // NOLINT
+        sprintf_s(frequencyString, "%.3f", handoff->resolvedController->GetFrequency()); // NOLINT
+        return frequencyString;                                                          // NOLINT
     }
 } // namespace UKControllerPlugin::Handoff

--- a/src/plugin/handoff/HandoffEventHandler.h
+++ b/src/plugin/handoff/HandoffEventHandler.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "controller/ActiveCallsignEventHandlerInterface.h"
 #include "flightplan/FlightPlanEventHandlerInterface.h"
 #include "integration/OutboundIntegrationEventHandler.h"
 #include "tag/TagItemInterface.h"
@@ -22,9 +21,7 @@ namespace UKControllerPlugin::Handoff {
     /*
         Handles handoff events
     */
-    class HandoffEventHandler : public Tag::TagItemInterface,
-                                public Flightplan::FlightPlanEventHandlerInterface,
-                                public Controller::ActiveCallsignEventHandlerInterface
+    class HandoffEventHandler : public Tag::TagItemInterface, public Flightplan::FlightPlanEventHandlerInterface
     {
         public:
         HandoffEventHandler(
@@ -43,11 +40,6 @@ namespace UKControllerPlugin::Handoff {
             Euroscope::EuroScopeCRadarTargetInterface& radarTarget) override;
         void FlightPlanDisconnectEvent(Euroscope::EuroScopeCFlightPlanInterface& flightPlan) override;
         void ControllerFlightPlanDataEvent(Euroscope::EuroScopeCFlightPlanInterface& flightPlan, int dataType) override;
-
-        // Inherited via ActiveCallsignEventHandlerInterface
-        void ActiveCallsignAdded(const Controller::ActiveCallsign& callsign) override;
-        void ActiveCallsignRemoved(const Controller::ActiveCallsign& callsign) override;
-        void CallsignsFlushed() override;
 
         private:
         void FireHandoffUpdatedEvent(const std::string& callsign);

--- a/src/plugin/handoff/ResolvedHandoff.cpp
+++ b/src/plugin/handoff/ResolvedHandoff.cpp
@@ -3,7 +3,9 @@
 namespace UKControllerPlugin::Handoff {
     ResolvedHandoff::ResolvedHandoff(
         std::string callsign,
-        double frequency,
-        const std::shared_ptr<Controller::ControllerPositionHierarchy>& hierarchy)
-        : callsign(std::move(callsign)), frequency(frequency), hierarchy(hierarchy){};
+        const std::shared_ptr<Controller::ControllerPosition> resolvedController,
+        const std::shared_ptr<Controller::ControllerPositionHierarchy> sidHierarchy,
+        const std::shared_ptr<Controller::ControllerPositionHierarchy> airfieldHierarchy)
+        : callsign(std::move(callsign)), resolvedController(resolvedController), sidHierarchy(sidHierarchy),
+          airfieldHierarchy(airfieldHierarchy){};
 } // namespace UKControllerPlugin::Handoff

--- a/src/plugin/handoff/ResolvedHandoff.h
+++ b/src/plugin/handoff/ResolvedHandoff.h
@@ -1,6 +1,7 @@
 #pragma once
 
 namespace UKControllerPlugin::Controller {
+    class ControllerPosition;
     class ControllerPositionHierarchy;
 } // namespace UKControllerPlugin::Controller
 
@@ -14,16 +15,20 @@ namespace UKControllerPlugin::Handoff {
         public:
         ResolvedHandoff(
             std::string callsign,
-            double frequency,
-            const std::shared_ptr<Controller::ControllerPositionHierarchy>& hierarchy);
+            const std::shared_ptr<Controller::ControllerPosition> resolvedController,
+            const std::shared_ptr<Controller::ControllerPositionHierarchy> sidHierarchy,
+            const std::shared_ptr<Controller::ControllerPositionHierarchy> airfieldHierarchy);
 
         // The normalised callsign of the position that the handoff is to
         const std::string callsign;
 
-        // The frequency that the handoff is to
-        const double frequency;
+        // Which controller position this has resolved to
+        const std::shared_ptr<Controller::ControllerPosition> resolvedController;
 
-        // The hierarchy of controllers this handoff is resolved too
-        const std::shared_ptr<Controller::ControllerPositionHierarchy> hierarchy;
+        // The hierarchy of controllers that the SID-specific handoff resolves to
+        const std::shared_ptr<Controller::ControllerPositionHierarchy> sidHierarchy;
+
+        // The hierarchy of airfield controllers that this resolves to
+        const std::shared_ptr<Controller::ControllerPositionHierarchy> airfieldHierarchy;
     };
 } // namespace UKControllerPlugin::Handoff

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -119,7 +119,7 @@ set(test__handoff
     handoff/FlightplanSidHandoffMapperTest.cpp
     handoff/FlightplanAirfieldHandoffMapperTest.cpp
     handoff/HandoffCacheTest.cpp
-    handoff/DepartureHandoffResolverTest.cpp)
+    handoff/DepartureHandoffResolverTest.cpp handoff/ClearCacheOnActiveCallsignChangesTest.cpp)
 source_group("test\\handoff" FILES ${test__handoff})
 
 set(test__headings

--- a/test/plugin/controller/ControllerPositionHierarchyTest.cpp
+++ b/test/plugin/controller/ControllerPositionHierarchyTest.cpp
@@ -104,4 +104,37 @@ namespace UKControllerPluginTest::Controller {
         hierarchy2.AddPosition(position2);
         EXPECT_TRUE(hierarchy1 == hierarchy2);
     }
+
+    TEST_F(ControllerPositionHierarchyTest, PositionPreceedsReturnsTrueIfPositionComesBefore)
+    {
+        ControllerPositionHierarchy hierarchy;
+        hierarchy.AddPosition(position1);
+        hierarchy.AddPosition(position2);
+
+        EXPECT_TRUE(hierarchy.PositionPreceeds(*position1, *position2));
+    }
+
+    TEST_F(ControllerPositionHierarchyTest, PositionPreceedsReturnsTrueIfSamePositionAndInHierarchy)
+    {
+        ControllerPositionHierarchy hierarchy;
+        hierarchy.AddPosition(position1);
+        hierarchy.AddPosition(position2);
+
+        EXPECT_TRUE(hierarchy.PositionPreceeds(*position1, *position1));
+    }
+
+    TEST_F(ControllerPositionHierarchyTest, PositionPreceedsReturnsFalseIfPositionComesAfter)
+    {
+        ControllerPositionHierarchy hierarchy;
+        hierarchy.AddPosition(position2);
+        hierarchy.AddPosition(position1);
+
+        EXPECT_FALSE(hierarchy.PositionPreceeds(*position1, *position2));
+    }
+
+    TEST_F(ControllerPositionHierarchyTest, PositionPreceedsReturnsFalseIfPositionNotInHierarchy)
+    {
+        ControllerPositionHierarchy hierarchy;
+        EXPECT_FALSE(hierarchy.PositionPreceeds(*position1, *position2));
+    }
 } // namespace UKControllerPluginTest::Controller

--- a/test/plugin/handoff/ClearCacheOnActiveCallsignChangesTest.cpp
+++ b/test/plugin/handoff/ClearCacheOnActiveCallsignChangesTest.cpp
@@ -26,12 +26,14 @@ namespace UKControllerPluginTest::Handoff {
               hierarchy1(std::make_shared<ControllerPositionHierarchy>()),
               hierarchy2(std::make_shared<ControllerPositionHierarchy>()),
               hierarchy3(std::make_shared<ControllerPositionHierarchy>()),
+              hierarchy4(std::make_shared<ControllerPositionHierarchy>()),
               callsign("LON_S_CTR", "Test", *position1, true), changes(cache)
         {
             hierarchy1->AddPosition(position1);
             hierarchy1->AddPosition(position2);
             hierarchy2->AddPosition(position2);
             hierarchy2->AddPosition(position1);
+            hierarchy4->AddPosition(position2);
         }
 
         std::shared_ptr<ControllerPosition> position1;
@@ -40,6 +42,7 @@ namespace UKControllerPluginTest::Handoff {
         std::shared_ptr<ControllerPositionHierarchy> hierarchy1;
         std::shared_ptr<ControllerPositionHierarchy> hierarchy2;
         std::shared_ptr<ControllerPositionHierarchy> hierarchy3;
+        std::shared_ptr<ControllerPositionHierarchy> hierarchy4;
         ActiveCallsign callsign;
         HandoffCache cache;
         ClearCacheOnActiveCallsignChanges changes;
@@ -85,6 +88,17 @@ namespace UKControllerPluginTest::Handoff {
     {
         // Resolve to LON_SC, LON_S comes on and preceeds in hierarchy
         cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position2, hierarchy3, hierarchy1));
+        changes.ActiveCallsignAdded(callsign);
+        EXPECT_EQ(nullptr, cache.Get("BAW123"));
+    }
+
+    TEST_F(
+        ClearCacheOnActiveCallsignChangesTest,
+        CallsignLoggingOnClearsCacheIfResolvedControllerInAirfieldHierarchyButControllerLoggingOnIsInSidHierarchy)
+    {
+        // Resolve to LON_SC on the airfield hierarchy, LON_S comes on, is not in the airfield hierarchy but is
+        // in the SID one, should clear.
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position2, hierarchy1, hierarchy4));
         changes.ActiveCallsignAdded(callsign);
         EXPECT_EQ(nullptr, cache.Get("BAW123"));
     }

--- a/test/plugin/handoff/ClearCacheOnActiveCallsignChangesTest.cpp
+++ b/test/plugin/handoff/ClearCacheOnActiveCallsignChangesTest.cpp
@@ -1,0 +1,129 @@
+#include "controller/ActiveCallsign.h"
+#include "controller/ControllerPosition.h"
+#include "controller/ControllerPositionHierarchy.h"
+#include "handoff/ClearCacheOnActiveCallsignChanges.h"
+#include "handoff/HandoffCache.h"
+#include "handoff/ResolvedHandoff.h"
+
+using UKControllerPlugin::Controller::ActiveCallsign;
+using UKControllerPlugin::Controller::ControllerPosition;
+using UKControllerPlugin::Controller::ControllerPositionHierarchy;
+using UKControllerPlugin::Handoff::ClearCacheOnActiveCallsignChanges;
+using UKControllerPlugin::Handoff::HandoffCache;
+using UKControllerPlugin::Handoff::ResolvedHandoff;
+
+namespace UKControllerPluginTest::Handoff {
+    class ClearCacheOnActiveCallsignChangesTest : public testing::Test
+    {
+        public:
+        ClearCacheOnActiveCallsignChangesTest()
+            : position1(std::make_shared<ControllerPosition>(
+                  1, "LON_S_CTR", 129.420, std::vector<std::string>{}, true, false)),
+              position2(std::make_shared<ControllerPosition>(
+                  2, "LON_SC_CTR", 132.6, std::vector<std::string>{}, true, false)),
+              position3(
+                  std::make_shared<ControllerPosition>(-1, "UNICOM", 122.800, std::vector<std::string>{}, true, false)),
+              hierarchy1(std::make_shared<ControllerPositionHierarchy>()),
+              hierarchy2(std::make_shared<ControllerPositionHierarchy>()),
+              hierarchy3(std::make_shared<ControllerPositionHierarchy>()),
+              callsign("LON_S_CTR", "Test", *position1, true), changes(cache)
+        {
+            hierarchy1->AddPosition(position1);
+            hierarchy1->AddPosition(position2);
+            hierarchy2->AddPosition(position2);
+            hierarchy2->AddPosition(position1);
+        }
+
+        std::shared_ptr<ControllerPosition> position1;
+        std::shared_ptr<ControllerPosition> position2;
+        std::shared_ptr<ControllerPosition> position3;
+        std::shared_ptr<ControllerPositionHierarchy> hierarchy1;
+        std::shared_ptr<ControllerPositionHierarchy> hierarchy2;
+        std::shared_ptr<ControllerPositionHierarchy> hierarchy3;
+        ActiveCallsign callsign;
+        HandoffCache cache;
+        ClearCacheOnActiveCallsignChanges changes;
+    };
+
+    TEST_F(ClearCacheOnActiveCallsignChangesTest, FlushingCallsignsClearsCache)
+    {
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", nullptr, nullptr, nullptr));
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW456", nullptr, nullptr, nullptr));
+        changes.CallsignsFlushed();
+        EXPECT_EQ(0, cache.Count());
+    }
+
+    TEST_F(ClearCacheOnActiveCallsignChangesTest, CallsignsLoggingOffEvictOnResolvedControllerMatch)
+    {
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position1, nullptr, nullptr));
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW456", position1, nullptr, nullptr));
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW789", position2, nullptr, nullptr));
+        changes.ActiveCallsignRemoved(callsign);
+        EXPECT_EQ(1, cache.Count());
+        EXPECT_EQ(nullptr, cache.Get("BAW123"));
+        EXPECT_EQ(nullptr, cache.Get("BAW456"));
+        EXPECT_NE(nullptr, cache.Get("BAW789"));
+    }
+
+    TEST_F(ClearCacheOnActiveCallsignChangesTest, CallsignsLoggingOnClearsCacheIfControllerPreceedsInSidHierarchy)
+    {
+        // Resolved to LON_SC, LON_S comes on and precedes in SID hierarchy
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position2, hierarchy1, hierarchy2));
+        changes.ActiveCallsignAdded(callsign);
+        EXPECT_EQ(nullptr, cache.Get("BAW123"));
+    }
+
+    TEST_F(ClearCacheOnActiveCallsignChangesTest, CallsignsLoggingOnDoesntClearCacheIfControllerAfterInSidHierarchy)
+    {
+        // Resolved to LON_SC, LON_S comes on but is after SC in the hierarchy
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position2, hierarchy2, hierarchy1));
+        changes.ActiveCallsignAdded(callsign);
+        EXPECT_NE(nullptr, cache.Get("BAW123"));
+    }
+
+    TEST_F(ClearCacheOnActiveCallsignChangesTest, CallsignLoggingOnClearsCacheIfControllerPreceedsInAirfieldHierarchy)
+    {
+        // Resolve to LON_SC, LON_S comes on and preceeds in hierarchy
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position2, hierarchy3, hierarchy1));
+        changes.ActiveCallsignAdded(callsign);
+        EXPECT_EQ(nullptr, cache.Get("BAW123"));
+    }
+
+    TEST_F(ClearCacheOnActiveCallsignChangesTest, CallsignLoggingOnDoesntClearCacheIfControllerAfterInAirfieldHierarchy)
+    {
+        // Resolve to LON_SC, LON_S comes on but is after SC in the hierarchy
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position2, hierarchy3, hierarchy2));
+        changes.ActiveCallsignAdded(callsign);
+        EXPECT_NE(nullptr, cache.Get("BAW123"));
+    }
+
+    TEST_F(
+        ClearCacheOnActiveCallsignChangesTest,
+        CallsignLoggingOnClearsCacheIfResolvedControllerNotInHierarchyButControllerInSidHierarchy)
+    {
+        // Resolve to unicom, LON_S comes on and is in SID hierarchy
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position3, hierarchy1, hierarchy3));
+        changes.ActiveCallsignAdded(callsign);
+        EXPECT_EQ(nullptr, cache.Get("BAW123"));
+    }
+
+    TEST_F(
+        ClearCacheOnActiveCallsignChangesTest,
+        CallsignLoggingOnClearsCacheIfResolvedControllerNotInHierarchyButControllerInAirfieldHierarchy)
+    {
+        // Resolve to unicom, LON_S comes on and is in airfield hierarchy
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position3, hierarchy3, hierarchy1));
+        changes.ActiveCallsignAdded(callsign);
+        EXPECT_EQ(nullptr, cache.Get("BAW123"));
+    }
+
+    TEST_F(
+        ClearCacheOnActiveCallsignChangesTest,
+        CallsignLoggingOnDoesntClearCacheIfResolvedControllerNotInHierarchyButControllerNotInHierarchy)
+    {
+        // Resolve to unicom, LON_S comes on and is in neither hierarchy
+        cache.Add(std::make_shared<ResolvedHandoff>("BAW123", position3, hierarchy3, hierarchy3));
+        changes.ActiveCallsignAdded(callsign);
+        EXPECT_NE(nullptr, cache.Get("BAW123"));
+    }
+} // namespace UKControllerPluginTest::Handoff

--- a/test/plugin/handoff/DepartureHandoffResolverTest.cpp
+++ b/test/plugin/handoff/DepartureHandoffResolverTest.cpp
@@ -74,8 +74,9 @@ namespace UKControllerPluginTest::Handoff {
         ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("LAM5M"));
 
         const auto resolved = resolver.Resolve(mockFlightplan);
-        EXPECT_EQ(122.800, resolved->frequency);
-        EXPECT_EQ(0, resolved->hierarchy->CountPositions());
+        EXPECT_EQ(122.800, resolved->resolvedController->GetFrequency());
+        EXPECT_EQ(0, resolved->sidHierarchy->CountPositions());
+        EXPECT_EQ(0, resolved->airfieldHierarchy->CountPositions());
     }
 
     TEST_F(DepartureHandoffResolverTest, ItReturnsUnicomIfNoPositionsActive)
@@ -83,8 +84,9 @@ namespace UKControllerPluginTest::Handoff {
         ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("CLN3X"));
 
         const auto resolved = resolver.Resolve(mockFlightplan);
-        EXPECT_EQ(122.800, resolved->frequency);
-        EXPECT_EQ(this->hierarchy, resolved->hierarchy);
+        EXPECT_EQ(122.800, resolved->resolvedController->GetFrequency());
+        EXPECT_EQ(this->hierarchy, resolved->sidHierarchy);
+        EXPECT_EQ(0, resolved->airfieldHierarchy->CountPositions());
     }
 
     TEST_F(DepartureHandoffResolverTest, ItReturnsUnicomIfFirstPositionOnlineIsUser)
@@ -95,8 +97,9 @@ namespace UKControllerPluginTest::Handoff {
         ON_CALL(mockFlightplan, GetSidName).WillByDefault(testing::Return("CLN3X"));
 
         const auto resolved = resolver.Resolve(mockFlightplan);
-        EXPECT_EQ(122.800, resolved->frequency);
-        EXPECT_EQ(this->hierarchy, resolved->hierarchy);
+        EXPECT_EQ(122.800, resolved->resolvedController->GetFrequency());
+        EXPECT_EQ(this->hierarchy, resolved->sidHierarchy);
+        EXPECT_EQ(0, resolved->airfieldHierarchy->CountPositions());
     }
 
     TEST_F(DepartureHandoffResolverTest, ItReturnsResolvedHandoff)
@@ -108,8 +111,9 @@ namespace UKControllerPluginTest::Handoff {
         const auto resolved = resolver.Resolve(mockFlightplan);
         EXPECT_NE(nullptr, resolved);
         EXPECT_EQ("BAW123", resolved->callsign);
-        EXPECT_EQ(121.950, resolved->frequency);
-        EXPECT_EQ(this->hierarchy, resolved->hierarchy);
+        EXPECT_EQ(121.950, resolved->resolvedController->GetFrequency());
+        EXPECT_EQ(this->hierarchy, resolved->sidHierarchy);
+        EXPECT_EQ(0, resolved->airfieldHierarchy->CountPositions());
     }
 
     TEST_F(DepartureHandoffResolverTest, ItReturnsResolvedAirfieldHandoffIfNoMatchingSid)
@@ -125,8 +129,9 @@ namespace UKControllerPluginTest::Handoff {
         const auto resolved = resolver.Resolve(mockFlightplan);
         EXPECT_NE(nullptr, resolved);
         EXPECT_EQ("BAW123", resolved->callsign);
-        EXPECT_EQ(121.800, resolved->frequency);
-        EXPECT_EQ(hierarchy2, resolved->hierarchy);
+        EXPECT_EQ(121.800, resolved->resolvedController->GetFrequency());
+        EXPECT_EQ(0, resolved->sidHierarchy->CountPositions());
+        EXPECT_EQ(hierarchy2, resolved->airfieldHierarchy);
     }
 
     TEST_F(DepartureHandoffResolverTest, ItResolvesToAirfieldHandoffIfSidResolvesToUnicom)
@@ -144,7 +149,8 @@ namespace UKControllerPluginTest::Handoff {
         const auto resolved = resolver.Resolve(mockFlightplan);
         EXPECT_NE(nullptr, resolved);
         EXPECT_EQ("BAW123", resolved->callsign);
-        EXPECT_EQ(124.220, resolved->frequency);
-        EXPECT_EQ(hierarchy2, resolved->hierarchy);
+        EXPECT_EQ(124.220, resolved->resolvedController->GetFrequency());
+        EXPECT_EQ(this->hierarchy, resolved->sidHierarchy);
+        EXPECT_EQ(hierarchy2, resolved->airfieldHierarchy);
     }
 } // namespace UKControllerPluginTest::Handoff

--- a/test/plugin/handoff/HandoffCacheTest.cpp
+++ b/test/plugin/handoff/HandoffCacheTest.cpp
@@ -9,8 +9,8 @@ namespace UKControllerPluginTest::Handoff {
     {
         public:
         HandoffCacheTest()
-            : handoff1(std::make_shared<ResolvedHandoff>("BAW123", 122.800, nullptr)),
-              handoff2(std::make_shared<ResolvedHandoff>("BAW456", 122.800, nullptr))
+            : handoff1(std::make_shared<ResolvedHandoff>("BAW123", nullptr, nullptr, nullptr)),
+              handoff2(std::make_shared<ResolvedHandoff>("BAW456", nullptr, nullptr, nullptr))
         {
         }
 


### PR DESCRIPTION
It was hanging on to old handoffs when controllers log on if the handoff
was from the airfield hierarchy.

Fix #412