### PR TITLE
fix(handoff): departure frequencies not updating after runway dialog change

### DIFF
--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -281,7 +281,7 @@ set(src__handoff
     "handoff/HandoffModule.cpp"
     "handoff/HandoffModule.h"
     controller/HandoffEventHandler.cpp
-    handoff/HandoffOrder.h handoff/HandoffOrder.cpp handoff/FlightplanSidHandoffMapper.cpp handoff/FlightplanSidHandoffMapper.h handoff/HandoffCache.cpp handoff/HandoffCache.h handoff/DepartureHandoffResolver.cpp handoff/DepartureHandoffResolver.h handoff/FlightplanAirfieldHandoffMapper.cpp handoff/FlightplanAirfieldHandoffMapper.h handoff/ClearCacheOnActiveCallsignChanges.cpp handoff/ClearCacheOnActiveCallsignChanges.h)
+    handoff/HandoffOrder.h handoff/HandoffOrder.cpp handoff/FlightplanSidHandoffMapper.cpp handoff/FlightplanSidHandoffMapper.h handoff/HandoffCache.cpp handoff/HandoffCache.h handoff/DepartureHandoffResolver.cpp handoff/DepartureHandoffResolver.h handoff/FlightplanAirfieldHandoffMapper.cpp handoff/FlightplanAirfieldHandoffMapper.h handoff/ClearCacheOnActiveCallsignChanges.cpp handoff/ClearCacheOnActiveCallsignChanges.h handoff/ClearCacheOnRunwayDialogSave.cpp handoff/ClearCacheOnRunwayDialogSave.h)
 source_group("src\\handoff" FILES ${src__handoff})
 
 set(src__headings headings/Heading.h headings/Heading.cpp)

--- a/src/plugin/euroscope/RunwayDialogAwareInterface.h
+++ b/src/plugin/euroscope/RunwayDialogAwareInterface.h
@@ -9,6 +9,7 @@ namespace UKControllerPlugin::Euroscope {
     class RunwayDialogAwareInterface
     {
         public:
+        virtual ~RunwayDialogAwareInterface() = default;
         virtual void RunwayDialogSaved() = 0;
     };
 } // namespace UKControllerPlugin::Euroscope

--- a/src/plugin/handoff/ClearCacheOnRunwayDialogSave.cpp
+++ b/src/plugin/handoff/ClearCacheOnRunwayDialogSave.cpp
@@ -1,0 +1,15 @@
+#include "ClearCacheOnRunwayDialogSave.h"
+#include "HandoffCache.h"
+
+namespace UKControllerPlugin::Handoff {
+
+    ClearCacheOnRunwayDialogSave::ClearCacheOnRunwayDialogSave(std::shared_ptr<HandoffCache> cache) : cache(cache)
+    {
+        assert(cache && "Handoff cache not set in ctor");
+    }
+
+    void ClearCacheOnRunwayDialogSave::RunwayDialogSaved()
+    {
+        cache->Clear();
+    }
+} // namespace UKControllerPlugin::Handoff

--- a/src/plugin/handoff/ClearCacheOnRunwayDialogSave.h
+++ b/src/plugin/handoff/ClearCacheOnRunwayDialogSave.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "euroscope/RunwayDialogAwareInterface.h"
+
+namespace UKControllerPlugin::Handoff {
+
+    class HandoffCache;
+
+    class ClearCacheOnRunwayDialogSave : public Euroscope::RunwayDialogAwareInterface
+    {
+        public:
+        ClearCacheOnRunwayDialogSave(std::shared_ptr<HandoffCache> cache);
+        void RunwayDialogSaved() override;
+
+        private:
+        // The cache
+        const std::shared_ptr<HandoffCache> cache;
+    };
+} // namespace UKControllerPlugin::Handoff

--- a/src/plugin/handoff/HandoffModule.cpp
+++ b/src/plugin/handoff/HandoffModule.cpp
@@ -1,4 +1,5 @@
 #include "ClearCacheOnActiveCallsignChanges.h"
+#include "ClearCacheOnRunwayDialogSave.h"
 #include "DepartureHandoffResolver.h"
 #include "FlightplanAirfieldHandoffMapper.h"
 #include "FlightplanSidHandoffMapper.h"
@@ -9,6 +10,7 @@
 #include "bootstrap/PersistenceContainer.h"
 #include "controller/ActiveCallsignCollection.h"
 #include "dependency/DependencyLoaderInterface.h"
+#include "euroscope/RunwayDialogAwareCollection.h"
 #include "flightplan/FlightPlanEventHandlerCollection.h"
 #include "tag/TagItemCollection.h"
 
