### PR TITLE
feat(api): use api prefix for all routes

### DIFF
--- a/src/utils/api/ApiRequestBuilder.cpp
+++ b/src/utils/api/ApiRequestBuilder.cpp
@@ -438,7 +438,7 @@ namespace UKControllerPlugin::Api {
 
     auto ApiRequestBuilder::BuildUrl(const std::string uri) const -> std::string
     {
-        return this->settings.Url() + uri;
+        return this->settings.Url() + "/api" + uri;
     }
 
     auto ApiRequestBuilder::GetApiDomain() const -> const std::string&

--- a/src/utils/api/ApiUrlBuilder.cpp
+++ b/src/utils/api/ApiUrlBuilder.cpp
@@ -11,7 +11,7 @@ namespace UKControllerPluginUtils::Api {
 
     auto ApiUrlBuilder::BuildUrl(const ApiRequestData& requestData) const -> const std::string
     {
-        return String::rtrim(settings.Url(), URL_PATH_SEPARATOR) + URL_PATH_SEPARATOR +
+        return String::rtrim(settings.Url(), URL_PATH_SEPARATOR) + URL_PATH_SEPARATOR + "api" + URL_PATH_SEPARATOR +
                String::trim(requestData.Uri(), URL_PATH_SEPARATOR);
     }
 } // namespace UKControllerPluginUtils::Api

--- a/test/testingutils/helper/ApiRequestHelperFunctions.cpp
+++ b/test/testingutils/helper/ApiRequestHelperFunctions.cpp
@@ -5,7 +5,7 @@ using UKControllerPlugin::Api::ApiRequestBuilder;
 using UKControllerPlugin::Curl::CurlRequest;
 using UKControllerPluginUtils::Api::ApiSettings;
 
-const std::string mockApiUrl = "http://ukcp.test.com/api";
+const std::string mockApiUrl = "http://ukcp.test.com";
 const std::string mockApiKey = "areallyniceapikey";
 std::shared_ptr<ApiSettings> settings;
 
@@ -14,7 +14,7 @@ std::shared_ptr<ApiSettings> settings;
 */
 CurlRequest GetApiCurlRequest(std::string route, std::string method, nlohmann::json body)
 {
-    CurlRequest request(mockApiUrl + route, method);
+    CurlRequest request(mockApiUrl + "/api" + route, method);
     request.SetBody(body.dump());
     request.AddHeader("Authorization", "Bearer " + mockApiKey);
     request.AddHeader("Accept", "application/json");
@@ -27,7 +27,7 @@ CurlRequest GetApiCurlRequest(std::string route, std::string method, nlohmann::j
 */
 CurlRequest GetApiCurlRequest(std::string route, std::string method)
 {
-    CurlRequest request(mockApiUrl + route, method);
+    CurlRequest request(mockApiUrl + "/api" + route, method);
     request.AddHeader("Authorization", "Bearer " + mockApiKey);
     request.AddHeader("Accept", "application/json");
     request.AddHeader("Content-Type", "application/json");

--- a/test/testingutils/helper/ApiRequestHelperFunctions.cpp
+++ b/test/testingutils/helper/ApiRequestHelperFunctions.cpp
@@ -5,7 +5,7 @@ using UKControllerPlugin::Api::ApiRequestBuilder;
 using UKControllerPlugin::Curl::CurlRequest;
 using UKControllerPluginUtils::Api::ApiSettings;
 
-const std::string mockApiUrl = "http://ukcp.test.com";
+const std::string mockApiUrl = "http://ukcp.test.com/api";
 const std::string mockApiKey = "areallyniceapikey";
 std::shared_ptr<ApiSettings> settings;
 

--- a/test/utils/api/ApiBootstrapTest.cpp
+++ b/test/utils/api/ApiBootstrapTest.cpp
@@ -41,7 +41,7 @@ namespace UKControllerPluginUtilsTest::Api {
         auto legacyInterface = BootstrapLegacy(*factory, curl);
         EXPECT_NE(nullptr, legacyInterface);
 
-        CurlRequest expectedRequest("https://ukcp.vatsim.uk/authorise", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("https://ukcp.vatsim.uk/api/authorise", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer ");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");

--- a/test/utils/api/ApiCurlRequestFactoryTest.cpp
+++ b/test/utils/api/ApiCurlRequestFactoryTest.cpp
@@ -31,7 +31,7 @@ namespace UKControllerPluginUtilsTest::Api {
         auto request =
             requestFactory.BuildCurlRequest(ApiRequestData("test", UKControllerPluginUtils::Http::HttpMethod::Get()));
 
-        CurlRequest expectedRequest("https://ukcp.vatsim.uk/test", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("https://ukcp.vatsim.uk/api/test", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer key");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");

--- a/test/utils/api/ApiFactoryTest.cpp
+++ b/test/utils/api/ApiFactoryTest.cpp
@@ -57,7 +57,7 @@ namespace UKControllerPluginUtilsTest::Api {
     {
         auto& builder = factory.LegacyRequestBuilder();
 
-        CurlRequest expectedRequest("https://ukcp.vatsim.uk/authorise", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("https://ukcp.vatsim.uk/api/authorise", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer key");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");

--- a/test/utils/api/ApiHelperTest.cpp
+++ b/test/utils/api/ApiHelperTest.cpp
@@ -423,7 +423,7 @@ namespace UKControllerPluginUtilsTest::Api {
         params.requestedLevel = 10000;
 
         CurlRequest expectedRequest(GetApiGetUriCurlRequest(
-            "http://ukcp.test.com/srd/route/search?origin=EGLL&destination=EGGD&requestedLevel=10000",
+            "http://ukcp.test.com/api/srd/route/search?origin=EGLL&destination=EGGD&requestedLevel=10000",
             CurlRequest::METHOD_GET));
 
         EXPECT_CALL(this->mockCurlApi, MakeCurlRequest(expectedRequest)).Times(1).WillOnce(Return(response));
@@ -438,7 +438,7 @@ namespace UKControllerPluginUtilsTest::Api {
         CurlResponse response(responseData.dump(), false, 200);
 
         CurlRequest expectedRequest(
-            GetApiGetUriCurlRequest("http://ukcp.test.com/hold/assigned", CurlRequest::METHOD_GET));
+            GetApiGetUriCurlRequest("http://ukcp.test.com/api/hold/assigned", CurlRequest::METHOD_GET));
 
         EXPECT_CALL(this->mockCurlApi, MakeCurlRequest(expectedRequest)).Times(1).WillOnce(Return(response));
 
@@ -523,7 +523,7 @@ namespace UKControllerPluginUtilsTest::Api {
         CurlResponse response(responseData.dump(), false, 200);
 
         CurlRequest expectedRequest(
-            GetApiGetUriCurlRequest("http://ukcp.test.com/stand/assignment", CurlRequest::METHOD_GET));
+            GetApiGetUriCurlRequest("http://ukcp.test.com/api/stand/assignment", CurlRequest::METHOD_GET));
 
         EXPECT_CALL(this->mockCurlApi, MakeCurlRequest(expectedRequest)).Times(1).WillOnce(Return(response));
 
@@ -632,7 +632,7 @@ namespace UKControllerPluginUtilsTest::Api {
         CurlResponse response(responseData.dump(), false, 200);
 
         CurlRequest expectedRequest(
-            GetApiGetUriCurlRequest("http://ukcp.test.com/version/latest?channel=beta", CurlRequest::METHOD_GET));
+            GetApiGetUriCurlRequest("http://ukcp.test.com/api/version/latest?channel=beta", CurlRequest::METHOD_GET));
 
         EXPECT_CALL(this->mockCurlApi, MakeCurlRequest(expectedRequest)).Times(1).WillOnce(Return(response));
 

--- a/test/utils/api/ApiRequestBuilderTest.cpp
+++ b/test/utils/api/ApiRequestBuilderTest.cpp
@@ -417,7 +417,8 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsRejectDepartureReleaseRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/api/departure/release/request/1/reject", CurlRequest::METHOD_PATCH);
+        CurlRequest expectedRequest(
+            "http://testurl.com/api/departure/release/request/1/reject", CurlRequest::METHOD_PATCH);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -507,7 +508,8 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsAcknowledgePrenoteMessage)
     {
-        CurlRequest expectedRequest("http://testurl.com/api/prenotes/messages/55/acknowledge", CurlRequest::METHOD_PATCH);
+        CurlRequest expectedRequest(
+            "http://testurl.com/api/prenotes/messages/55/acknowledge", CurlRequest::METHOD_PATCH);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");

--- a/test/utils/api/ApiRequestBuilderTest.cpp
+++ b/test/utils/api/ApiRequestBuilderTest.cpp
@@ -24,7 +24,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsAuthCheckRequests)
     {
-        CurlRequest expectedRequest("http://testurl.com/authorise", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/authorise", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -33,7 +33,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsDependencyListRequests)
     {
-        CurlRequest expectedRequest("http://testurl.com/dependency", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/dependency", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -42,13 +42,13 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsRemoteFileDownloadRequests)
     {
-        CurlRequest expectedRequest("http://testurl.com/files/test1.json", CurlRequest::METHOD_GET);
-        EXPECT_TRUE(expectedRequest == this->builder.BuildRemoteFileRequest("http://testurl.com/files/test1.json"));
+        CurlRequest expectedRequest("http://testurl.com/api/files/test1.json", CurlRequest::METHOD_GET);
+        EXPECT_TRUE(expectedRequest == this->builder.BuildRemoteFileRequest("http://testurl.com/api/files/test1.json"));
     }
 
     TEST_F(ApiRequestBuilderTest, ItBuildsSquawkAssignmentDeletionRequests)
     {
-        CurlRequest expectedRequest("http://testurl.com/squawk-assignment/BAW123", CurlRequest::METHOD_DELETE);
+        CurlRequest expectedRequest("http://testurl.com/api/squawk-assignment/BAW123", CurlRequest::METHOD_DELETE);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -57,7 +57,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsSquawkAssignmentCheckRequests)
     {
-        CurlRequest expectedRequest("http://testurl.com/squawk-assignment/BAW123", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/squawk-assignment/BAW123", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -66,7 +66,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsGeneralSquawkAssignmentRequests)
     {
-        CurlRequest expectedRequest("http://testurl.com/squawk-assignment/BAW123", CurlRequest::METHOD_PUT);
+        CurlRequest expectedRequest("http://testurl.com/api/squawk-assignment/BAW123", CurlRequest::METHOD_PUT);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -82,7 +82,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsLocalSquawkAssignmentRequests)
     {
-        CurlRequest expectedRequest("http://testurl.com/squawk-assignment/BAW123", CurlRequest::METHOD_PUT);
+        CurlRequest expectedRequest("http://testurl.com/api/squawk-assignment/BAW123", CurlRequest::METHOD_PUT);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -98,7 +98,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsHoldDependencyDataRequests)
     {
-        CurlRequest expectedRequest("http://testurl.com/hold", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/hold", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -107,7 +107,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsAMinStackRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/msl", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/msl", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -117,7 +117,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsARegionalPressureRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/regional-pressure", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/regional-pressure", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -143,7 +143,7 @@ namespace UKControllerPluginUtilsTest::Api {
         params.destination = "EGLL";
 
         CurlRequest expectedRequest(
-            "http://testurl.com/srd/route/search?origin=EGKK&destination=EGLL", CurlRequest::METHOD_GET);
+            "http://testurl.com/api/srd/route/search?origin=EGKK&destination=EGLL", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -159,7 +159,7 @@ namespace UKControllerPluginUtilsTest::Api {
         params.requestedLevel = 15000;
 
         CurlRequest expectedRequest(
-            "http://testurl.com/srd/route/search?origin=EGKK&destination=EGLL&requestedLevel=15000",
+            "http://testurl.com/api/srd/route/search?origin=EGKK&destination=EGLL&requestedLevel=15000",
             CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -170,7 +170,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsGetAssignedHoldsRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/hold/assigned", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/hold/assigned", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -180,7 +180,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsSetAssignedHoldRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/hold/assigned", CurlRequest::METHOD_PUT);
+        CurlRequest expectedRequest("http://testurl.com/api/hold/assigned", CurlRequest::METHOD_PUT);
 
         nlohmann::json expectedData;
         expectedData["callsign"] = "BAW123";
@@ -196,7 +196,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsDeleteAssignedHoldRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/hold/assigned/BAW123", CurlRequest::METHOD_DELETE);
+        CurlRequest expectedRequest("http://testurl.com/api/hold/assigned/BAW123", CurlRequest::METHOD_DELETE);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -207,7 +207,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsBuildEnrouteReleaseRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/release/enroute", CurlRequest::METHOD_POST);
+        CurlRequest expectedRequest("http://testurl.com/api/release/enroute", CurlRequest::METHOD_POST);
 
         nlohmann::json expectedData{
             {"callsign", "BAW123"},
@@ -226,7 +226,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsBuildEnrouteReleaseRequestWithReleasePoint)
     {
-        CurlRequest expectedRequest("http://testurl.com/release/enroute", CurlRequest::METHOD_POST);
+        CurlRequest expectedRequest("http://testurl.com/api/release/enroute", CurlRequest::METHOD_POST);
 
         nlohmann::json expectedData{
             {"callsign", "BAW123"},
@@ -248,7 +248,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsGetAssignedStandsRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/stand/assignment", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/stand/assignment", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -258,7 +258,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsSetAssignedStandForAircraftRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/stand/assignment", CurlRequest::METHOD_PUT);
+        CurlRequest expectedRequest("http://testurl.com/api/stand/assignment", CurlRequest::METHOD_PUT);
 
         nlohmann::json expectedData;
         expectedData["callsign"] = "BAW123";
@@ -274,7 +274,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsDeleteAssignedStandForAircraftRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/stand/assignment/BAW123", CurlRequest::METHOD_DELETE);
+        CurlRequest expectedRequest("http://testurl.com/api/stand/assignment/BAW123", CurlRequest::METHOD_DELETE);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -285,7 +285,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsGetAllNotificationsRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/notifications", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/notifications", CurlRequest::METHOD_GET);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -296,7 +296,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsGetUnreadNotificationsRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/notifications/unread", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/notifications/unread", CurlRequest::METHOD_GET);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -307,7 +307,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsReadNotificationRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/notifications/read/1", CurlRequest::METHOD_PUT);
+        CurlRequest expectedRequest("http://testurl.com/api/notifications/read/1", CurlRequest::METHOD_PUT);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -318,7 +318,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsLatestVersionDetailsRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/version/latest?channel=beta", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/version/latest?channel=beta", CurlRequest::METHOD_GET);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -329,7 +329,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsPluginEventsSyncRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/plugin-events/sync", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/plugin-events/sync", CurlRequest::METHOD_GET);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -340,7 +340,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsGetLastestPluginEventsTest)
     {
-        CurlRequest expectedRequest("http://testurl.com/plugin-events/recent?previous=5", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/plugin-events/recent?previous=5", CurlRequest::METHOD_GET);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -351,7 +351,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsDepartureReleaseRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/departure/release/request", CurlRequest::METHOD_POST);
+        CurlRequest expectedRequest("http://testurl.com/api/departure/release/request", CurlRequest::METHOD_POST);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -370,7 +370,7 @@ namespace UKControllerPluginUtilsTest::Api {
     TEST_F(ApiRequestBuilderTest, ItBuildsApproveDepartureReleaseRequest)
     {
         CurlRequest expectedRequest(
-            "http://testurl.com/departure/release/request/1/approve", CurlRequest::METHOD_PATCH);
+            "http://testurl.com/api/departure/release/request/1/approve", CurlRequest::METHOD_PATCH);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -394,7 +394,7 @@ namespace UKControllerPluginUtilsTest::Api {
     TEST_F(ApiRequestBuilderTest, ItBuildsApproveDepartureReleaseRequestWithNoExpiry)
     {
         CurlRequest expectedRequest(
-            "http://testurl.com/departure/release/request/1/approve", CurlRequest::METHOD_PATCH);
+            "http://testurl.com/api/departure/release/request/1/approve", CurlRequest::METHOD_PATCH);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -417,7 +417,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsRejectDepartureReleaseRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/departure/release/request/1/reject", CurlRequest::METHOD_PATCH);
+        CurlRequest expectedRequest("http://testurl.com/api/departure/release/request/1/reject", CurlRequest::METHOD_PATCH);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -434,7 +434,7 @@ namespace UKControllerPluginUtilsTest::Api {
     TEST_F(ApiRequestBuilderTest, ItBuildsAcknowledgeDepartureReleaseRequest)
     {
         CurlRequest expectedRequest(
-            "http://testurl.com/departure/release/request/1/acknowledge", CurlRequest::METHOD_PATCH);
+            "http://testurl.com/api/departure/release/request/1/acknowledge", CurlRequest::METHOD_PATCH);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -449,7 +449,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsCancelDepartureReleaseRequest)
     {
-        CurlRequest expectedRequest("http://testurl.com/departure/release/request/1", CurlRequest::METHOD_DELETE);
+        CurlRequest expectedRequest("http://testurl.com/api/departure/release/request/1", CurlRequest::METHOD_DELETE);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -460,7 +460,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsCreatePrenoteMessageWithAllValues)
     {
-        CurlRequest expectedRequest("http://testurl.com/prenotes/messages", CurlRequest::METHOD_POST);
+        CurlRequest expectedRequest("http://testurl.com/api/prenotes/messages", CurlRequest::METHOD_POST);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -484,7 +484,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsCreatePrenoteMessageWithMissingValues)
     {
-        CurlRequest expectedRequest("http://testurl.com/prenotes/messages", CurlRequest::METHOD_POST);
+        CurlRequest expectedRequest("http://testurl.com/api/prenotes/messages", CurlRequest::METHOD_POST);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -507,7 +507,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsAcknowledgePrenoteMessage)
     {
-        CurlRequest expectedRequest("http://testurl.com/prenotes/messages/55/acknowledge", CurlRequest::METHOD_PATCH);
+        CurlRequest expectedRequest("http://testurl.com/api/prenotes/messages/55/acknowledge", CurlRequest::METHOD_PATCH);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -523,7 +523,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsDeletePrenoteMessage)
     {
-        CurlRequest expectedRequest("http://testurl.com/prenotes/messages/55", CurlRequest::METHOD_DELETE);
+        CurlRequest expectedRequest("http://testurl.com/api/prenotes/messages/55", CurlRequest::METHOD_DELETE);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -534,7 +534,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsMissedApproachMessage)
     {
-        CurlRequest expectedRequest("http://testurl.com/missed-approaches", CurlRequest::METHOD_POST);
+        CurlRequest expectedRequest("http://testurl.com/api/missed-approaches", CurlRequest::METHOD_POST);
 
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
@@ -548,7 +548,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsGetAllMetarsMessage)
     {
-        CurlRequest expectedRequest("http://testurl.com/metar", CurlRequest::METHOD_GET);
+        CurlRequest expectedRequest("http://testurl.com/api/metar", CurlRequest::METHOD_GET);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");
@@ -558,7 +558,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
     TEST_F(ApiRequestBuilderTest, ItBuildsMissedApproachAcknowledge)
     {
-        CurlRequest expectedRequest("http://testurl.com/missed-approaches/1", CurlRequest::METHOD_PATCH);
+        CurlRequest expectedRequest("http://testurl.com/api/missed-approaches/1", CurlRequest::METHOD_PATCH);
         expectedRequest.AddHeader("Authorization", "Bearer apikey");
         expectedRequest.AddHeader("Accept", "application/json");
         expectedRequest.AddHeader("Content-Type", "application/json");

--- a/test/utils/api/ApiUrlBuilderTest.cpp
+++ b/test/utils/api/ApiUrlBuilderTest.cpp
@@ -18,7 +18,7 @@ namespace UKControllerPluginUtilsTest::Api {
         auto requestData = ApiRequestData("test", HttpMethod::Get());
         auto builder = ApiUrlBuilder(settings);
 
-        EXPECT_EQ("https://ukcp.vatsim.uk/test", builder.BuildUrl(requestData));
+        EXPECT_EQ("https://ukcp.vatsim.uk/api/test", builder.BuildUrl(requestData));
     }
 
     TEST_F(ApiUrlBuilderTest, ItBuildsUrlRightTrimmingTheBaseUrl)
@@ -27,7 +27,7 @@ namespace UKControllerPluginUtilsTest::Api {
         auto requestData = ApiRequestData("test", HttpMethod::Get());
         auto builder = ApiUrlBuilder(settings);
 
-        EXPECT_EQ("https://ukcp.vatsim.uk/test", builder.BuildUrl(requestData));
+        EXPECT_EQ("https://ukcp.vatsim.uk/api/test", builder.BuildUrl(requestData));
     }
 
     TEST_F(ApiUrlBuilderTest, ItBuildsUrlLeftTrimmingTheUri)
@@ -36,7 +36,7 @@ namespace UKControllerPluginUtilsTest::Api {
         auto requestData = ApiRequestData("/test", HttpMethod::Get());
         auto builder = ApiUrlBuilder(settings);
 
-        EXPECT_EQ("https://ukcp.vatsim.uk/test", builder.BuildUrl(requestData));
+        EXPECT_EQ("https://ukcp.vatsim.uk/api/test", builder.BuildUrl(requestData));
     }
 
     TEST_F(ApiUrlBuilderTest, ItBuildsUrlRightTrimmingTheUri)
@@ -45,6 +45,6 @@ namespace UKControllerPluginUtilsTest::Api {
         auto requestData = ApiRequestData("test/", HttpMethod::Get());
         auto builder = ApiUrlBuilder(settings);
 
-        EXPECT_EQ("https://ukcp.vatsim.uk/test", builder.BuildUrl(requestData));
+        EXPECT_EQ("https://ukcp.vatsim.uk/api/test", builder.BuildUrl(requestData));
     }
 } // namespace UKControllerPluginUtilsTest::Api

--- a/test/utils/api/CurlApiRequestPerformerTest.cpp
+++ b/test/utils/api/CurlApiRequestPerformerTest.cpp
@@ -33,7 +33,7 @@ namespace UKControllerPluginUtilsTest::Api {
 
         [[nodiscard]] static auto GetRequest() -> CurlRequest
         {
-            CurlRequest expectedRequest("https://ukcp.vatsim.uk/test", CurlRequest::METHOD_GET);
+            CurlRequest expectedRequest("https://ukcp.vatsim.uk/api/test", CurlRequest::METHOD_GET);
             expectedRequest.AddHeader("Authorization", "Bearer key");
             expectedRequest.AddHeader("Accept", "application/json");
             expectedRequest.AddHeader("Content-Type", "application/json");


### PR DESCRIPTION
Compliments https://github.com/VATSIM-UK/uk-controller-api/pull/956 - prefix all the api routes so that we follow a more standard Laravel setup.