### PR TITLE
fix: invalidate intention code caches on controller and fp events

### DIFF
--- a/test/plugin/intention/IntentionCodeBootstrapProviderTest.cpp
+++ b/test/plugin/intention/IntentionCodeBootstrapProviderTest.cpp
@@ -34,10 +34,16 @@ namespace UKControllerPluginTest::IntentionCode {
         IntentionCodeBootstrapProvider provider;
     };
 
-    TEST_F(IntentionCodeModuleBootstrapProviderTest, TestItRegistersFirExitGeneratorForFlightplanEvents)
+    TEST_F(IntentionCodeModuleBootstrapProviderTest, TestItRegistersFirExitAndIntentionGeneratorsForFlightplanEvents)
     {
         this->RunBootstrapPlugin(provider);
-        EXPECT_EQ(1, container.flightplanHandler->CountHandlers());
+        EXPECT_EQ(2, container.flightplanHandler->CountHandlers());
+    }
+
+    TEST_F(IntentionCodeModuleBootstrapProviderTest, TestItRegistersIntentionGeneratorForActiveCallsignEvents)
+    {
+        this->RunBootstrapPlugin(provider);
+        EXPECT_EQ(1, container.activeCallsigns->CountHandlers());
     }
 
     TEST_F(IntentionCodeModuleBootstrapProviderTest, TestItRegistersIntegrationCodeUpdatedMessageForEvents)


### PR DESCRIPTION
Intention codes weren't clearing on FP/Controller events, leading to stale codes.