### PR TITLE
fix(updater): Updater not respecting selected release channel

### DIFF
--- a/src/plugin/euroscope/GeneralSettingsConfigurationBootstrap.cpp
+++ b/src/plugin/euroscope/GeneralSettingsConfigurationBootstrap.cpp
@@ -10,6 +10,7 @@
 #include "euroscope/UserSettingAwareCollection.h"
 #include "setting/SettingRepository.h"
 #include "setting/JsonFileSettingProvider.h"
+#include "update/BootstrapReleaseChannelSettings.h"
 
 using UKControllerPlugin::Command::CommandHandlerCollection;
 using UKControllerPlugin::Dialog::DialogData;
@@ -22,6 +23,7 @@ using UKControllerPlugin::Plugin::FunctionCallEventHandler;
 using UKControllerPlugin::RadarScreen::ConfigurableDisplayCollection;
 using UKControllerPlugin::Setting::JsonFileSettingProvider;
 using UKControllerPlugin::Windows::WinApiInterface;
+using UKControllerPluginUtils::Update::BootstrapReleaseChannelSettings;
 
 namespace UKControllerPlugin {
     namespace Euroscope {
@@ -33,8 +35,7 @@ namespace UKControllerPlugin {
             Setting::SettingRepository& settings,
             WinApiInterface& windows)
         {
-            settings.AddProvider(std::make_shared<JsonFileSettingProvider>(
-                L"release-channel.json", std::set<std::string>{"release_channel"}, windows));
+            BootstrapReleaseChannelSettings(settings, windows);
             std::shared_ptr<GeneralSettingsDialog> dialog =
                 std::make_shared<GeneralSettingsDialog>(userSettings, userSettingsHandlers, settings);
             dialogManager.AddDialog(

--- a/src/updater/dllmain.cpp
+++ b/src/updater/dllmain.cpp
@@ -6,6 +6,7 @@
 #include "setting/SettingRepositoryFactory.h"
 #include "curl/CurlApi.h"
 #include "log/LoggerBootstrap.h"
+#include "update/BootstrapReleaseChannelSettings.h"
 #include "update/PluginVersion.h"
 #include "duplicate/DuplicatePlugin.h"
 
@@ -36,6 +37,7 @@ UKCP_UPDATER_API bool PerformUpdates()
     UKControllerPlugin::Curl::CurlApi curl;
     std::unique_ptr<UKControllerPlugin::Setting::SettingRepository> settings =
         UKControllerPlugin::Setting::SettingRepositoryFactory::Create();
+    UKControllerPluginUtils::Update::BootstrapReleaseChannelSettings(*settings, *windows);
 
     auto factory = UKControllerPluginUtils::Api::Bootstrap(*settings, *windows);
     auto api = UKControllerPluginUtils::Api::BootstrapLegacy(*factory, curl);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -163,7 +163,7 @@ set(update
     "update/PluginVersion.h"
     "update/UpdateBinaries.cpp"
     "update/UpdateBinaries.h"
-)
+        update/BootstrapReleaseChannelSettings.cpp update/BootstrapReleaseChannelSettings.h)
 source_group("update" FILES ${update})
 
 set(windows

--- a/src/utils/update/BootstrapReleaseChannelSettings.cpp
+++ b/src/utils/update/BootstrapReleaseChannelSettings.cpp
@@ -1,0 +1,16 @@
+#include "BootstrapReleaseChannelSettings.h"
+#include "setting/JsonFileSettingProvider.h"
+#include "setting/SettingRepository.h"
+
+using UKControllerPlugin::Setting::JsonFileSettingProvider;
+using UKControllerPlugin::Setting::SettingRepository;
+
+namespace UKControllerPluginUtils::Update {
+
+    void
+    BootstrapReleaseChannelSettings(SettingRepository& settings, UKControllerPlugin::Windows::WinApiInterface& windows)
+    {
+        settings.AddProvider(std::make_shared<JsonFileSettingProvider>(
+            L"release-channel.json", std::set<std::string>{"release_channel"}, windows));
+    }
+} // namespace UKControllerPluginUtils::Update

--- a/src/utils/update/BootstrapReleaseChannelSettings.h
+++ b/src/utils/update/BootstrapReleaseChannelSettings.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace UKControllerPlugin {
+    namespace Setting {
+        class SettingRepository;
+    } // namespace Setting
+    namespace Windows {
+        class WinApiInterface;
+    } // namespace Windows
+} // namespace UKControllerPlugin
+
+namespace UKControllerPluginUtils::Update {
+    void BootstrapReleaseChannelSettings(
+        UKControllerPlugin::Setting::SettingRepository& settings,
+        UKControllerPlugin::Windows::WinApiInterface& windows);
+} // namespace UKControllerPluginUtils::Update

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -91,7 +91,7 @@ source_group("test\\string" FILES ${test__string})
 set(test__update
     "update/UpdateBinariesTest.cpp"
     "update/CheckDevelopmentVersionTest.cpp"
-)
+        update/BootstrapReleaseChannelSettingsTest.cpp)
 source_group("test\\update" FILES ${test__update})
 
 set(ALL_FILES

--- a/test/utils/update/BootstrapReleaseChannelSettingsTest.cpp
+++ b/test/utils/update/BootstrapReleaseChannelSettingsTest.cpp
@@ -1,0 +1,22 @@
+#include "setting/SettingRepository.h"
+#include "update/BootstrapReleaseChannelSettings.h"
+
+using UKControllerPlugin::Setting::SettingRepository;
+using UKControllerPluginTest::Windows::MockWinApi;
+using UKControllerPluginUtils::Update::BootstrapReleaseChannelSettings;
+
+namespace UKControllerPluginUtilsTest::Update {
+    class BootstrapReleaseChannelSettingsTest : public testing::Test
+    {
+        public:
+        testing::NiceMock<MockWinApi> windows;
+        SettingRepository settings;
+    };
+
+    TEST_F(BootstrapReleaseChannelSettingsTest, ItBootstrapsTheSettings)
+    {
+        BootstrapReleaseChannelSettings(settings, windows);
+        EXPECT_EQ(1, settings.CountSettings());
+        EXPECT_TRUE(settings.HasSetting("release_channel"));
+    }
+} // namespace UKControllerPluginUtilsTest::Update


### PR DESCRIPTION
It was defaulting to stable as the settings file was not loaded