### PR TITLE
fix: oceanic tag items crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: windows-server-2019
     concurrency:
       group: ukcp-build-${{ github.ref }}
       cancel-in-progress: true
@@ -113,8 +113,7 @@ jobs:
       - name: Run Tests
         working-directory: build
         run: |
-          dir .\\bin\\
-          .\\bin\\UKControllerPluginCoreTest.exe
+          ctest -C Release --output-on-failure --no-tests=error
 
       # Do Srclinting
       - name: Get Changed Files (Src)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,10 @@ jobs:
       # Run the build and tests
       - name: Run Ninja Build
         working-directory: build
-        run: ninja
+        run: |
+          Get-ChildItem c:\windows\syswow64 -include *.dll -recurse | foreach-object { "{0}" -f [System.Diagnostics.FileVersionInfo]::GetVersionInfo($_) } | Select-String -Pattern "vcruntime|api-ms-win-crt|msvcp140|gdiplus|normaliz|wldap32|crypt32|advapi32|winmm|ole32|shell32|ws2_32|gdi32|user32|kernel32" > dlls.txt
+          type dlls.txt
+          ninja
 
       - name: Run Tests
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Run Tests
         working-directory: build
         run: |
+          dir .\\bin\\
           .\\bin\\UKControllerPluginCoreTest.exe
 
       # Do Srclinting

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,6 @@ jobs:
         working-directory: build
         run: |
           .\\bin\\UKControllerPluginCoreTest.exe
-          ctest -C Release --output-on-failure --no-tests=error
 
       # Do Srclinting
       - name: Get Changed Files (Src)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,15 +103,12 @@ jobs:
           CFLAGS: -m32
           CXX: clang-cl
           CXXFLAGS: -m32
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DEPENDS_USE_COMPILER=FALSE -G Ninja -Bbuild
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -G Ninja -Bbuild
 
       # Run the build and tests
       - name: Run Ninja Build
         working-directory: build
-        run: |
-          Get-ChildItem c:\windows\syswow64 -include *.dll -recurse | foreach-object { "{0}" -f [System.Diagnostics.FileVersionInfo]::GetVersionInfo($_) } | Select-String -Pattern "vcruntime|api-ms-win-crt|msvcp140|gdiplus|normaliz|wldap32|crypt32|advapi32|winmm|ole32|shell32|ws2_32|gdi32|user32|kernel32" > dlls.txt
-          type dlls.txt
-          ninja
+        run: ninja
 
       - name: Run Tests
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: windows-server-2019
+    runs-on: windows-2019
     concurrency:
       group: ukcp-build-${{ github.ref }}
       cancel-in-progress: true

--- a/src/plugin/oceanic/OceanicEventHandler.cpp
+++ b/src/plugin/oceanic/OceanicEventHandler.cpp
@@ -124,12 +124,7 @@ namespace UKControllerPlugin::Oceanic {
         const std::string& context,
         const POINT& mousePos)
     {
-        auto lock = std::lock_guard(this->clearanceMapMutex);
-        auto storedClearance = this->clearances.find(flightplan.GetCallsign());
-        this->currentlySelectedClearance = storedClearance != this->clearances.cend()
-                                               ? storedClearance->second
-                                               : GetDefaultClearanceForCallsign(flightplan);
-
+        SetCurrentlySelectedClearance(flightplan);
         this->dialogManager.OpenDialog(
             IDD_OCEANIC_CLEARANCE,
             reinterpret_cast<LPARAM>(&this->currentlySelectedClearance) // NOLINT
@@ -244,5 +239,14 @@ namespace UKControllerPlugin::Oceanic {
         -> Clearance
     {
         return Clearance{flightplan.GetCallsign()};
+    }
+
+    void OceanicEventHandler::SetCurrentlySelectedClearance(Euroscope::EuroScopeCFlightPlanInterface& flightplan)
+    {
+        auto lock = std::lock_guard(this->clearanceMapMutex);
+        auto storedClearance = this->clearances.find(flightplan.GetCallsign());
+        this->currentlySelectedClearance = storedClearance != this->clearances.cend()
+                                               ? storedClearance->second
+                                               : GetDefaultClearanceForCallsign(flightplan);
     }
 } // namespace UKControllerPlugin::Oceanic

--- a/src/plugin/oceanic/OceanicEventHandler.h
+++ b/src/plugin/oceanic/OceanicEventHandler.h
@@ -55,6 +55,7 @@ namespace UKControllerPlugin::Oceanic {
         static auto GetDefaultClearanceForCallsign(Euroscope::EuroScopeCFlightPlanInterface& flightplan) -> Clearance;
         static auto ConvertNattrakLevelToEuroscope(const std::string& level) -> int;
         static auto NattrakLevelValid(std::string level) -> bool;
+        void SetCurrentlySelectedClearance(Euroscope::EuroScopeCFlightPlanInterface& flightplan);
         [[nodiscard]] static auto GetClearedTagItemColour(int clearedLevel, int currentLevel) -> COLORREF;
         void SetClearanceIndicatorTagItem(Tag::TagData& tagData, const Clearance& clearance) const;
         void SetClearedLevelTagItem(Tag::TagData& tagData, const Clearance& clearance) const;


### PR DESCRIPTION
Fixes a crash if you try to open the oceanic clearance dialog when using the oceanic clearance tag items. This crash happens because the mutex covering the clearance map is locked at the start of TagFunction and wont unlock until the window has been closed. This causes the same ES thread to come along later (to display the tag items, try to lock the mutex, and everything explodes.

This change fixes the issue by scoping the mutex to a new function that has only the responsibility to grab the value from the map (or use the default if required). That way, subsequent calls can access the map properly.

Fixes #511