### PR TITLE
Hold outbound leg details

### DIFF
--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -269,7 +269,7 @@ set(src__flightrule
 source_group("src\\flightrule" FILES ${src__flightrule})
 
 set(src__geometry
-        geometry/Line.cpp geometry/Line.h geometry/DistanceRadiusToScreenRadius.cpp geometry/DistanceRadiusToScreenRadius.h)
+        geometry/Line.cpp geometry/Line.h geometry/DistanceRadiusToScreenRadius.cpp geometry/DistanceRadiusToScreenRadius.h geometry/MeasurementUnitType.h geometry/MeasurementUnitFactory.cpp geometry/MeasurementUnitFactory.h geometry/Measurement.cpp geometry/Measurement.h geometry/MeasurementUnit.cpp geometry/MeasurementUnit.h)
 source_group("src\\geometry" FILES ${src__geometry})
 
 set(src__graphics

--- a/src/plugin/geometry/Measurement.cpp
+++ b/src/plugin/geometry/Measurement.cpp
@@ -1,0 +1,12 @@
+#include "Measurement.h"
+#include "MeasurementUnit.h"
+
+namespace UKControllerPlugin::Geometry {
+
+    Measurement::Measurement(std::unique_ptr<MeasurementUnit> unit, double value) : unit(std::move(unit)), value(value)
+    {
+        assert(this->unit && "Invalid unit in measurement");
+    }
+
+    Measurement::~Measurement() = default;
+} // namespace UKControllerPlugin::Geometry

--- a/src/plugin/geometry/Measurement.h
+++ b/src/plugin/geometry/Measurement.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "MeasurementUnit.h"
+
+namespace UKControllerPlugin::Geometry {
+
+    struct MeasurementUnit;
+
+    /**
+     * A measurement, comprising a unit and a value
+     */
+    struct Measurement
+    {
+        public:
+        Measurement(std::unique_ptr<MeasurementUnit> unit, double value);
+        ~Measurement();
+
+        // The unit for the measurement
+        std::unique_ptr<MeasurementUnit> unit;
+
+        // The value of the measurement
+        double value;
+    };
+} // namespace UKControllerPlugin::Geometry

--- a/src/plugin/geometry/MeasurementUnit.cpp
+++ b/src/plugin/geometry/MeasurementUnit.cpp
@@ -1,0 +1,8 @@
+#include "MeasurementUnit.h"
+
+namespace UKControllerPlugin::Geometry {
+    auto MeasurementUnit::operator==(const MeasurementUnitType& type) const -> bool
+    {
+        return this->type == type;
+    }
+} // namespace UKControllerPlugin::Geometry

--- a/src/plugin/geometry/MeasurementUnit.h
+++ b/src/plugin/geometry/MeasurementUnit.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "MeasurementUnitType.h"
+
+namespace UKControllerPlugin::Geometry {
+    struct MeasurementUnit
+    {
+        MeasurementUnit(MeasurementUnitType type, std::string description)
+            : type(type), description(std::move(description)){};
+
+        // An enum representing the unit type
+        MeasurementUnitType type;
+
+        // A description of the unit
+        std::string description;
+
+        [[nodiscard]] auto operator==(const MeasurementUnitType& type) const -> bool;
+    };
+} // namespace UKControllerPlugin::Geometry

--- a/src/plugin/geometry/MeasurementUnitFactory.cpp
+++ b/src/plugin/geometry/MeasurementUnitFactory.cpp
@@ -1,0 +1,50 @@
+#include "MeasurementUnit.h"
+#include "MeasurementUnitFactory.h"
+
+namespace UKControllerPlugin::Geometry {
+
+    auto UnitTypeFromString(const std::string& unitString) -> MeasurementUnitType
+    {
+        if (unitString == "s") {
+            return MeasurementUnitType::Seconds;
+        }
+
+        if (unitString == "min") {
+            return MeasurementUnitType::Minutes;
+        }
+
+        if (unitString == "nm") {
+            return MeasurementUnitType::NauticalMiles;
+        }
+
+        return MeasurementUnitType::None;
+    }
+
+    auto UnitToString(MeasurementUnitType unit) -> std::string
+    {
+        if (unit == MeasurementUnitType::Seconds) {
+            return "Seconds";
+        }
+
+        if (unit == MeasurementUnitType::Minutes) {
+            return "Minutes";
+        }
+
+        if (unit == MeasurementUnitType::NauticalMiles) {
+            return "NM";
+        }
+
+        return "??";
+    }
+
+    auto UnitFromString(const std::string& unitString) -> std::unique_ptr<MeasurementUnit>
+    {
+        const auto unitType = UnitTypeFromString(unitString);
+        return std::make_unique<MeasurementUnit>(unitType, UnitToString(unitType));
+    }
+
+    auto UnitStringValid(const std::string& unitString) -> bool
+    {
+        return UnitTypeFromString(unitString) != MeasurementUnitType::None;
+    }
+} // namespace UKControllerPlugin::Geometry

--- a/src/plugin/geometry/MeasurementUnitFactory.h
+++ b/src/plugin/geometry/MeasurementUnitFactory.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "MeasurementUnitType.h"
+
+namespace UKControllerPlugin::Geometry {
+    struct MeasurementUnit;
+
+    [[nodiscard]] auto UnitFromString(const std::string& unitString) -> std::unique_ptr<MeasurementUnit>;
+    [[nodiscard]] auto UnitStringValid(const std::string& unitString) -> bool;
+} // namespace UKControllerPlugin::Geometry

--- a/src/plugin/geometry/MeasurementUnitType.h
+++ b/src/plugin/geometry/MeasurementUnitType.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace UKControllerPlugin::Geometry {
+    enum class MeasurementUnitType : unsigned int
+    {
+        None,
+        Seconds,
+        Minutes,
+        NauticalMiles,
+    };
+} // namespace UKControllerPlugin::Geometry

--- a/src/plugin/hold/HoldDisplay.cpp
+++ b/src/plugin/hold/HoldDisplay.cpp
@@ -681,9 +681,8 @@ namespace UKControllerPlugin {
             // Render the title bar
             this->RenderTitleBar(graphics, radarScreen, screenObjectId);
 
-            // Render the data
             Gdiplus::Rect dataRect = {
-                this->windowPos.x, this->dataStartHeight - 10, this->windowWidth, this->lineHeight};
+                this->windowPos.x, this->dataStartHeight - 15, this->windowWidth, this->lineHeight};
 
             // Render a message if no published holds
             if (this->publishedHolds.empty()) {
@@ -691,9 +690,14 @@ namespace UKControllerPlugin {
                 return;
             }
 
+            // Display the published hold selection buttons
+
             const HoldingData* hold = *this->publishedHolds.cbegin();
 
             // Render the data
+            graphics.DrawString(ConvertToTchar(hold->description), dataRect, this->dataBrush);
+
+            dataRect.Y = dataRect.Y + this->lineHeight + 5;
             graphics.DrawString(
                 std::wstring(L"Fix: ") + ConvertToTchar(this->navaid.identifier), dataRect, this->dataBrush);
 

--- a/src/plugin/hold/HoldDisplay.cpp
+++ b/src/plugin/hold/HoldDisplay.cpp
@@ -98,6 +98,19 @@ namespace UKControllerPlugin {
                 this->showHoldInformation = !this->showHoldInformation;
             } else if (button == "options") {
                 this->dialogManager.OpenDialog(IDD_HOLD_PARAMS, reinterpret_cast<LPARAM>(this));
+            } else if (button == "prevhold") {
+                if (this->selectedPublishedHoldIndex == 0) {
+                    return;
+                }
+
+                this->selectedPublishedHoldIndex--;
+            } else if (button == "nexthold") {
+                if (this->publishedHolds.empty() ||
+                    this->selectedPublishedHoldIndex == this->publishedHolds.size() - 1) {
+                    return;
+                }
+
+                this->selectedPublishedHoldIndex++;
             }
         }
 
@@ -118,6 +131,11 @@ namespace UKControllerPlugin {
             if (button == "add") {
                 addAircraftSelector->Trigger({this->addButtonClickRect.left, this->addButtonClickRect.top});
             }
+        }
+
+        unsigned int HoldDisplay::GetPublishedHoldIndex() const
+        {
+            return this->selectedPublishedHoldIndex;
         }
 
         /*
@@ -691,8 +709,37 @@ namespace UKControllerPlugin {
             }
 
             // Display the published hold selection buttons
+            const HoldingData* hold = *std::next(this->publishedHolds.cbegin(), this->selectedPublishedHoldIndex);
 
-            const HoldingData* hold = *this->publishedHolds.cbegin();
+            Gdiplus::Rect buttonRect = {this->windowPos.x + 5, this->titleArea.GetBottom() + 5, 20, 20};
+
+            // Left
+            graphics.DrawRect(buttonRect, this->sameLevelBoxPen);
+            graphics.DrawString(L"<", buttonRect, this->dataBrush);
+            radarScreen.RegisterScreenObject(
+                screenObjectId,
+                this->navaid.identifier + "/prevhold",
+                RECT{buttonRect.GetLeft(), buttonRect.GetTop(), buttonRect.GetRight(), buttonRect.GetBottom()},
+                false);
+
+            // Right
+            buttonRect.X = this->titleArea.GetRight() - 25;
+            graphics.DrawRect(buttonRect, this->sameLevelBoxPen);
+            graphics.DrawString(L">", buttonRect, this->dataBrush);
+            radarScreen.RegisterScreenObject(
+                screenObjectId,
+                this->navaid.identifier + "/nexthold",
+                RECT{buttonRect.GetLeft(), buttonRect.GetTop(), buttonRect.GetRight(), buttonRect.GetBottom()},
+                false);
+
+            // Text
+            buttonRect.X = this->windowPos.x + 30;
+            buttonRect.Width = this->titleArea.Width - 60;
+            graphics.DrawString(
+                L"Hold " + std::to_wstring(this->selectedPublishedHoldIndex + 1) + L" of " +
+                    std::to_wstring(this->publishedHolds.size()),
+                buttonRect,
+                this->dataBrush);
 
             // Render the data
             graphics.DrawString(ConvertToTchar(hold->description), dataRect, this->dataBrush);

--- a/src/plugin/hold/HoldDisplay.cpp
+++ b/src/plugin/hold/HoldDisplay.cpp
@@ -686,7 +686,7 @@ namespace UKControllerPlugin {
                 this->windowPos.x, this->dataStartHeight - 10, this->windowWidth, this->lineHeight};
 
             // Render a message if no published holds
-            if (!this->publishedHolds.size()) {
+            if (this->publishedHolds.empty()) {
                 graphics.DrawString(std::wstring(L"No published holds found."), dataRect, this->dataBrush);
                 return;
             }

--- a/src/plugin/hold/HoldDisplay.cpp
+++ b/src/plugin/hold/HoldDisplay.cpp
@@ -14,6 +14,8 @@
 #include "euroscope/EuroscopePluginLoopbackInterface.h"
 #include "euroscope/EuroscopeRadarLoopbackInterface.h"
 #include "euroscope/UserSetting.h"
+#include "geometry/Measurement.h"
+#include "geometry/MeasurementUnit.h"
 #include "graphics/GdiGraphicsInterface.h"
 #include "list/PopupListInterface.h"
 #include "navaids/Navaid.h"
@@ -686,7 +688,8 @@ namespace UKControllerPlugin {
             const HoldingData* hold = *this->publishedHolds.cbegin();
 
             // Render the data
-            Gdiplus::Rect dataRect = {this->windowPos.x, this->dataStartHeight, this->windowWidth, this->lineHeight};
+            Gdiplus::Rect dataRect = {this->windowPos.x, this->dataStartHeight - 10, this->windowWidth,
+                                      this->lineHeight};
 
             graphics.DrawString(
                 std::wstring(L"Fix: ") + ConvertToTchar(this->navaid.identifier), dataRect, this->dataBrush);
@@ -703,6 +706,18 @@ namespace UKControllerPlugin {
 
             dataRect.Y = dataRect.Y + this->lineHeight + 5;
             graphics.DrawString(std::wstring(L"Minimum: ") + ConvertToTchar(hold->minimum), dataRect, this->dataBrush);
+
+            dataRect.Y = dataRect.Y + this->lineHeight + 5;
+
+            if (*hold->outboundLeg->unit == Geometry::MeasurementUnitType::None) {
+                graphics.DrawString(std::wstring(L"Outbound Leg: --"), dataRect, this->dataBrush);
+            } else {
+                graphics.DrawString(
+                    std::wstring(L"Outbound Leg: ") + FormatOutboundLegValue(hold->outboundLeg->value) + L" " +
+                        ConvertToTchar(hold->outboundLeg->unit->description),
+                    dataRect,
+                    this->dataBrush);
+            }
         }
 
         /*

--- a/src/plugin/hold/HoldDisplay.cpp
+++ b/src/plugin/hold/HoldDisplay.cpp
@@ -681,16 +681,19 @@ namespace UKControllerPlugin {
             // Render the title bar
             this->RenderTitleBar(graphics, radarScreen, screenObjectId);
 
+            // Render the data
+            Gdiplus::Rect dataRect = {
+                this->windowPos.x, this->dataStartHeight - 10, this->windowWidth, this->lineHeight};
+
+            // Render a message if no published holds
             if (!this->publishedHolds.size()) {
+                graphics.DrawString(std::wstring(L"No published holds found."), dataRect, this->dataBrush);
                 return;
             }
 
             const HoldingData* hold = *this->publishedHolds.cbegin();
 
             // Render the data
-            Gdiplus::Rect dataRect = {this->windowPos.x, this->dataStartHeight - 10, this->windowWidth,
-                                      this->lineHeight};
-
             graphics.DrawString(
                 std::wstring(L"Fix: ") + ConvertToTchar(this->navaid.identifier), dataRect, this->dataBrush);
 

--- a/src/plugin/hold/HoldDisplay.h
+++ b/src/plugin/hold/HoldDisplay.h
@@ -82,6 +82,7 @@ namespace UKControllerPlugin {
             int GetMinimumLevel(void) const;
             void SetMaximumLevel(int level);
             void SetMinimumLevel(int level);
+            unsigned int GetPublishedHoldIndex() const;
             std::map<int, std::set<std::shared_ptr<HoldingAircraft>, CompareHoldingAircraft>> MapAircraftToLevels(
                 const std::set<std::shared_ptr<HoldingAircraft>, CompareHoldingAircraft>& aircraft) const;
             bool IsInInformationMode(void) const;
@@ -205,6 +206,9 @@ namespace UKControllerPlugin {
 
             // Should we display the information about the hold
             bool showHoldInformation = false;
+
+            // The currently selected published hold to display in the information tab
+            unsigned int selectedPublishedHoldIndex = 0;
 
             // Titlebar
             Gdiplus::Rect titleArea = {0, 0, this->windowWidth, 15};

--- a/src/plugin/hold/HoldDisplay.h
+++ b/src/plugin/hold/HoldDisplay.h
@@ -195,7 +195,7 @@ namespace UKControllerPlugin {
             bool minimised = false;
 
             // The height of the window to use when doing the information display
-            const int informationDisplayWindowHeight = 225;
+            const int informationDisplayWindowHeight = 250;
 
             // The minimum level in the hold
             int minimumLevel = 7000;

--- a/src/plugin/hold/HoldDisplayFunctions.cpp
+++ b/src/plugin/hold/HoldDisplayFunctions.cpp
@@ -111,5 +111,15 @@ namespace UKControllerPlugin {
 
             return verticalSpeed > 0 ? 1 : -1;
         }
+
+        auto FormatOutboundLegValue(double value) -> std::wstring
+        {
+            std::wstringstream stream;
+            stream.setf(std::ios::fixed);
+            stream.precision(1);
+            stream << value;
+
+            return stream.str();
+        }
     } // namespace Hold
 } // namespace UKControllerPlugin

--- a/src/plugin/hold/HoldDisplayFunctions.h
+++ b/src/plugin/hold/HoldDisplayFunctions.h
@@ -14,5 +14,6 @@ namespace UKControllerPlugin {
         unsigned int GetDisplayRow(int holdMax, int occupiedLevel);
         std::wstring GetTimeInHoldDisplayString(const std::chrono::system_clock::time_point& entryTime);
         int GetVerticalSpeedDirection(int verticalSpeed);
+        [[nodiscard]] auto FormatOutboundLegValue(double value) -> std::wstring;
     } // namespace Hold
 } // namespace UKControllerPlugin

--- a/src/plugin/hold/HoldingData.cpp
+++ b/src/plugin/hold/HoldingData.cpp
@@ -11,7 +11,7 @@ namespace UKControllerPlugin::Hold {
         : identifier(original.identifier), fix(original.fix), description(original.description),
           minimum(original.minimum), maximum(original.maximum), inbound(original.inbound),
           turnDirection(original.turnDirection), restrictions(std::move(original.restrictions)),
-          deemedSeparatedHolds(std::move(original.deemedSeparatedHolds))
+          deemedSeparatedHolds(std::move(original.deemedSeparatedHolds)), outboundLeg(std::move(original.outboundLeg))
     {
     }
 

--- a/src/plugin/hold/HoldingData.h
+++ b/src/plugin/hold/HoldingData.h
@@ -1,4 +1,7 @@
 #pragma once
+#include "geometry/Measurement.h"
+#include "geometry/MeasurementUnit.h"
+#include "geometry/MeasurementUnitType.h"
 
 namespace UKControllerPlugin {
     namespace Hold {
@@ -19,10 +22,15 @@ namespace UKControllerPlugin {
                 unsigned int inbound = 361,
                 std::string turnDirection = "up",
                 std::set<std::unique_ptr<AbstractHoldLevelRestriction>> restrictions = {},
-                std::set<std::unique_ptr<DeemedSeparatedHold>> deemedSeparatedHolds = {})
+                std::set<std::unique_ptr<DeemedSeparatedHold>> deemedSeparatedHolds = {},
+                std::unique_ptr<Geometry::Measurement> outboundLeg = std::make_unique<Geometry::Measurement>(
+                    std::make_unique<Geometry::MeasurementUnit>(Geometry::MeasurementUnitType::None, "Unknown Units"),
+                    -1.0))
                 : identifier(identifier), fix(fix), description(description), minimum(minimum), maximum(maximum),
                   inbound(inbound), turnDirection(turnDirection), restrictions(std::move(restrictions)),
-                  deemedSeparatedHolds(std::move(deemedSeparatedHolds)){};
+                  deemedSeparatedHolds(std::move(deemedSeparatedHolds)), outboundLeg(std::move(outboundLeg))
+            {
+            }
             ~HoldingData();
             HoldingData(HoldingData const&) = delete;
             HoldingData& operator=(HoldingData const&) = delete;
@@ -56,6 +64,9 @@ namespace UKControllerPlugin {
 
             // Holds against which this hold is deemed separated
             std::set<std::unique_ptr<DeemedSeparatedHold>> deemedSeparatedHolds;
+
+            // The outbound leg
+            std::unique_ptr<Geometry::Measurement> outboundLeg;
 
             /*
                 Compare two holds

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -146,7 +146,7 @@ set(test__flightrule
 source_group("test\\flightrule" FILES ${test__flightrule})
 
 set(test__geometry
-        geometry/LineTest.cpp geometry/DistanceRadiusToScreenRadiusTest.cpp)
+        geometry/LineTest.cpp geometry/DistanceRadiusToScreenRadiusTest.cpp geometry/MeasurementUnitFactoryTest.cpp)
 source_group("test\\geometry" FILES ${test__geometry})
 
 set(test__handoff

--- a/test/plugin/geometry/MeasurementUnitFactoryTest.cpp
+++ b/test/plugin/geometry/MeasurementUnitFactoryTest.cpp
@@ -1,0 +1,61 @@
+#include "geometry/MeasurementUnit.h"
+#include "geometry/MeasurementUnitType.h"
+#include "geometry/MeasurementUnitFactory.h"
+
+using UKControllerPlugin::Geometry::MeasurementUnitType;
+using UKControllerPlugin::Geometry::UnitFromString;
+using UKControllerPlugin::Geometry::UnitStringValid;
+
+namespace UKControllerPluginTest::Geometry {
+    class MeasurementUnitFactoryTest : public testing::Test
+    {
+    };
+
+    TEST_F(MeasurementUnitFactoryTest, ItReturnsSecondsFromString)
+    {
+        const auto unit = UnitFromString("s");
+        EXPECT_EQ(*unit, MeasurementUnitType::Seconds);
+        EXPECT_EQ(unit->description, "Seconds");
+    }
+
+    TEST_F(MeasurementUnitFactoryTest, ItReturnsMinutesFromString)
+    {
+        const auto unit = UnitFromString("min");
+        EXPECT_EQ(*unit, MeasurementUnitType::Minutes);
+        EXPECT_EQ(unit->description, "Minutes");
+    }
+
+    TEST_F(MeasurementUnitFactoryTest, ItReturnsNauticalMilesFromString)
+    {
+        const auto unit = UnitFromString("nm");
+        EXPECT_EQ(*unit, MeasurementUnitType::NauticalMiles);
+        EXPECT_EQ(unit->description, "NM");
+    }
+
+    TEST_F(MeasurementUnitFactoryTest, ItReturnsUnknownUnitFromString)
+    {
+        const auto unit = UnitFromString("abc");
+        EXPECT_EQ(*unit, MeasurementUnitType::None);
+        EXPECT_EQ(unit->description, "??");
+    }
+
+    TEST_F(MeasurementUnitFactoryTest, StringIsValidSeconds)
+    {
+        EXPECT_TRUE(UnitStringValid("s"));
+    }
+
+    TEST_F(MeasurementUnitFactoryTest, StringIsValidMinutes)
+    {
+        EXPECT_TRUE(UnitStringValid("min"));
+    }
+
+    TEST_F(MeasurementUnitFactoryTest, StringIsValidNauticalMiles)
+    {
+        EXPECT_TRUE(UnitStringValid("nm"));
+    }
+
+    TEST_F(MeasurementUnitFactoryTest, StringIsNotValidUnknownString)
+    {
+        EXPECT_FALSE(UnitStringValid("abc"));
+    }
+} // namespace UKControllerPluginTest::Geometry

--- a/test/plugin/hold/HoldDisplayFunctionsTest.cpp
+++ b/test/plugin/hold/HoldDisplayFunctionsTest.cpp
@@ -169,4 +169,19 @@ namespace UKControllerPluginTest::Hold {
     {
         EXPECT_EQ(-1, UKControllerPlugin::Hold::GetVerticalSpeedDirection(-500));
     }
+
+    TEST(HoldDisplayFunctionsTest, ItReturnsOutboundLegValueIfWhole)
+    {
+        EXPECT_EQ(std::wstring(L"2.0"), UKControllerPlugin::Hold::FormatOutboundLegValue(2.0));
+    }
+
+    TEST(HoldDisplayFunctionsTest, ItReturnsOutboundLegValueIfMultipleDecimalPlaces)
+    {
+        EXPECT_EQ(std::wstring(L"3.1"), UKControllerPlugin::Hold::FormatOutboundLegValue(3.134));
+    }
+
+    TEST(HoldDisplayFunctionsTest, ItReturnsOutboundLegValueIfOneDecimalPlace)
+    {
+        EXPECT_EQ(std::wstring(L"4.5"), UKControllerPlugin::Hold::FormatOutboundLegValue(4.5));
+    }
 } // namespace UKControllerPluginTest::Hold

--- a/test/plugin/hold/HoldDisplayTest.cpp
+++ b/test/plugin/hold/HoldDisplayTest.cpp
@@ -212,6 +212,34 @@ namespace UKControllerPluginTest {
             this->display.SaveDataToAsr(userSetting);
         }
 
+        TEST_F(HoldDisplayTest, ClickingPreviousAndNextHoldChangesSelectedHold)
+        {
+            this->publishedHolds.Add({1, "TIMBA", "TIMBA", 2000, 3000});
+            this->publishedHolds.Add({2, "TIMBA", "TIMBA", 2000, 3000});
+            this->publishedHolds.Add({3, "TIMBA", "TIMBA", 2000, 3000});
+            this->publishedHolds.Add({4, "TIMBA", "TIMBA", 2000, 3000});
+
+            HoldDisplay display2(mockPlugin, holdManager, navaid, publishedHolds, dialogManager, addAircraftList);
+
+            EXPECT_EQ(0, display2.GetPublishedHoldIndex());
+            display2.ButtonClicked("nexthold");
+            EXPECT_EQ(1, display2.GetPublishedHoldIndex());
+            display2.ButtonClicked("nexthold");
+            EXPECT_EQ(2, display2.GetPublishedHoldIndex());
+            display2.ButtonClicked("nexthold");
+            EXPECT_EQ(3, display2.GetPublishedHoldIndex());
+            display2.ButtonClicked("nexthold");
+            EXPECT_EQ(3, display2.GetPublishedHoldIndex());
+            display2.ButtonClicked("prevhold");
+            EXPECT_EQ(2, display2.GetPublishedHoldIndex());
+            display2.ButtonClicked("prevhold");
+            EXPECT_EQ(1, display2.GetPublishedHoldIndex());
+            display2.ButtonClicked("prevhold");
+            EXPECT_EQ(0, display2.GetPublishedHoldIndex());
+            display2.ButtonClicked("prevhold");
+            EXPECT_EQ(0, display2.GetPublishedHoldIndex());
+        }
+
         TEST_F(HoldDisplayTest, ClickingMinusDescreasesMaximumDisplayLevelUntilMinimum)
         {
             EXPECT_EQ(15000, this->display.GetMaximumLevel());

--- a/test/plugin/hold/HoldModuleTest.cpp
+++ b/test/plugin/hold/HoldModuleTest.cpp
@@ -21,6 +21,9 @@
 #include "hold/HoldManager.h"
 #include "hold/PublishedHoldCollection.h"
 #include "hold/HoldSelectionMenu.h"
+#include "geometry/Measurement.h"
+#include "geometry/MeasurementUnit.h"
+#include "geometry/MeasurementUnitFactory.h"
 
 using ::testing::_;
 using ::testing::NiceMock;
@@ -67,6 +70,8 @@ namespace UKControllerPluginTest::Hold {
                 {"maximum_altitude", 15000},
                 {"inbound_heading", 309},
                 {"turn_direction", "right"},
+                {"outbound_leg_unit", "nm"},
+                {"outbound_leg_value", 1.5},
                 {"restrictions", nlohmann::json::array()},
                 {"deemed_separated_holds", nlohmann::json::array()}};
 
@@ -79,6 +84,8 @@ namespace UKControllerPluginTest::Hold {
                 {"maximum_altitude", 15000},
                 {"inbound_heading", 309},
                 {"turn_direction", "right"},
+                {"outbound_leg_unit", "nm"},
+                {"outbound_leg_value", 1.5},
                 {"restrictions", nlohmann::json::array()},
                 {"deemed_separated_holds", nlohmann::json::array()}};
 
@@ -194,7 +201,18 @@ namespace UKControllerPluginTest::Hold {
     TEST_F(HoldModuleTest, ItLoadsHoldData)
     {
         BootstrapPlugin(this->mockDependencyProvider, this->container);
-        HoldingData expectedHold = {1, "TIMBA", "TIMBA", 7000, 15000, 309, HoldingData::TURN_DIRECTION_RIGHT, {}, {}};
+        HoldingData expectedHold = {
+            1,
+            "TIMBA",
+            "TIMBA",
+            7000,
+            15000,
+            309,
+            HoldingData::TURN_DIRECTION_RIGHT,
+            {},
+            {},
+            std::make_unique<UKControllerPlugin::Geometry::Measurement>(
+                UKControllerPlugin::Geometry::UnitFromString("nm"), 1.5)};
 
         std::set<const HoldingData*> expectedHoldSet;
         expectedHoldSet.emplace(&expectedHold);

--- a/test/plugin/hold/PublishedHoldCollectionFactoryTest.cpp
+++ b/test/plugin/hold/PublishedHoldCollectionFactoryTest.cpp
@@ -45,6 +45,8 @@ namespace UKControllerPluginTest {
             hold1["turn_direction"] = "right";
             hold1["restrictions"] = nlohmann::json::array();
             hold1["deemed_separated_holds"] = nlohmann::json::array();
+            hold1["outbound_leg_unit"] = "nm";
+            hold1["outbound_leg_value"] = 1.5;
             nlohmann::json hold2;
             hold2["id"] = 2;
             hold2["description"] = "WILLO";
@@ -53,6 +55,8 @@ namespace UKControllerPluginTest {
             hold2["maximum_altitude"] = 15000;
             hold2["inbound_heading"] = 285;
             hold2["turn_direction"] = "left";
+            hold2["outbound_leg_unit"] = "nm";
+            hold2["outbound_leg_value"] = 1.5;
             hold2["restrictions"] = nlohmann::json::array();
             hold2["deemed_separated_holds"] = nlohmann::json::array();
 
@@ -78,6 +82,8 @@ namespace UKControllerPluginTest {
             hold["maximum_altitude"] = 15000;
             hold["inbound_heading"] = 309;
             hold["turn_direction"] = "left";
+            hold["outbound_leg_unit"] = "nm";
+            hold["outbound_leg_value"] = 1.5;
 
             data = {hold};
 


### PR DESCRIPTION
- Display the outbound leg details in the hold information display
- Show the description of the hold (for holds with multiple published holds)
- Allow switching between published holds on the information display 