### PR TITLE
fix(historytrails): Missing first dot on faded trails

### DIFF
--- a/src/plugin/historytrail/HistoryTrailRenderer.cpp
+++ b/src/plugin/historytrail/HistoryTrailRenderer.cpp
@@ -336,6 +336,8 @@ namespace UKControllerPlugin {
                 // Round number used to govern fade and degrade, reset the colour
                 roundNumber = 0;
                 currentColourArgb = *this->startColour;
+                this->pen->SetColor(currentColourArgb);
+                this->brush->SetColor(currentColourArgb);
 
                 // Reset the dot height and width
                 dot.Width = this->historyTrailDotSizeFloat;


### PR DESCRIPTION
We weren't resetting the pen/brush after each run, so the first dot of the
second aircraft onwards was always invisible.

Fix #436