### PR TITLE
fix(fonts): Provide fallback font if EuroScope is not installed

### DIFF
--- a/src/plugin/graphics/FontManager.cpp
+++ b/src/plugin/graphics/FontManager.cpp
@@ -6,8 +6,10 @@ namespace UKControllerPlugin::Graphics {
     {
         static std::unique_ptr<FontManager> instance;
         if (instance == nullptr) {
-            instance =
-                std::unique_ptr<FontManager>(new FontManager(std::make_unique<Gdiplus::FontFamily>(L"EuroScope")));
+            auto euroscopeFontFamily = std::make_unique<Gdiplus::FontFamily>(L"EuroScope");
+            instance = std::unique_ptr<FontManager>(new FontManager(
+                euroscopeFontFamily->IsAvailable() ? std::move(euroscopeFontFamily)
+                                                   : std::make_unique<Gdiplus::FontFamily>(L"Segoe UI")));
         }
 
         return *instance;


### PR DESCRIPTION
Some users don't have the EuroScope font. Use Segoe UI as a fallback,
it doesn't look the best, but better than nothing!

Fixes #433