@@ -41,6 +43,7 @@ namespace UKControllerPlugin::Handoff {
         container.tagHandler->RegisterTagItem(handoffTagItem, handler);
         container.flightplanHandler->RegisterHandler(handler);
         container.activeCallsigns->AddHandler(std::make_shared<ClearCacheOnActiveCallsignChanges>(*cache));
+        container.runwayDialogEventHandlers->AddHandler(std::make_shared<ClearCacheOnRunwayDialogSave>(cache));
     }
 
     auto GetHandoffDependencyKey() -> std::string

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -155,7 +155,9 @@ set(test__handoff
     handoff/FlightplanSidHandoffMapperTest.cpp
     handoff/FlightplanAirfieldHandoffMapperTest.cpp
     handoff/HandoffCacheTest.cpp
-    handoff/DepartureHandoffResolverTest.cpp handoff/ClearCacheOnActiveCallsignChangesTest.cpp)
+    handoff/DepartureHandoffResolverTest.cpp
+    handoff/ClearCacheOnActiveCallsignChangesTest.cpp
+    handoff/ClearCacheOnRunwayDialogSaveTest.cpp)
 source_group("test\\handoff" FILES ${test__handoff})
 
 set(test__headings

--- a/test/plugin/handoff/ClearCacheOnRunwayDialogSaveTest.cpp
+++ b/test/plugin/handoff/ClearCacheOnRunwayDialogSaveTest.cpp
@@ -1,0 +1,28 @@
+#include "handoff/ClearCacheOnRunwayDialogSave.h"
+#include "handoff/HandoffCache.h"
+#include "handoff/ResolvedHandoff.h"
+
+using UKControllerPlugin::Handoff::ClearCacheOnRunwayDialogSave;
+using UKControllerPlugin::Handoff::HandoffCache;
+using UKControllerPlugin::Handoff::ResolvedHandoff;
+
+namespace UKControllerPluginTest::Handoff {
+
+    class ClearCacheOnRunwayDialogSaveTest : public testing::Test
+    {
+    };
+
+    TEST_F(ClearCacheOnRunwayDialogSaveTest, FlushingCallsignsClearsCache)
+    {
+        auto cache = std::make_shared<HandoffCache>();
+        ClearCacheOnRunwayDialogSave clear(cache);
+
+        cache->Add(std::make_shared<ResolvedHandoff>("BAW123", nullptr, nullptr, nullptr));
+        cache->Add(std::make_shared<ResolvedHandoff>("BAW456", nullptr, nullptr, nullptr));
+        cache->Add(std::make_shared<ResolvedHandoff>("BAW789", nullptr, nullptr, nullptr));
+
+        EXPECT_EQ(3, cache->Count());
+        clear.RunwayDialogSaved();
+        EXPECT_EQ(0, cache->Count());
+    }
+} // namespace UKControllerPluginTest::Handoff

--- a/test/plugin/handoff/HandoffModuleTest.cpp
+++ b/test/plugin/handoff/HandoffModuleTest.cpp
@@ -1,8 +1,8 @@
 #include "bootstrap/PersistenceContainer.h"
 #include "controller/ActiveCallsignCollection.h"
+#include "euroscope/RunwayDialogAwareCollection.h"
 #include "flightplan/FlightPlanEventHandlerCollection.h"
 #include "handoff/HandoffModule.h"
-#include "handoff/HandoffCollection.h"
 #include "integration/IntegrationServer.h"
 #include "tag/TagItemCollection.h"
 
@@ -10,6 +10,7 @@ using ::testing::NiceMock;
 using ::testing::Test;
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
 using UKControllerPlugin::Controller::ActiveCallsignCollection;
+using UKControllerPlugin::Euroscope::RunwayDialogAwareCollection;
 using UKControllerPlugin::Flightplan::FlightPlanEventHandlerCollection;
 using UKControllerPlugin::Handoff::BootstrapPlugin;
 using UKControllerPlugin::Integration::IntegrationPersistenceContainer;
@@ -26,6 +27,7 @@ namespace UKControllerPluginTest::Handoff {
             this->container.tagHandler = std::make_unique<TagItemCollection>();
             this->container.flightplanHandler = std::make_unique<FlightPlanEventHandlerCollection>();
             this->container.activeCallsigns = std::make_unique<ActiveCallsignCollection>();
+            this->container.runwayDialogEventHandlers = std::make_unique<RunwayDialogAwareCollection>();
             this->container.integrationModuleContainer =
                 std::make_unique<IntegrationPersistenceContainer>(nullptr, nullptr, nullptr);
         }
@@ -51,5 +53,11 @@ namespace UKControllerPluginTest::Handoff {
     {
         BootstrapPlugin(this->container, this->dependencyLoader);
         ASSERT_EQ(1, this->container.activeCallsigns->CountHandlers());
+    }
+
+    TEST_F(HandoffModuleTest, TestItRegistersRunwayDialogHandler)
+    {
+        BootstrapPlugin(this->container, this->dependencyLoader);
+        ASSERT_EQ(1, this->container.runwayDialogEventHandlers->CountHandlers());
     }
 } // namespace UKControllerPluginTest::Handoff


### PR DESCRIPTION
Runway dialog changes do trigger a SID change, but do not trigger a FP change event.
This means the plugin does not update the departure frequencies of any FPs that had
an airfield resolved handoff, even if the new SID (after the runway dialog change) would
have had a different controller. This fixes that by clearing the handoff cache after
a runway dialog change.

fix #480