### PR TITLE
feat(wake): Add not applicable to wake calculator display

### DIFF
--- a/src/plugin/wake/WakeCalculatorDisplay.cpp
+++ b/src/plugin/wake/WakeCalculatorDisplay.cpp
@@ -251,6 +251,12 @@ namespace UKControllerPlugin::Wake {
         const auto leadFlightplan = plugin.GetFlightplanForCallsign(options->LeadAircraft());
         const auto followingFlightplan = plugin.GetFlightplanForCallsign(options->FollowingAircraft());
         if (options->SchemeMapper() == nullptr || leadFlightplan == nullptr || followingFlightplan == nullptr) {
+            graphics.DrawString(
+                L"--",
+                calculationResultArea,
+                *resultBrush,
+                Graphics::StringFormatManager::Instance().GetCentreAlign(),
+                Graphics::FontManager::Instance().Get(16));
             return;
         }
 
@@ -258,6 +264,12 @@ namespace UKControllerPlugin::Wake {
         const auto leadCategory = mapper->MapForFlightplan(*leadFlightplan);
         const auto followingCategory = mapper->MapForFlightplan(*followingFlightplan);
         if (leadCategory == nullptr || followingCategory == nullptr) {
+            graphics.DrawString(
+                L"--",
+                calculationResultArea,
+                *resultBrush,
+                Graphics::StringFormatManager::Instance().GetCentreAlign(),
+                Graphics::FontManager::Instance().Get(16));
             return;
         }
 
@@ -273,7 +285,7 @@ namespace UKControllerPlugin::Wake {
         const auto departureInterval = leadCategory->DepartureInterval(*followingCategory, options->Intermediate());
         if (departureInterval == nullptr) {
             graphics.DrawString(
-                L"--",
+                L"N/A",
                 calculationResultArea,
                 *resultBrush,
                 Graphics::StringFormatManager::Instance().GetCentreAlign(),


### PR DESCRIPTION
It was sometimes hard to tell when there wasn't a wake interval because
it couldn't be worked out (or because of a bug) and when there legitimately isn't one.
This makes the default display to be a double dash. If two aircraft are selected such that
no interval applies (e.g. LM followed by LM), it will instead display N/A which makes it clear
to the user that there is no applicable interval.

Resolves #425