### PR TITLE
Cancel initial altitudes automatically on departure

### DIFF
--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -158,7 +158,7 @@ set(src__datablock
 source_group("src\\datablock" FILES ${src__datablock})
 
 set(src__departure
-        departure/DepartureCoordinationList.cpp departure/DepartureCoordinationList.h departure/ToggleDepartureCoordinationList.cpp departure/ToggleDepartureCoordinationList.h departure/DepartureModule.cpp departure/DepartureModule.h departure/AircraftDepartedEvent.h departure/AircraftDepartedEventHandler.h)
+        departure/DepartureCoordinationList.cpp departure/DepartureCoordinationList.h departure/ToggleDepartureCoordinationList.cpp departure/ToggleDepartureCoordinationList.h departure/DepartureModule.cpp departure/DepartureModule.h departure/AircraftDepartedEvent.h departure/DepartureMonitor.h departure/DepartureMonitor.cpp)
 source_group("src\\departure" FILES ${src__departure})
 
 set(src__dependency

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -158,7 +158,7 @@ set(src__datablock
 source_group("src\\datablock" FILES ${src__datablock})
 
 set(src__departure
-        departure/DepartureCoordinationList.cpp departure/DepartureCoordinationList.h departure/ToggleDepartureCoordinationList.cpp departure/ToggleDepartureCoordinationList.h departure/DepartureModule.cpp departure/DepartureModule.h)
+        departure/DepartureCoordinationList.cpp departure/DepartureCoordinationList.h departure/ToggleDepartureCoordinationList.cpp departure/ToggleDepartureCoordinationList.h departure/DepartureModule.cpp departure/DepartureModule.h departure/AircraftDepartedEvent.h departure/AircraftDepartedEventHandler.h)
 source_group("src\\departure" FILES ${src__departure})
 
 set(src__dependency
@@ -231,6 +231,14 @@ set(src__euroscope
     euroscope/PluginSettingsProviderCollection.cpp euroscope/PluginSettingsProviderCollection.h
     euroscope/EuroscopeExtractedRouteWrapper.cpp euroscope/EuroscopeExtractedRouteWrapper.h)
 source_group("src\\euroscope" FILES ${src__euroscope})
+
+set(src__eventhandler
+        eventhandler/EventHandler.h
+        eventhandler/EventBus.h eventhandler/EventBus.cpp
+        eventhandler/MutableEventBus.h eventhandler/MutableEventBus.cpp
+        eventhandler/EventStream.tpp eventhandler/EventStream.h
+        eventhandler/EventHandlerFlags.h eventhandler/EventBus.tpp eventhandler/EventObserver.h eventhandler/EventBusFactory.h eventhandler/StandardEventBusFactory.cpp eventhandler/StandardEventBusFactory.h)
+source_group("src\\eventhandler" FILES ${src__eventhandler})
 
 set(src__flightinformationservice
     "flightinformationservice/FlightInformationServiceModule.cpp"
@@ -967,6 +975,7 @@ set(ALL_FILES
     ${src__departure}
     ${src__dependency}
     ${src__euroscope}
+    ${src__eventhandler}
     ${src__flightinformationservice}
     ${src__flightplan}
     ${src__flightrule}
@@ -1009,7 +1018,7 @@ set(ALL_FILES
     ${src__time}
     ${src__timedevent}
     ${src__timer}
-    ${src__wake} prenote/PrenoteMessageEventHandlerCollection.cpp prenote/PrenoteMessageEventHandlerCollection.h)
+    ${src__wake} prenote/PrenoteMessageEventHandlerCollection.cpp prenote/PrenoteMessageEventHandlerCollection.h eventhandler/MutableEventBus.cpp eventhandler/MutableEventBus.h)
 
 ################################################################################
 # Target

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -397,7 +397,7 @@ set(src__initialheading
     "initialheading/InitialHeadingEventHandler.h"
     "initialheading/InitialHeadingModule.cpp"
     "initialheading/InitialHeadingModule.h"
-)
+        initialheading/ClearInitialHeading.cpp initialheading/ClearInitialHeading.h)
 source_group("src\\initialheading" FILES ${src__initialheading})
 
 set(src__integration

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -158,7 +158,7 @@ set(src__datablock
 source_group("src\\datablock" FILES ${src__datablock})
 
 set(src__departure
-        departure/DepartureCoordinationList.cpp departure/DepartureCoordinationList.h departure/ToggleDepartureCoordinationList.cpp departure/ToggleDepartureCoordinationList.h departure/DepartureModule.cpp departure/DepartureModule.h departure/AircraftDepartedEvent.h departure/DepartureMonitor.h departure/DepartureMonitor.cpp)
+        departure/DepartureCoordinationList.cpp departure/DepartureCoordinationList.h departure/ToggleDepartureCoordinationList.cpp departure/ToggleDepartureCoordinationList.h departure/DepartureModule.cpp departure/DepartureModule.h departure/AircraftDepartedEvent.h departure/DepartureMonitor.h departure/DepartureMonitor.cpp departure/UserShouldClearDepartureDataEvent.h)
 source_group("src\\departure" FILES ${src__departure})
 
 set(src__dependency
@@ -389,7 +389,7 @@ set(src__initialaltitude
     "initialaltitude/InitialAltitudeEventHandler.h"
     "initialaltitude/InitialAltitudeModule.cpp"
     "initialaltitude/InitialAltitudeModule.h"
-)
+        departure/UserShouldClearDepartureDataMonitor.cpp departure/UserShouldClearDepartureDataMonitor.h initialaltitude/ClearInitialAltitude.cpp initialaltitude/ClearInitialAltitude.h)
 source_group("src\\initialaltitude" FILES ${src__initialaltitude})
 
 set(src__initialheading

--- a/src/plugin/bootstrap/InitialisePlugin.cpp
+++ b/src/plugin/bootstrap/InitialisePlugin.cpp
@@ -21,6 +21,8 @@
 #include "dependency/UpdateDependencies.h"
 #include "euroscope/GeneralSettingsConfigurationBootstrap.h"
 #include "euroscope/PluginUserSettingBootstrap.h"
+#include "eventhandler/MutableEventBus.h"
+#include "eventhandler/StandardEventBusFactory.h"
 #include "flightinformationservice/FlightInformationServiceModule.h"
 #include "flightplan/FlightplanStorageBootstrap.h"
 #include "flightrule/FlightRuleModule.h"
@@ -112,6 +114,10 @@ namespace UKControllerPlugin {
         // Shut down GDI
         Gdiplus::GdiplusShutdown(this->gdiPlusToken);
         LogInfo("Plugin shutdown");
+
+        // Shutdown the event bus
+        EventHandler::MutableEventBus::Reset();
+
         ShutdownLogger();
     }
 
@@ -136,6 +142,9 @@ namespace UKControllerPlugin {
         // Check if we're a duplicate plugin
         this->duplicatePlugin = std::make_unique<DuplicatePlugin>();
         this->container = std::make_unique<PersistenceContainer>();
+
+        // Create the event bus.
+        EventHandler::MutableEventBus::SetFactory(std::make_shared<EventHandler::StandardEventBusFactory>());
 
         // Do helpers.
         EventHandlerCollectionBootstrap::BoostrapPlugin(*this->container);

--- a/src/plugin/bootstrap/InitialisePlugin.cpp
+++ b/src/plugin/bootstrap/InitialisePlugin.cpp
@@ -17,6 +17,7 @@
 #include "controller/ControllerBootstrap.h"
 #include "countdown/CountdownModule.h"
 #include "datablock/DatablockBoostrap.h"
+#include "departure/DepartureModule.h"
 #include "dependency/DependencyLoader.h"
 #include "dependency/UpdateDependencies.h"
 #include "euroscope/GeneralSettingsConfigurationBootstrap.h"
@@ -267,7 +268,9 @@ namespace UKControllerPlugin {
         SquawkModule::BootstrapPlugin(*this->container, this->duplicatePlugin->Duplicate());
 
         PrenoteModule::BootstrapPlugin(*this->container, *this->container->dependencyLoader);
+        // Handoff has to come before departure as the latter depends on it, namely the handoff cache.
         Handoff::BootstrapPlugin(*this->container, *this->container->dependencyLoader);
+        Departure::BootstrapPlugin(*this->container);
         MissedApproach::BootstrapPlugin(*this->container);
         Selcal::BootstrapPlugin(*this->container);
 

--- a/src/plugin/bootstrap/PersistenceContainer.h
+++ b/src/plugin/bootstrap/PersistenceContainer.h
@@ -60,6 +60,9 @@ namespace UKControllerPlugin {
     namespace FlightRules {
         class FlightRuleCollection;
     } // namespace FlightRules
+    namespace Handoff {
+        class HandoffCache;
+    } // namespace Handoff
     namespace HistoryTrail {
         class HistoryTrailRepository;
     } // namespace HistoryTrail
@@ -196,6 +199,7 @@ namespace UKControllerPlugin::Bootstrap {
         std::shared_ptr<UKControllerPlugin::Prenote::PrenoteMessageCollection> prenotes;
         std::unique_ptr<UKControllerPlugin::Prenote::PrenoteMessageEventHandlerCollection> prenoteMessageHandlers;
         std::shared_ptr<UKControllerPlugin::Dependency::DependencyLoaderInterface> dependencyLoader;
+        std::shared_ptr<const UKControllerPlugin::Handoff::HandoffCache> handoffCache;
 
         // Collections of event handlers
         std::unique_ptr<UKControllerPlugin::Flightplan::FlightPlanEventHandlerCollection> flightplanHandler;

--- a/src/plugin/departure/AircraftDepartedEvent.h
+++ b/src/plugin/departure/AircraftDepartedEvent.h
@@ -1,9 +1,15 @@
 #pragma once
 
 namespace UKControllerPlugin::Departure {
+    /**
+     * Event fired when an aircraft departs.
+     */
     struct AircraftDepartedEvent
     {
         // The aircraft
         std::string callsign;
+
+        // The airfield
+        std::string airfield;
     };
 } // namespace UKControllerPlugin::Departure

--- a/src/plugin/departure/AircraftDepartedEvent.h
+++ b/src/plugin/departure/AircraftDepartedEvent.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace UKControllerPlugin::Departure {
+    struct AircraftDepartedEvent
+    {
+        // The aircraft
+        std::string callsign;
+    };
+} // namespace UKControllerPlugin::Departure

--- a/src/plugin/departure/DepartureModule.cpp
+++ b/src/plugin/departure/DepartureModule.cpp
@@ -1,17 +1,29 @@
-#include "DepartureModule.h"
 #include "DepartureCoordinationList.h"
+#include "DepartureModule.h"
+#include "DepartureMonitor.h"
 #include "ToggleDepartureCoordinationList.h"
 #include "bootstrap/PersistenceContainer.h"
 #include "euroscope/AsrEventHandlerCollection.h"
 #include "euroscope/CallbackFunction.h"
+#include "flightplan/FlightPlanEventHandlerCollection.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "plugin/UKPlugin.h"
 #include "radarscreen/ConfigurableDisplayCollection.h"
 #include "radarscreen/RadarRenderableCollection.h"
+#include "timedevent/TimedEventCollection.h"
 
 using UKControllerPlugin::Euroscope::CallbackFunction;
 
 namespace UKControllerPlugin::Departure {
+
+    void BootstrapPlugin(const Bootstrap::PersistenceContainer& container)
+    {
+        // Create the departure monitor
+        const auto departureMonitor = std::make_shared<DepartureMonitor>(*container.plugin);
+        container.flightplanHandler->RegisterHandler(departureMonitor);
+        container.timedHandler->RegisterEvent(departureMonitor, 10);
+    }
+
     void BootstrapRadarScreen(
         const Bootstrap::PersistenceContainer& container,
         RadarScreen::RadarRenderableCollection& renderables,

--- a/src/plugin/departure/DepartureModule.cpp
+++ b/src/plugin/departure/DepartureModule.cpp
@@ -24,7 +24,7 @@ namespace UKControllerPlugin::Departure {
     void BootstrapPlugin(const Bootstrap::PersistenceContainer& container)
     {
         // Create the departure monitor
-        const auto departureMonitor = std::make_shared<DepartureMonitor>(*container.plugin);
+        const auto departureMonitor = std::make_shared<DepartureMonitor>(*container.login, *container.plugin);
         container.flightplanHandler->RegisterHandler(departureMonitor);
         container.timedHandler->RegisterEvent(departureMonitor, 10);
 

--- a/src/plugin/departure/DepartureModule.cpp
+++ b/src/plugin/departure/DepartureModule.cpp
@@ -1,10 +1,13 @@
+#include "AircraftDepartedEvent.h"
 #include "DepartureCoordinationList.h"
 #include "DepartureModule.h"
 #include "DepartureMonitor.h"
 #include "ToggleDepartureCoordinationList.h"
+#include "UserShouldClearDepartureDataMonitor.h"
 #include "bootstrap/PersistenceContainer.h"
 #include "euroscope/AsrEventHandlerCollection.h"
 #include "euroscope/CallbackFunction.h"
+#include "eventhandler/EventBus.h"
 #include "flightplan/FlightPlanEventHandlerCollection.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "plugin/UKPlugin.h"
@@ -13,6 +16,8 @@
 #include "timedevent/TimedEventCollection.h"
 
 using UKControllerPlugin::Euroscope::CallbackFunction;
+using UKControllerPlugin::EventHandler::EventBus;
+using UKControllerPlugin::EventHandler::EventHandler;
 
 namespace UKControllerPlugin::Departure {
 
@@ -22,6 +27,11 @@ namespace UKControllerPlugin::Departure {
         const auto departureMonitor = std::make_shared<DepartureMonitor>(*container.plugin);
         container.flightplanHandler->RegisterHandler(departureMonitor);
         container.timedHandler->RegisterEvent(departureMonitor, 10);
+
+        // Create the user should clear departure data monitor
+        EventBus::Bus().AddHandler<AircraftDepartedEvent>(
+            std::make_shared<UserShouldClearDepartureDataMonitor>(container.handoffCache, container.airfieldOwnership),
+            UKControllerPlugin::EventHandler::EventHandlerFlags::Sync);
     }
 
     void BootstrapRadarScreen(

--- a/src/plugin/departure/DepartureModule.h
+++ b/src/plugin/departure/DepartureModule.h
@@ -14,6 +14,8 @@ namespace UKControllerPlugin {
 } // namespace UKControllerPlugin
 
 namespace UKControllerPlugin::Departure {
+    void BootstrapPlugin(const Bootstrap::PersistenceContainer& container);
+
     void BootstrapRadarScreen(
         const Bootstrap::PersistenceContainer& container,
         RadarScreen::RadarRenderableCollection& renderables,

--- a/src/plugin/departure/DepartureMonitor.cpp
+++ b/src/plugin/departure/DepartureMonitor.cpp
@@ -1,0 +1,64 @@
+#include "AircraftDepartedEvent.h"
+#include "DepartureMonitor.h"
+#include "euroscope/EuroScopeCFlightPlanInterface.h"
+#include "euroscope/EuroScopeCRadarTargetInterface.h"
+#include "euroscope/EuroscopePluginLoopbackInterface.h"
+#include "eventhandler/EventBus.h"
+
+namespace UKControllerPlugin::Departure {
+
+    DepartureMonitor::DepartureMonitor(Euroscope::EuroscopePluginLoopbackInterface& plugin) : plugin(plugin)
+    {
+    }
+
+    void DepartureMonitor::TimedEventTrigger()
+    {
+        plugin.ApplyFunctionToAllFlightplans([this](
+                                                 std::shared_ptr<Euroscope::EuroScopeCFlightPlanInterface> fp,
+                                                 std::shared_ptr<Euroscope::EuroScopeCRadarTargetInterface> rt) {
+            // You only depart once
+            if (alreadyDeparted.contains(fp->GetCallsign())) {
+                return;
+            }
+
+            if (HasDeparted(*fp, *rt)) {
+                alreadyDeparted.insert({fp->GetCallsign(), fp->GetOrigin()});
+                EventHandler::EventBus::Bus().OnEvent<AircraftDepartedEvent>({"BAW123"});
+            }
+        });
+    }
+
+    auto DepartureMonitor::HasDeparted(
+        Euroscope::EuroScopeCFlightPlanInterface& flightplan,
+        Euroscope::EuroScopeCRadarTargetInterface& radarTarget) const -> bool
+    {
+        // Workaround for ES putting aircraft at right on their destination during out-of-range handoff events
+        if (radarTarget.GetFlightLevel() == 0 || flightplan.GetDistanceFromOrigin() == 0.0) {
+            return false;
+        }
+
+        return !flightplan.GetOrigin().empty() && flightplan.GetDistanceFromOrigin() < 5.0 &&
+               radarTarget.GetFlightLevel() < 5000 && radarTarget.GetFlightLevel() > 1500 &&
+               radarTarget.GetGroundSpeed() > 70;
+    }
+
+    void DepartureMonitor::FlightPlanEvent(
+        Euroscope::EuroScopeCFlightPlanInterface& flightplan, Euroscope::EuroScopeCRadarTargetInterface& radarTarget)
+    {
+        if (alreadyDeparted.contains(flightplan.GetCallsign()) &&
+            alreadyDeparted.at(flightplan.GetCallsign()) != flightplan.GetOrigin()) {
+            alreadyDeparted.erase(flightplan.GetCallsign());
+        }
+    }
+
+    void DepartureMonitor::FlightPlanDisconnectEvent(Euroscope::EuroScopeCFlightPlanInterface& flightplan)
+    {
+        alreadyDeparted.erase(flightplan.GetCallsign());
+    }
+
+    void
+    DepartureMonitor::ControllerFlightPlanDataEvent(Euroscope::EuroScopeCFlightPlanInterface& flightplan, int dataType)
+    {
+        // No-op
+    }
+} // namespace UKControllerPlugin::Departure

--- a/src/plugin/departure/DepartureMonitor.cpp
+++ b/src/plugin/departure/DepartureMonitor.cpp
@@ -16,15 +16,15 @@ namespace UKControllerPlugin::Departure {
 
     void DepartureMonitor::TimedEventTrigger()
     {
+        // Not logged in long enough
+        if (login.GetSecondsLoggedIn() < std::chrono::seconds(10)) {
+            LogInfo("Skipping departure monitor check as only just logged in");
+            return;
+        }
+
         plugin.ApplyFunctionToAllFlightplans([this](
                                                  std::shared_ptr<Euroscope::EuroScopeCFlightPlanInterface> fp,
                                                  std::shared_ptr<Euroscope::EuroScopeCRadarTargetInterface> rt) {
-            // Not logged in long enough
-            if (login.GetSecondsLoggedIn() < std::chrono::seconds(10)) {
-                LogInfo("Skipping departure monitor check as only just logged in");
-                return;
-            }
-
             // You only depart once
             if (alreadyDeparted.contains(fp->GetCallsign())) {
                 return;

--- a/src/plugin/departure/DepartureMonitor.cpp
+++ b/src/plugin/departure/DepartureMonitor.cpp
@@ -23,6 +23,7 @@ namespace UKControllerPlugin::Departure {
 
             if (HasDeparted(*fp, *rt)) {
                 alreadyDeparted.insert({fp->GetCallsign(), fp->GetOrigin()});
+                LogDebug("Firing AircraftDepartedEvent for " + fp->GetCallsign() + " at " + fp->GetOrigin());
                 EventHandler::EventBus::Bus().OnEvent<AircraftDepartedEvent>({fp->GetCallsign(), fp->GetOrigin()});
             }
         });

--- a/src/plugin/departure/DepartureMonitor.cpp
+++ b/src/plugin/departure/DepartureMonitor.cpp
@@ -23,7 +23,7 @@ namespace UKControllerPlugin::Departure {
 
             if (HasDeparted(*fp, *rt)) {
                 alreadyDeparted.insert({fp->GetCallsign(), fp->GetOrigin()});
-                EventHandler::EventBus::Bus().OnEvent<AircraftDepartedEvent>({"BAW123"});
+                EventHandler::EventBus::Bus().OnEvent<AircraftDepartedEvent>({fp->GetCallsign(), fp->GetOrigin()});
             }
         });
     }

--- a/src/plugin/departure/DepartureMonitor.h
+++ b/src/plugin/departure/DepartureMonitor.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "flightplan/FlightPlanEventHandlerInterface.h"
+#include "message/UserMessager.h"
+#include "timedevent/AbstractTimedEvent.h"
+
+namespace UKControllerPlugin::Euroscope {
+    class EuroScopeCFlightPlanInterface;
+    class EuroScopeCRadarTargetInterface;
+    class EuroscopePluginLoopbackInterface;
+} // namespace UKControllerPlugin::Euroscope
+
+namespace UKControllerPlugin::Departure {
+
+    class DepartureMonitor : public TimedEvent::AbstractTimedEvent, public Flightplan::FlightPlanEventHandlerInterface
+    {
+        public:
+        DepartureMonitor(Euroscope::EuroscopePluginLoopbackInterface& plugin);
+        void TimedEventTrigger() override;
+        void FlightPlanDisconnectEvent(Euroscope::EuroScopeCFlightPlanInterface& flightplan) override;
+        void ControllerFlightPlanDataEvent(Euroscope::EuroScopeCFlightPlanInterface& flightplan, int dataType) override;
+        void FlightPlanEvent(
+            Euroscope::EuroScopeCFlightPlanInterface& flightPlan,
+            Euroscope::EuroScopeCRadarTargetInterface& radarTarget) override;
+
+        private:
+        [[nodiscard]] auto HasDeparted(
+            Euroscope::EuroScopeCFlightPlanInterface& flightplan,
+            Euroscope::EuroScopeCRadarTargetInterface& radarTarget) const -> bool;
+
+        // Plugin
+        Euroscope::EuroscopePluginLoopbackInterface& plugin;
+
+        // Already departed
+        std::map<std::string, std::string> alreadyDeparted;
+    };
+} // namespace UKControllerPlugin::Departure

--- a/src/plugin/departure/DepartureMonitor.h
+++ b/src/plugin/departure/DepartureMonitor.h
@@ -3,18 +3,23 @@
 #include "message/UserMessager.h"
 #include "timedevent/AbstractTimedEvent.h"
 
-namespace UKControllerPlugin::Euroscope {
-    class EuroScopeCFlightPlanInterface;
-    class EuroScopeCRadarTargetInterface;
-    class EuroscopePluginLoopbackInterface;
-} // namespace UKControllerPlugin::Euroscope
+namespace UKControllerPlugin {
+    namespace Controller {
+        class Login;
+    } // namespace Controller
+    namespace Euroscope {
+        class EuroScopeCFlightPlanInterface;
+        class EuroScopeCRadarTargetInterface;
+        class EuroscopePluginLoopbackInterface;
+    } // namespace Euroscope
+} // namespace UKControllerPlugin
 
 namespace UKControllerPlugin::Departure {
 
     class DepartureMonitor : public TimedEvent::AbstractTimedEvent, public Flightplan::FlightPlanEventHandlerInterface
     {
         public:
-        DepartureMonitor(Euroscope::EuroscopePluginLoopbackInterface& plugin);
+        DepartureMonitor(const Controller::Login& login, Euroscope::EuroscopePluginLoopbackInterface& plugin);
         void TimedEventTrigger() override;
         void FlightPlanDisconnectEvent(Euroscope::EuroScopeCFlightPlanInterface& flightplan) override;
         void ControllerFlightPlanDataEvent(Euroscope::EuroScopeCFlightPlanInterface& flightplan, int dataType) override;
@@ -26,6 +31,9 @@ namespace UKControllerPlugin::Departure {
         [[nodiscard]] auto HasDeparted(
             Euroscope::EuroScopeCFlightPlanInterface& flightplan,
             Euroscope::EuroScopeCRadarTargetInterface& radarTarget) const -> bool;
+
+        // For checking controller logins
+        const Controller::Login& login;
 
         // Plugin
         Euroscope::EuroscopePluginLoopbackInterface& plugin;

--- a/src/plugin/departure/UserShouldClearDepartureDataEvent.h
+++ b/src/plugin/departure/UserShouldClearDepartureDataEvent.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace UKControllerPlugin::Departure {
+    /**
+     * An event fired when a user should be clearing the departure data (e.g. initial altitude,
+     * initial heading) of an aircraft.
+     */
+    using UserShouldClearDepartureDataEvent = struct UserShouldClearDepartureDataEvent
+    {
+        // Callsign of the aircraft
+        std::string callsign;
+    };
+} // namespace UKControllerPlugin::Departure

--- a/src/plugin/departure/UserShouldClearDepartureDataMonitor.cpp
+++ b/src/plugin/departure/UserShouldClearDepartureDataMonitor.cpp
@@ -1,0 +1,53 @@
+#include "UserShouldClearDepartureDataEvent.h"
+#include "UserShouldClearDepartureDataMonitor.h"
+#include "eventhandler/EventBus.h"
+#include "handoff/HandoffCache.h"
+#include "ownership/AirfieldServiceProviderCollection.h"
+#include "ownership/ServiceType.h"
+
+using UKControllerPlugin::EventHandler::EventBus;
+
+namespace UKControllerPlugin::Departure {
+
+    UserShouldClearDepartureDataMonitor::UserShouldClearDepartureDataMonitor(
+        std::shared_ptr<Handoff::HandoffCache> handoffs,
+        std::shared_ptr<Ownership::AirfieldServiceProviderCollection> ownership)
+        : handoffs(std::move(handoffs)), ownership(std::move(ownership))
+    {
+        assert(this->handoffs && "Handoffs not set in ClearInitialAltitudeOnDeparture");
+        assert(this->ownership && "Ownership not set in ClearInitialAltitudeOnDeparture");
+    }
+
+    void UserShouldClearDepartureDataMonitor::OnEvent(const Departure::AircraftDepartedEvent& event)
+    {
+        // Check for a handoff, dont do it if there's a handoff currently present.
+        const auto handoff = handoffs->Get(event.callsign);
+        if (handoff) {
+            return;
+        }
+
+        // If we're providing approach control, then we are the next controller due to top-down rules
+        if (ownership->ApproachControlProvidedByUser(event.airfield)) {
+            return;
+        }
+
+        if (!UserIsResponsibleForClearingData(event.airfield)) {
+            return;
+        }
+
+        EventBus::Bus().OnEvent<UserShouldClearDepartureDataEvent>({event.callsign});
+    }
+
+    /**
+     * A user is only responsible for clearing data if they're the closest thing to tower.
+     */
+    auto UserShouldClearDepartureDataMonitor::UserIsResponsibleForClearingData(const std::string& airfield) -> bool
+    {
+        return ownership->TowerControlProvidedByUser(airfield) ||
+               (!ownership->ServiceProvidedAtAirfield(airfield, Ownership::ServiceType::Tower) &&
+                ownership->GroundControlProvidedByUser(airfield)) ||
+               (!ownership->ServiceProvidedAtAirfield(airfield, Ownership::ServiceType::Tower) &&
+                !ownership->ServiceProvidedAtAirfield(airfield, Ownership::ServiceType::Ground) &&
+                ownership->DeliveryControlProvidedByUser(airfield));
+    }
+} // namespace UKControllerPlugin::Departure

--- a/src/plugin/departure/UserShouldClearDepartureDataMonitor.h
+++ b/src/plugin/departure/UserShouldClearDepartureDataMonitor.h
@@ -17,7 +17,7 @@ namespace UKControllerPlugin::Departure {
     {
         public:
         UserShouldClearDepartureDataMonitor(
-            std::shared_ptr<Handoff::HandoffCache> handoffs,
+            std::shared_ptr<const Handoff::HandoffCache> handoffs,
             std::shared_ptr<Ownership::AirfieldServiceProviderCollection> ownership);
         void OnEvent(const Departure::AircraftDepartedEvent& event);
 
@@ -25,7 +25,7 @@ namespace UKControllerPlugin::Departure {
         [[nodiscard]] auto UserIsResponsibleForClearingData(const std::string& airfield) -> bool;
 
         // For getting handoffs
-        std::shared_ptr<Handoff::HandoffCache> handoffs;
+        std::shared_ptr<const Handoff::HandoffCache> handoffs;
 
         // For getting ownership
         std::shared_ptr<Ownership::AirfieldServiceProviderCollection> ownership;

--- a/src/plugin/departure/UserShouldClearDepartureDataMonitor.h
+++ b/src/plugin/departure/UserShouldClearDepartureDataMonitor.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "departure/AircraftDepartedEvent.h"
+#include "eventhandler/EventHandler.h"
+
+namespace UKControllerPlugin {
+    namespace Handoff {
+        class HandoffCache;
+    } // namespace Handoff
+    namespace Ownership {
+        class AirfieldServiceProviderCollection;
+    } // namespace Ownership
+} // namespace UKControllerPlugin
+
+namespace UKControllerPlugin::Departure {
+
+    class UserShouldClearDepartureDataMonitor : public EventHandler::EventHandler<Departure::AircraftDepartedEvent>
+    {
+        public:
+        UserShouldClearDepartureDataMonitor(
+            std::shared_ptr<Handoff::HandoffCache> handoffs,
+            std::shared_ptr<Ownership::AirfieldServiceProviderCollection> ownership);
+        void OnEvent(const Departure::AircraftDepartedEvent& event);
+
+        private:
+        [[nodiscard]] auto UserIsResponsibleForClearingData(const std::string& airfield) -> bool;
+
+        // For getting handoffs
+        std::shared_ptr<Handoff::HandoffCache> handoffs;
+
+        // For getting ownership
+        std::shared_ptr<Ownership::AirfieldServiceProviderCollection> ownership;
+    };
+} // namespace UKControllerPlugin::Departure

--- a/src/plugin/euroscope/EuroScopeCFlightPlanInterface.h
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanInterface.h
@@ -19,6 +19,7 @@ namespace UKControllerPlugin::Euroscope {
         [[nodiscard]] virtual std::string GetAnnotation(int index) const = 0;
         [[nodiscard]] virtual std::string GetCallsign() const = 0;
         [[nodiscard]] virtual int GetClearedAltitude() const = 0;
+        [[nodiscard]] virtual int GetAssignedHeading() const = 0;
         [[nodiscard]] virtual int GetCruiseLevel() const = 0;
         [[nodiscard]] virtual std::string GetDestination() const = 0;
         [[nodiscard]] virtual double GetDistanceFromOrigin() const = 0;

--- a/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.cpp
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.cpp
@@ -41,6 +41,11 @@ namespace UKControllerPlugin::Euroscope {
         return this->originalData.GetControllerAssignedData().GetClearedAltitude();
     }
 
+    auto EuroScopeCFlightPlanWrapper::GetAssignedHeading() const -> int
+    {
+        return this->originalData.GetControllerAssignedData().GetAssignedHeading();
+    }
+
     auto EuroScopeCFlightPlanWrapper::GetCruiseLevel() const -> int
     {
         return this->originalData.GetFinalAltitude();

--- a/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.h
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.h
@@ -17,6 +17,7 @@ namespace UKControllerPlugin::Euroscope {
         std::string GetAssignedSquawk() const override;
         std::string GetCallsign() const override;
         int GetClearedAltitude() const override;
+        int GetAssignedHeading() const override;
         int GetCruiseLevel() const override;
         std::string GetDestination() const override;
         double GetDistanceFromOrigin() const override;

--- a/src/plugin/eventhandler/EventBus.cpp
+++ b/src/plugin/eventhandler/EventBus.cpp
@@ -23,4 +23,9 @@ namespace UKControllerPlugin::EventHandler {
 
         return *EventBus::singleton;
     }
+
+    auto EventBus::GetAnyStream(const std::type_index& type) const -> const std::any&
+    {
+        return streams.at(type);
+    }
 } // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/EventBus.cpp
+++ b/src/plugin/eventhandler/EventBus.cpp
@@ -1,0 +1,25 @@
+#include "EventBus.h"
+#include "EventBusFactory.h"
+
+namespace UKControllerPlugin::EventHandler {
+
+    std::unique_ptr<EventBus> EventBus::singleton;
+    std::shared_ptr<EventBusFactory> EventBus::factory;
+
+    EventBus::~EventBus() = default;
+
+    auto EventBus::Bus() -> EventBus&
+    {
+        if (EventBus::singleton) {
+            return *EventBus::singleton;
+        }
+
+        if (!EventBus::factory) {
+            throw std::exception("No event bus factory specified");
+        }
+
+        EventBus::singleton = EventBus::factory->CreateBus();
+
+        return *EventBus::singleton;
+    }
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/EventBus.cpp
+++ b/src/plugin/eventhandler/EventBus.cpp
@@ -18,6 +18,7 @@ namespace UKControllerPlugin::EventHandler {
             throw std::exception("No event bus factory specified");
         }
 
+        LogInfo("Created EventBus");
         EventBus::singleton = EventBus::factory->CreateBus();
 
         return *EventBus::singleton;

--- a/src/plugin/eventhandler/EventBus.h
+++ b/src/plugin/eventhandler/EventBus.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "EventHandlerFlags.h"
+
+namespace UKControllerPlugin::EventHandler {
+    template <class T> class EventHandler;
+    template <class T> class EventStream;
+    class EventObserver;
+    class EventBusFactory;
+
+    /**
+     * Handles events around the plugin
+     */
+    class EventBus
+    {
+        public:
+        ~EventBus();
+
+        [[nodiscard]] static auto Bus() -> EventBus&;
+
+        /**
+         * Add a handler for an event.
+         */
+        template <typename T> void AddHandler(std::shared_ptr<EventHandler<T>> handler, EventHandlerFlags flags);
+
+        /**
+         * Fire an event.
+         */
+        template <typename T> void OnEvent(const T& event);
+
+        protected:
+        template <typename T> [[nodiscard]] auto GetStream() -> EventStream<T>&;
+
+        // This is a singleton
+        static std::unique_ptr<EventBus> singleton;
+
+        // A factory for event busses
+        static std::shared_ptr<EventBusFactory> factory;
+
+        // The event streams
+        std::map<std::type_index, std::any> streams;
+
+        // An observer
+        std::shared_ptr<EventObserver> observer = nullptr;
+    };
+} // namespace UKControllerPlugin::EventHandler
+
+// Include the implementation of template methods
+#include "EventBus.tpp"

--- a/src/plugin/eventhandler/EventBus.h
+++ b/src/plugin/eventhandler/EventBus.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "EventHandlerFlags.h"
+#include <typeindex>
 
 namespace UKControllerPlugin::EventHandler {
     template <class T> class EventHandler;
@@ -26,6 +27,12 @@ namespace UKControllerPlugin::EventHandler {
          * Fire an event.
          */
         template <typename T> void OnEvent(const T& event);
+
+        /**
+         * Get the given stream as a std::any. For test purposes only and should not be called
+         * anywhere else.
+         */
+        [[nodiscard]] auto GetAnyStream(const std::type_index& type) const -> const std::any&;
 
         protected:
         template <typename T> [[nodiscard]] auto GetStream() -> EventStream<T>&;

--- a/src/plugin/eventhandler/EventBus.tpp
+++ b/src/plugin/eventhandler/EventBus.tpp
@@ -5,7 +5,7 @@
 namespace UKControllerPlugin::EventHandler {
 
     /**
-     * Get
+     * Get the given stream, or create if it doesn't exist
      */
     template <typename T> auto EventBus::GetStream() -> EventStream<T>&
     {

--- a/src/plugin/eventhandler/EventBus.tpp
+++ b/src/plugin/eventhandler/EventBus.tpp
@@ -1,0 +1,35 @@
+#include "EventObserver.h"
+#include "EventStream.h"
+#include "log/LoggerFunctions.h"
+
+namespace UKControllerPlugin::EventHandler {
+
+    /**
+     * Get
+     */
+    template <typename T> auto EventBus::GetStream() -> EventStream<T>&
+    {
+        const auto index = std::type_index(typeid(T));
+        if (!streams.contains(index)) {
+            streams.insert({index, std::any(std::make_shared<EventStream<T>>())});
+        }
+
+        return *std::any_cast<std::shared_ptr<EventStream<T>>>(streams.at(index));
+    }
+
+    template <typename T> void EventBus::AddHandler(std::shared_ptr<EventHandler<T>> handler, EventHandlerFlags flags)
+    {
+        this->GetStream<T>().AddHandler(handler, flags);
+    }
+
+    template <typename T> void EventBus::OnEvent(const T& event)
+    {
+        // Send the event to any observer
+        if (observer != nullptr) {
+            observer->OnEvent(event);
+        }
+
+        // Send the event to its stream
+        this->GetStream<T>().OnEvent(event);
+    }
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/EventBusFactory.h
+++ b/src/plugin/eventhandler/EventBusFactory.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace UKControllerPlugin::EventHandler {
+    class EventBus;
+    /**
+     * Creates event busses.
+     */
+    class EventBusFactory
+    {
+        public:
+        virtual ~EventBusFactory() = default;
+        [[nodiscard]] virtual auto CreateBus() -> std::unique_ptr<EventBus> = 0;
+    };
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/EventHandler.h
+++ b/src/plugin/eventhandler/EventHandler.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace UKControllerPlugin::EventHandler {
+
+    template <class T> class EventHandler
+    {
+        public:
+        virtual ~EventHandler() = default;
+
+        /**
+         * Process the given event.
+         */
+        virtual void OnEvent(const T& event) = 0;
+    };
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/EventHandlerFlags.h
+++ b/src/plugin/eventhandler/EventHandlerFlags.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace UKControllerPlugin::EventHandler {
+    // A set of flags for event handlers
+    enum class EventHandlerFlags : unsigned int
+    {
+        Sync = 1 << 0,
+        Async = 1 << 1
+    };
+
+    DEFINE_ENUM_FLAG_OPERATORS(EventHandlerFlags)
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/EventObserver.h
+++ b/src/plugin/eventhandler/EventObserver.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace UKControllerPlugin::EventHandler {
+    /**
+     * Interface for observing the events coming out of the event bus (for testing purposes)
+     */
+    class EventObserver
+    {
+        public:
+        virtual ~EventObserver() = default;
+        virtual void OnEvent(std::any event) = 0;
+    };
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/EventStream.h
+++ b/src/plugin/eventhandler/EventStream.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "EventHandlerFlags.h"
+
+namespace UKControllerPlugin::EventHandler {
+    template <class T> class EventHandler;
+
+    template <typename T> class EventStream
+    {
+        public:
+        /**
+         * Adds a handler to the event stream.
+         */
+        void AddHandler(std::shared_ptr<EventHandler<T>> handler, EventHandlerFlags flags);
+
+        /**
+         * Processes an event.
+         */
+        void OnEvent(const T& event);
+
+        private:
+        // Contains data about the handlers
+        using HandlerData = struct
+        {
+            std::shared_ptr<EventHandler<T>> handler;
+
+            EventHandlerFlags flags;
+        };
+        std::vector<HandlerData> handlers;
+    };
+} // namespace UKControllerPlugin::EventHandler
+
+// Include the implementation of template methods
+#include "EventStream.tpp"

--- a/src/plugin/eventhandler/EventStream.h
+++ b/src/plugin/eventhandler/EventStream.h
@@ -17,7 +17,6 @@ namespace UKControllerPlugin::EventHandler {
          */
         void OnEvent(const T& event);
 
-        private:
         // Contains data about the handlers
         using HandlerData = struct
         {
@@ -25,6 +24,13 @@ namespace UKControllerPlugin::EventHandler {
 
             EventHandlerFlags flags;
         };
+
+        [[nodiscard]] auto Handlers() const -> const std::vector<HandlerData>&
+        {
+            return handlers;
+        }
+
+        private:
         std::vector<HandlerData> handlers;
     };
 } // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/EventStream.tpp
+++ b/src/plugin/eventhandler/EventStream.tpp
@@ -1,3 +1,4 @@
+#include "EventHandler.h"
 #include "task/RunAsyncTask.h"
 
 namespace UKControllerPlugin::EventHandler {

--- a/src/plugin/eventhandler/EventStream.tpp
+++ b/src/plugin/eventhandler/EventStream.tpp
@@ -1,0 +1,24 @@
+#include "task/RunAsyncTask.h"
+
+namespace UKControllerPlugin::EventHandler {
+    template <typename T>
+    void EventStream<T>::AddHandler(std::shared_ptr<EventHandler<T>> handler, EventHandlerFlags flags)
+    {
+        this->handlers.push_back({handler, flags});
+    }
+
+    template <typename T> void EventStream<T>::OnEvent(const T& event)
+    {
+        for (const auto& handler : this->handlers) {
+            if ((handler.flags & EventHandlerFlags::Sync) == EventHandlerFlags::Sync) {
+                handler.handler->OnEvent(event);
+                continue;
+            }
+
+            if ((handler.flags & EventHandlerFlags::Async) == EventHandlerFlags::Async) {
+                Async([event, handler]() { handler.handler->OnEvent(event); });
+                continue;
+            }
+        }
+    }
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/MutableEventBus.cpp
+++ b/src/plugin/eventhandler/MutableEventBus.cpp
@@ -7,6 +7,7 @@ namespace UKControllerPlugin::EventHandler {
     {
         EventBus::singleton = nullptr;
         EventBus::factory = nullptr;
+        LogInfo("EventBus shutdown");
     }
 
     void MutableEventBus::SetObserver(std::shared_ptr<EventObserver> observer)

--- a/src/plugin/eventhandler/MutableEventBus.cpp
+++ b/src/plugin/eventhandler/MutableEventBus.cpp
@@ -1,0 +1,21 @@
+#include "EventBusFactory.h"
+#include "MutableEventBus.h"
+
+namespace UKControllerPlugin::EventHandler {
+
+    void MutableEventBus::Reset()
+    {
+        EventBus::singleton = nullptr;
+        EventBus::factory = nullptr;
+    }
+
+    void MutableEventBus::SetObserver(std::shared_ptr<EventObserver> observer)
+    {
+        this->observer = std::move(observer);
+    }
+
+    void MutableEventBus::SetFactory(std::shared_ptr<EventBusFactory> factory)
+    {
+        EventBus::factory = std::move(factory);
+    }
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/MutableEventBus.h
+++ b/src/plugin/eventhandler/MutableEventBus.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "EventBus.h"
+#include "EventBusFactory.h"
+
+namespace UKControllerPlugin::EventHandler {
+    class EventObserver;
+
+    class MutableEventBus : public EventBus
+    {
+        public:
+        static void SetFactory(std::shared_ptr<EventBusFactory> factory);
+        void SetObserver(std::shared_ptr<EventObserver> observer);
+        static void Reset();
+    };
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/StandardEventBusFactory.cpp
+++ b/src/plugin/eventhandler/StandardEventBusFactory.cpp
@@ -1,0 +1,10 @@
+#include "MutableEventBus.h"
+#include "StandardEventBusFactory.h"
+
+namespace UKControllerPlugin::EventHandler {
+
+    auto StandardEventBusFactory::CreateBus() -> std::unique_ptr<EventBus>
+    {
+        return std::make_unique<MutableEventBus>();
+    }
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/eventhandler/StandardEventBusFactory.h
+++ b/src/plugin/eventhandler/StandardEventBusFactory.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <memory>
+#include "eventhandler/EventBusFactory.h"
+
+namespace UKControllerPlugin::EventHandler {
+
+    /**
+     * Creates a "normal" event bus.
+     */
+    class StandardEventBusFactory : public EventBusFactory
+    {
+        public:
+        auto CreateBus() -> std::unique_ptr<EventBus> override;
+    };
+} // namespace UKControllerPlugin::EventHandler

--- a/src/plugin/handoff/HandoffModule.cpp
+++ b/src/plugin/handoff/HandoffModule.cpp
@@ -41,6 +41,7 @@ namespace UKControllerPlugin::Handoff {
             cache,
             *container.integrationModuleContainer->outboundMessageHandler);
 
+        container.handoffCache = cache;
         container.tagHandler->RegisterTagItem(handoffTagItem, handler);
         container.flightplanHandler->RegisterHandler(handler);
         container.activeCallsigns->AddHandler(std::make_shared<ClearCacheOnActiveCallsignChanges>(*cache));

--- a/src/plugin/initialaltitude/ClearInitialAltitude.cpp
+++ b/src/plugin/initialaltitude/ClearInitialAltitude.cpp
@@ -39,6 +39,11 @@ namespace UKControllerPlugin::InitialAltitude {
             return;
         }
 
+        if (flightplan->GetClearedAltitude() == EUROSCOPE_FLIGHTPLAN_NO_CLEARED_LEVEL) {
+            LogDebug("Not clearing level for " + event.callsign + " on departure, is not set");
+            return;
+        }
+
         LogInfo("Removing cleared level on departure for " + event.callsign);
         flightplan->SetClearedAltitude(EUROSCOPE_FLIGHTPLAN_NO_CLEARED_LEVEL);
     }

--- a/src/plugin/initialaltitude/ClearInitialAltitude.cpp
+++ b/src/plugin/initialaltitude/ClearInitialAltitude.cpp
@@ -1,0 +1,45 @@
+#include "ClearInitialAltitude.h"
+#include "euroscope/EuroscopePluginLoopbackInterface.h"
+#include "euroscope/EuroScopeCFlightPlanInterface.h"
+#include "log/LoggerFunctions.h"
+#include "sid/SidMapperInterface.h"
+#include "sid/StandardInstrumentDeparture.h"
+
+namespace UKControllerPlugin::InitialAltitude {
+
+    ClearInitialAltitude::ClearInitialAltitude(
+        const Euroscope::EuroscopePluginLoopbackInterface& plugin, const Sid::SidMapperInterface& sidMapper)
+        : plugin(plugin), sidMapper(sidMapper)
+    {
+    }
+
+    void ClearInitialAltitude::OnEvent(const Departure::UserShouldClearDepartureDataEvent& event)
+    {
+        // Dont clear if flightplan is tracked by someone else
+        const auto flightplan = plugin.GetFlightplanForCallsign(event.callsign);
+        if (!flightplan) {
+            LogDebug("Not removing cleared level for " + event.callsign + " as disconnected");
+            return;
+        }
+
+        if (flightplan->IsTracked() && !flightplan->IsTrackedByUser()) {
+            LogDebug("Not removing cleared level for " + event.callsign + " as tracked by someone else");
+            return;
+        }
+
+        // Dont clear if the flightplan has a cleared level different to the sid level
+        const auto sid = sidMapper.MapFlightplanToSid(*flightplan);
+        if (!sid) {
+            LogWarning("Sid not found when removing cleared level for " + event.callsign);
+            return;
+        }
+
+        if (flightplan->GetClearedAltitude() != sid->InitialAltitude()) {
+            LogDebug("Not clearing level for " + event.callsign + " on departure, has been modified");
+            return;
+        }
+
+        LogInfo("Removing cleared level on departure for " + event.callsign);
+        flightplan->SetClearedAltitude(EUROSCOPE_FLIGHTPLAN_NO_CLEARED_LEVEL);
+    }
+} // namespace UKControllerPlugin::InitialAltitude

--- a/src/plugin/initialaltitude/ClearInitialAltitude.h
+++ b/src/plugin/initialaltitude/ClearInitialAltitude.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "departure/UserShouldClearDepartureDataEvent.h"
+#include "eventhandler/EventHandler.h"
+
+namespace UKControllerPlugin {
+    namespace Euroscope {
+        class EuroscopePluginLoopbackInterface;
+    }
+    namespace Sid {
+        class SidMapperInterface;
+    } // namespace Sid
+} // namespace UKControllerPlugin
+
+namespace UKControllerPlugin::InitialAltitude {
+
+    /**
+     * Clears the initial altitude when a user should be clearing departure settings.
+     */
+    class ClearInitialAltitude : public EventHandler::EventHandler<Departure::UserShouldClearDepartureDataEvent>
+    {
+        public:
+        ClearInitialAltitude(
+            const Euroscope::EuroscopePluginLoopbackInterface& plugin, const Sid::SidMapperInterface& sidMapper);
+        void OnEvent(const Departure::UserShouldClearDepartureDataEvent& event) override;
+
+        private:
+        // For getting flightplans
+        const Euroscope::EuroscopePluginLoopbackInterface& plugin;
+
+        // For mapping flightplans to sid
+        const Sid::SidMapperInterface& sidMapper;
+
+        // The euroscope value for "no cleared level"
+        const int EUROSCOPE_FLIGHTPLAN_NO_CLEARED_LEVEL = 0;
+    };
+
+} // namespace UKControllerPlugin::InitialAltitude

--- a/src/plugin/initialaltitude/InitialAltitudeModule.cpp
+++ b/src/plugin/initialaltitude/InitialAltitudeModule.cpp
@@ -1,7 +1,11 @@
+#include "ClearInitialAltitude.h"
 #include "InitialAltitudeModule.h"
 #include "bootstrap/PersistenceContainer.h"
 #include "controller/ActiveCallsignCollection.h"
+#include "departure/UserShouldClearDepartureDataEvent.h"
 #include "euroscope/UserSettingAwareCollection.h"
+#include "eventhandler/EventBus.h"
+#include "eventhandler/EventHandlerFlags.h"
 #include "flightplan/FlightPlanEventHandlerCollection.h"
 #include "InitialAltitudeEventHandler.h"
 #include "plugin/FunctionCallEventHandler.h"
@@ -10,9 +14,11 @@
 #include "timedevent/TimedEventCollection.h"
 
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
+using UKControllerPlugin::EventHandler::EventBus;
 using UKControllerPlugin::Flightplan::FlightPlanEventHandlerCollection;
 using UKControllerPlugin::InitialAltitude::InitialAltitudeEventHandler;
 using UKControllerPlugin::Tag::TagFunction;
+
 namespace UKControllerPlugin::InitialAltitude {
 
     const int timedHandlerFrequency = 10;
@@ -46,5 +52,10 @@ namespace UKControllerPlugin::InitialAltitude {
                 initialAltitudeEventHandler->RecycleInitialAltitude(fp, rt, std::move(context), mousePos);
             });
         persistence.pluginFunctionHandlers->RegisterFunctionCall(recycleFunction);
+
+        // Register the clear initial altitude event handler
+        EventBus::Bus().AddHandler<Departure::UserShouldClearDepartureDataEvent>(
+            std::make_shared<ClearInitialAltitude>(*persistence.plugin, *persistence.sidMapper),
+            EventHandler::EventHandlerFlags::Sync);
     }
 } // namespace UKControllerPlugin::InitialAltitude

--- a/src/plugin/initialheading/ClearInitialHeading.cpp
+++ b/src/plugin/initialheading/ClearInitialHeading.cpp
@@ -40,6 +40,6 @@ namespace UKControllerPlugin::InitialHeading {
         }
 
         LogInfo("Removing cleared heading on departure for " + event.callsign);
-        flightplan->SetClearedAltitude(EUROSCOPE_FLIGHTPLAN_NO_HEADING);
+        flightplan->SetHeading(EUROSCOPE_FLIGHTPLAN_NO_HEADING);
     }
 } // namespace UKControllerPlugin::InitialHeading

--- a/src/plugin/initialheading/ClearInitialHeading.cpp
+++ b/src/plugin/initialheading/ClearInitialHeading.cpp
@@ -39,6 +39,11 @@ namespace UKControllerPlugin::InitialHeading {
             return;
         }
 
+        if (flightplan->GetAssignedHeading() == EUROSCOPE_FLIGHTPLAN_NO_HEADING) {
+            LogDebug("Not clearing heading for " + event.callsign + " on departure, not set");
+            return;
+        }
+
         LogInfo("Removing cleared heading on departure for " + event.callsign);
         flightplan->SetHeading(EUROSCOPE_FLIGHTPLAN_NO_HEADING);
     }

--- a/src/plugin/initialheading/ClearInitialHeading.cpp
+++ b/src/plugin/initialheading/ClearInitialHeading.cpp
@@ -1,0 +1,45 @@
+#include "ClearInitialHeading.h"
+#include "euroscope/EuroscopePluginLoopbackInterface.h"
+#include "euroscope/EuroScopeCFlightPlanInterface.h"
+#include "log/LoggerFunctions.h"
+#include "sid/SidMapperInterface.h"
+#include "sid/StandardInstrumentDeparture.h"
+
+namespace UKControllerPlugin::InitialHeading {
+
+    ClearInitialHeading::ClearInitialHeading(
+        const Euroscope::EuroscopePluginLoopbackInterface& plugin, const Sid::SidMapperInterface& sidMapper)
+        : plugin(plugin), sidMapper(sidMapper)
+    {
+    }
+
+    void ClearInitialHeading::OnEvent(const Departure::UserShouldClearDepartureDataEvent& event)
+    {
+        // Dont clear if flightplan is tracked by someone else
+        const auto flightplan = plugin.GetFlightplanForCallsign(event.callsign);
+        if (!flightplan) {
+            LogDebug("Not removing cleared heading for " + event.callsign + " as disconnected");
+            return;
+        }
+
+        if (flightplan->IsTracked() && !flightplan->IsTrackedByUser()) {
+            LogDebug("Not removing cleared heading for " + event.callsign + " as tracked by someone else");
+            return;
+        }
+
+        // Dont clear if the flightplan has a cleared level different to the sid level
+        const auto sid = sidMapper.MapFlightplanToSid(*flightplan);
+        if (!sid) {
+            LogWarning("Sid not found when removing cleared heading for " + event.callsign);
+            return;
+        }
+
+        if (flightplan->GetAssignedHeading() != sid->InitialHeading()) {
+            LogDebug("Not clearing heading for " + event.callsign + " on departure, has been modified");
+            return;
+        }
+
+        LogInfo("Removing cleared heading on departure for " + event.callsign);
+        flightplan->SetClearedAltitude(EUROSCOPE_FLIGHTPLAN_NO_HEADING);
+    }
+} // namespace UKControllerPlugin::InitialHeading

--- a/src/plugin/initialheading/ClearInitialHeading.h
+++ b/src/plugin/initialheading/ClearInitialHeading.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "departure/UserShouldClearDepartureDataEvent.h"
+#include "eventhandler/EventHandler.h"
+
+namespace UKControllerPlugin {
+    namespace Euroscope {
+        class EuroscopePluginLoopbackInterface;
+    }
+    namespace Sid {
+        class SidMapperInterface;
+    } // namespace Sid
+} // namespace UKControllerPlugin
+
+namespace UKControllerPlugin::InitialHeading {
+
+    /**
+     * Clears the initial altitude when a user should be clearing departure settings.
+     */
+    class ClearInitialHeading : public EventHandler::EventHandler<Departure::UserShouldClearDepartureDataEvent>
+    {
+        public:
+        ClearInitialHeading(
+            const Euroscope::EuroscopePluginLoopbackInterface& plugin, const Sid::SidMapperInterface& sidMapper);
+        void OnEvent(const Departure::UserShouldClearDepartureDataEvent& event) override;
+
+        private:
+        // For getting flightplans
+        const Euroscope::EuroscopePluginLoopbackInterface& plugin;
+
+        // For mapping flightplans to sid
+        const Sid::SidMapperInterface& sidMapper;
+
+        // The euroscope value for "no cleared level"
+        const int EUROSCOPE_FLIGHTPLAN_NO_HEADING = 0;
+    };
+} // namespace UKControllerPlugin::InitialHeading

--- a/src/plugin/initialheading/InitialHeadingModule.cpp
+++ b/src/plugin/initialheading/InitialHeadingModule.cpp
@@ -1,7 +1,10 @@
 #include "bootstrap/PersistenceContainer.h"
 #include "controller/ActiveCallsignCollection.h"
+#include "departure/UserShouldClearDepartureDataEvent.h"
 #include "euroscope/UserSettingAwareCollection.h"
+#include "eventhandler/EventBus.h"
 #include "flightplan/FlightPlanEventHandlerCollection.h"
+#include "initialheading/ClearInitialHeading.h"
 #include "initialheading/InitialHeadingEventHandler.h"
 #include "initialheading/InitialHeadingModule.h"
 #include "plugin/FunctionCallEventHandler.h"
@@ -10,6 +13,7 @@
 #include "timedevent/TimedEventCollection.h"
 
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
+using UKControllerPlugin::EventHandler::EventBus;
 using UKControllerPlugin::Flightplan::FlightPlanEventHandlerCollection;
 using UKControllerPlugin::InitialHeading::InitialHeadingEventHandler;
 using UKControllerPlugin::Tag::TagFunction;
@@ -46,5 +50,10 @@ namespace UKControllerPlugin::InitialHeading {
                 std::string context,
                 const POINT& mousePos) { handler->RecycleInitialHeading(fp, rt, std::move(context), mousePos); });
         persistence.pluginFunctionHandlers->RegisterFunctionCall(recycleFunction);
+
+        // Register the clear initial heading event handler
+        EventBus::Bus().AddHandler<Departure::UserShouldClearDepartureDataEvent>(
+            std::make_shared<ClearInitialHeading>(*persistence.plugin, *persistence.sidMapper),
+            EventHandler::EventHandlerFlags::Sync);
     }
 } // namespace UKControllerPlugin::InitialHeading

--- a/src/plugin/ownership/AirfieldServiceProviderCollection.cpp
+++ b/src/plugin/ownership/AirfieldServiceProviderCollection.cpp
@@ -15,6 +15,11 @@ namespace UKControllerPlugin::Ownership {
         return this->ServiceProvidedAtAirfieldByUser(icao, ServiceType::Delivery);
     }
 
+    auto AirfieldServiceProviderCollection::GroundControlProvidedByUser(const std::string& icao) const -> bool
+    {
+        return this->ServiceProvidedAtAirfieldByUser(icao, ServiceType::Ground);
+    }
+
     auto AirfieldServiceProviderCollection::AirfieldHasDeliveryProvider(const std::string& icao) const -> bool
     {
         return this->ServiceProvidedAtAirfield(icao, ServiceType::Delivery);

--- a/src/plugin/ownership/AirfieldServiceProviderCollection.h
+++ b/src/plugin/ownership/AirfieldServiceProviderCollection.h
@@ -23,6 +23,7 @@ namespace UKControllerPlugin::Ownership {
             -> const std::shared_ptr<ServiceProvision>&;
         [[nodiscard]] auto AirfieldHasDeliveryProvider(const std::string& icao) const -> bool;
         [[nodiscard]] auto DeliveryControlProvidedByUser(const std::string& icao) const -> bool;
+        [[nodiscard]] auto GroundControlProvidedByUser(const std::string& icao) const -> bool;
         [[nodiscard]] auto FinalApproachControlProvidedByUser(const std::string& icao) const -> bool;
         [[nodiscard]] auto ApproachControlProvidedByUser(const std::string& icao) const -> bool;
         [[nodiscard]] auto TowerControlProvidedByUser(const std::string& icao) const -> bool;

--- a/src/plugin/pch/pch.h
+++ b/src/plugin/pch/pch.h
@@ -34,6 +34,7 @@ using std::min;
 #include <Shlobj.h>
 #include <Shobjidl.h>
 #include <algorithm>
+#include <any>
 #include <cctype>
 #include <codecvt>
 #include <ctime>
@@ -59,6 +60,7 @@ using std::min;
 #include <string>
 #include <tchar.h>
 #include <type_traits>
+#include <typeindex>
 #include <unordered_set>
 #include <utility>
 #include <variant>

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -218,7 +218,7 @@ source_group("test\\initialaltitude" FILES ${test__initialaltitude})
 set(test__initialheading
     "initialheading/InitialHeadingEventHandlerTest.cpp"
     "initialheading/InitialHeadingModuleTest.cpp"
-        initialaltitude/ClearInitialAltitudeTest.cpp)
+        initialaltitude/ClearInitialAltitudeTest.cpp initialheading/ClearInitialHeadingTest.cpp)
 source_group("test\\initialheading" FILES ${test__initialheading})
 
 set(test__integration

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -123,6 +123,10 @@ set(test__euroscope
         euroscope/PluginSettingsProviderCollectionTest.cpp euroscope/PluginUserSettingBootstrapTest.cpp)
 source_group("test\\euroscope" FILES ${test__euroscope})
 
+set(test__eventhandler
+        eventhandler/EventBusTest.cpp test/EventBusTestCase.h)
+source_group("test\\eventhandler" FILES ${test__eventhandler})
+
 set(test__flightinformationservice
     "flightinformationservice/FlightInformationServiceModuleTest.cpp"
     "flightinformationservice/FlightInformationServiceTagItemTest.cpp"
@@ -620,6 +624,7 @@ set(ALL_FILES
     ${test__departure}
     ${test__dependency}
     ${test__euroscope}
+    ${test__eventhandler}
     ${test__flightinformationservice}
     ${test__flightplan}
     ${test__flightrule}

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -124,7 +124,7 @@ set(test__euroscope
 source_group("test\\euroscope" FILES ${test__euroscope})
 
 set(test__eventhandler
-        eventhandler/EventBusTest.cpp test/EventBusTestCase.h)
+        eventhandler/EventBusTest.cpp test/EventBusTestCase.h eventhandler/EventStreamTest.cpp)
 source_group("test\\eventhandler" FILES ${test__eventhandler})
 
 set(test__flightinformationservice

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -100,7 +100,7 @@ source_group("test\\datablock" FILES ${test__datablock})
 
 set(test__departure
         
-        departure/DepartureCoordinationListTest.cpp departure/ToggleDepartureCoordinationListTest.cpp departure/DepartureModuleTest.cpp)
+        departure/DepartureCoordinationListTest.cpp departure/ToggleDepartureCoordinationListTest.cpp departure/DepartureModuleTest.cpp departure/DepartureMonitorTest.cpp)
 source_group("test\\departure" FILES ${test__departure})
 
 set(test__dependency

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -100,7 +100,7 @@ source_group("test\\datablock" FILES ${test__datablock})
 
 set(test__departure
         
-        departure/DepartureCoordinationListTest.cpp departure/ToggleDepartureCoordinationListTest.cpp departure/DepartureModuleTest.cpp departure/DepartureMonitorTest.cpp)
+        departure/DepartureCoordinationListTest.cpp departure/ToggleDepartureCoordinationListTest.cpp departure/DepartureModuleTest.cpp departure/DepartureMonitorTest.cpp departure/UserShouldClearDepartureDataMonitorTest.cpp)
 source_group("test\\departure" FILES ${test__departure})
 
 set(test__dependency
@@ -218,7 +218,7 @@ source_group("test\\initialaltitude" FILES ${test__initialaltitude})
 set(test__initialheading
     "initialheading/InitialHeadingEventHandlerTest.cpp"
     "initialheading/InitialHeadingModuleTest.cpp"
-)
+        initialaltitude/ClearInitialAltitudeTest.cpp)
 source_group("test\\initialheading" FILES ${test__initialheading})
 
 set(test__integration

--- a/test/plugin/departure/DepartureModuleTest.cpp
+++ b/test/plugin/departure/DepartureModuleTest.cpp
@@ -1,8 +1,9 @@
 #include "departure/DepartureModule.h"
+#include "flightplan/FlightPlanEventHandlerCollection.h"
+#include "timedevent/TimedEventCollection.h"
 #include "bootstrap/PersistenceContainer.h"
 #include "push/PushEventProcessorCollection.h"
 #include "tag/TagItemCollection.h"
-#include "timedevent/TimedEventCollection.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "controller/HandoffEventHandlerCollection.h"
 #include "dialog/DialogManager.h"
@@ -15,6 +16,7 @@ using ::testing::Return;
 using ::testing::Test;
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
 using UKControllerPlugin::Controller::HandoffEventHandlerCollection;
+using UKControllerPlugin::Departure::BootstrapPlugin;
 using UKControllerPlugin::Departure::BootstrapRadarScreen;
 using UKControllerPlugin::Dialog::DialogManager;
 using UKControllerPlugin::Plugin::FunctionCallEventHandler;
@@ -36,6 +38,9 @@ namespace UKControllerPluginTest::Departure {
         {
             container.tagHandler = std::make_unique<TagItemCollection>();
             container.pluginFunctionHandlers = std::make_unique<FunctionCallEventHandler>();
+            container.timedHandler = std::make_unique<TimedEventCollection>();
+            container.flightplanHandler =
+                std::make_unique<UKControllerPlugin::Flightplan::FlightPlanEventHandlerCollection>();
         }
 
         PersistenceContainer container;
@@ -43,6 +48,19 @@ namespace UKControllerPluginTest::Departure {
         ConfigurableDisplayCollection configurables;
         UKControllerPlugin::Euroscope::AsrEventHandlerCollection asr;
     };
+
+    TEST_F(DepartureModuleTest, PluginRegistersDepartureMonitorForFlightplanEvents)
+    {
+        BootstrapPlugin(this->container);
+        EXPECT_EQ(1, this->container.flightplanHandler->CountHandlers());
+    }
+
+    TEST_F(DepartureModuleTest, PluginRegistersDepartureMonitorForTimedEvents)
+    {
+        BootstrapPlugin(this->container);
+        EXPECT_EQ(1, this->container.timedHandler->CountHandlers());
+        EXPECT_EQ(1, this->container.timedHandler->CountHandlersForFrequency(10));
+    }
 
     TEST_F(DepartureModuleTest, RadarScreenAddsRenderable)
     {

--- a/test/plugin/departure/DepartureMonitorTest.cpp
+++ b/test/plugin/departure/DepartureMonitorTest.cpp
@@ -1,0 +1,203 @@
+#include "departure/AircraftDepartedEvent.h"
+#include "departure/DepartureMonitor.h"
+#include "handoff/HandoffCache.h"
+#include "mock/MockEuroScopeCFlightplanInterface.h"
+#include "mock/MockEuroScopeCRadarTargetInterface.h"
+#include "mock/MockEuroscopePluginLoopbackInterface.h"
+#include "test/EventBusTestCase.h"
+
+namespace UKControllerPluginTest::Departure {
+
+    class DepartureMonitorTest : public EventBusTestCase
+    {
+        public:
+        DepartureMonitorTest() : monitor(mockPlugin)
+        {
+            mockFlightplan = std::make_shared<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>>();
+            mockRadarTarget = std::make_shared<testing::NiceMock<Euroscope::MockEuroScopeCRadarTargetInterface>>();
+
+            ON_CALL(*mockFlightplan, GetCallsign).WillByDefault(testing::Return("BAW123"));
+            ON_CALL(*mockFlightplan, GetOrigin).WillByDefault(testing::Return("EGKK"));
+
+            mockPlugin.AddAllFlightplansItem({mockFlightplan, mockRadarTarget});
+        }
+
+        std::shared_ptr<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>> mockFlightplan;
+        std::shared_ptr<testing::NiceMock<Euroscope::MockEuroScopeCRadarTargetInterface>> mockRadarTarget;
+        testing::NiceMock<Euroscope::MockEuroscopePluginLoopbackInterface> mockPlugin;
+        UKControllerPlugin::Departure::DepartureMonitor monitor;
+    };
+
+    TEST_F(DepartureMonitorTest, ItSendsDepartedEvent)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(2500));
+
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(1, EventBusObserver().observedEvents.size());
+        EXPECT_EQ(
+            "BAW123",
+            std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[0])
+                .callsign);
+    }
+
+    TEST_F(DepartureMonitorTest, ItDoesntSendDuplicateDepartedEvents)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(2500));
+
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(1, EventBusObserver().observedEvents.size());
+        EXPECT_EQ(
+            "BAW123",
+            std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[0])
+                .callsign);
+
+        monitor.TimedEventTrigger();
+        EXPECT_EQ(1, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(DepartureMonitorTest, ItAllowsRedepartureIfAircraftGoesOffline)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(2500));
+
+        monitor.TimedEventTrigger();
+        monitor.FlightPlanDisconnectEvent(*mockFlightplan);
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(2, EventBusObserver().observedEvents.size());
+        EXPECT_EQ(
+            "BAW123",
+            std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[1])
+                .callsign);
+    }
+
+    TEST_F(DepartureMonitorTest, ItAllowsRedepartureIfAircraftChangesOriginAirport)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(2500));
+
+        monitor.TimedEventTrigger();
+
+        ON_CALL(*mockFlightplan, GetOrigin).WillByDefault(testing::Return("EGLL"));
+
+        monitor.FlightPlanEvent(*mockFlightplan, *mockRadarTarget);
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(2, EventBusObserver().observedEvents.size());
+        EXPECT_EQ(
+            "BAW123",
+            std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[1])
+                .callsign);
+    }
+
+    TEST_F(DepartureMonitorTest, ItDoesntAllowRedepartureIfAircraftDoesntChangeOriginAirport)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(2500));
+
+        monitor.TimedEventTrigger();
+        monitor.FlightPlanEvent(*mockFlightplan, *mockRadarTarget);
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(1, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(DepartureMonitorTest, ItDoesntSendDepartedEventNoOrigin)
+    {
+        ON_CALL(*mockFlightplan, GetOrigin).WillByDefault(testing::Return(""));
+
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(2500));
+
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(DepartureMonitorTest, ItDoesntSendDepartedEventTooFarFromOrigin)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(5.1));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(2500));
+
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(DepartureMonitorTest, ItDoesntSendDepartedEventTooHigh)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(5100));
+
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(DepartureMonitorTest, ItDoesntSendDepartedEventTooLow)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(1400));
+
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(DepartureMonitorTest, ItDoesntSendDepartedEventTooSlow)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(2.5));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(69));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(2500));
+
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(DepartureMonitorTest, ItDoesntSendDepartedEventOutOfRange)
+    {
+        ON_CALL(*mockFlightplan, GetDistanceFromOrigin).WillByDefault(testing::Return(0));
+
+        ON_CALL(*mockRadarTarget, GetGroundSpeed).WillByDefault(testing::Return(125));
+
+        ON_CALL(*mockRadarTarget, GetFlightLevel).WillByDefault(testing::Return(0));
+
+        monitor.TimedEventTrigger();
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+} // namespace UKControllerPluginTest::Departure

--- a/test/plugin/departure/DepartureMonitorTest.cpp
+++ b/test/plugin/departure/DepartureMonitorTest.cpp
@@ -1,6 +1,5 @@
 #include "departure/AircraftDepartedEvent.h"
 #include "departure/DepartureMonitor.h"
-#include "handoff/HandoffCache.h"
 #include "mock/MockEuroScopeCFlightplanInterface.h"
 #include "mock/MockEuroScopeCRadarTargetInterface.h"
 #include "mock/MockEuroscopePluginLoopbackInterface.h"
@@ -43,6 +42,10 @@ namespace UKControllerPluginTest::Departure {
             "BAW123",
             std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[0])
                 .callsign);
+        EXPECT_EQ(
+            "EGKK",
+            std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[0])
+                .airfield);
     }
 
     TEST_F(DepartureMonitorTest, ItDoesntSendDuplicateDepartedEvents)
@@ -60,6 +63,10 @@ namespace UKControllerPluginTest::Departure {
             "BAW123",
             std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[0])
                 .callsign);
+        EXPECT_EQ(
+            "EGKK",
+            std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[0])
+                .airfield);
 
         monitor.TimedEventTrigger();
         EXPECT_EQ(1, EventBusObserver().observedEvents.size());
@@ -82,6 +89,10 @@ namespace UKControllerPluginTest::Departure {
             "BAW123",
             std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[1])
                 .callsign);
+        EXPECT_EQ(
+            "EGKK",
+            std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[1])
+                .airfield);
     }
 
     TEST_F(DepartureMonitorTest, ItAllowsRedepartureIfAircraftChangesOriginAirport)
@@ -104,6 +115,10 @@ namespace UKControllerPluginTest::Departure {
             "BAW123",
             std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[1])
                 .callsign);
+        EXPECT_EQ(
+            "EGLL",
+            std::any_cast<UKControllerPlugin::Departure::AircraftDepartedEvent>(EventBusObserver().observedEvents[1])
+                .airfield);
     }
 
     TEST_F(DepartureMonitorTest, ItDoesntAllowRedepartureIfAircraftDoesntChangeOriginAirport)

--- a/test/plugin/departure/UserShouldClearDepartureDataMonitorTest.cpp
+++ b/test/plugin/departure/UserShouldClearDepartureDataMonitorTest.cpp
@@ -1,0 +1,159 @@
+#include "controller/ActiveCallsign.h"
+#include "controller/ControllerPosition.h"
+#include "departure/AircraftDepartedEvent.h"
+#include "departure/UserShouldClearDepartureDataEvent.h"
+#include "departure/UserShouldClearDepartureDataMonitor.h"
+#include "handoff/HandoffCache.h"
+#include "handoff/ResolvedHandoff.h"
+#include "ownership/AirfieldServiceProviderCollection.h"
+#include "ownership/ServiceProvision.h"
+#include "test/EventBusTestCase.h"
+
+namespace UKControllerPluginTest::Departure {
+
+    class UserShouldClearDepartureDataMonitorTest : public EventBusTestCase
+    {
+        public:
+        UserShouldClearDepartureDataMonitorTest()
+            : position(1, "EGKK_TWR", 118.5, {"EGLL"}, true, false),
+              callsign(std::make_shared<UKControllerPlugin::Controller::ActiveCallsign>(
+                  "EGKK_TWR", "Test", position, false)),
+              userCallsign(
+                  std::make_shared<UKControllerPlugin::Controller::ActiveCallsign>("EGKK_TWR", "Test", position, true)),
+              handoffs(std::make_shared<UKControllerPlugin::Handoff::HandoffCache>()),
+              ownership(std::make_shared<UKControllerPlugin::Ownership::AirfieldServiceProviderCollection>()),
+              monitor(handoffs, ownership)
+        {
+        }
+
+        UKControllerPlugin::Controller::ControllerPosition position;
+        std::shared_ptr<UKControllerPlugin::Controller::ActiveCallsign> callsign;
+        std::shared_ptr<UKControllerPlugin::Controller::ActiveCallsign> userCallsign;
+        std::shared_ptr<UKControllerPlugin::Handoff::HandoffCache> handoffs;
+        std::shared_ptr<UKControllerPlugin::Ownership::AirfieldServiceProviderCollection> ownership;
+        UKControllerPlugin::Departure::UserShouldClearDepartureDataMonitor monitor;
+    };
+
+    TEST_F(UserShouldClearDepartureDataMonitorTest, ItFiresEventIfUserIsOnTower)
+    {
+        std::vector<std::shared_ptr<UKControllerPlugin::Ownership::ServiceProvision>> provisions;
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Tower, userCallsign));
+        ownership->SetProvidersForAirfield("EGKK", provisions);
+
+        monitor.OnEvent({"BAW123", "EGKK"});
+
+        EXPECT_EQ(1, EventBusObserver().observedEvents.size());
+        EXPECT_EQ(
+            "BAW123",
+            std::any_cast<UKControllerPlugin::Departure::UserShouldClearDepartureDataEvent>(
+                EventBusObserver().observedEvents[0])
+                .callsign);
+    }
+
+    TEST_F(UserShouldClearDepartureDataMonitorTest, ItFiresEventIfUserIsOnGroundWithNoTower)
+    {
+        std::vector<std::shared_ptr<UKControllerPlugin::Ownership::ServiceProvision>> provisions;
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Ground, userCallsign));
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Delivery, callsign));
+        ownership->SetProvidersForAirfield("EGKK", provisions);
+
+        monitor.OnEvent({"BAW123", "EGKK"});
+
+        EXPECT_EQ(1, EventBusObserver().observedEvents.size());
+        EXPECT_EQ(
+            "BAW123",
+            std::any_cast<UKControllerPlugin::Departure::UserShouldClearDepartureDataEvent>(
+                EventBusObserver().observedEvents[0])
+                .callsign);
+    }
+
+    TEST_F(UserShouldClearDepartureDataMonitorTest, ItFiresEventIfUserIsOnDeliveryWithNoGroundOrTower)
+    {
+        std::vector<std::shared_ptr<UKControllerPlugin::Ownership::ServiceProvision>> provisions;
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Delivery, userCallsign));
+        ownership->SetProvidersForAirfield("EGKK", provisions);
+
+        monitor.OnEvent({"BAW123", "EGKK"});
+
+        EXPECT_EQ(1, EventBusObserver().observedEvents.size());
+        EXPECT_EQ(
+            "BAW123",
+            std::any_cast<UKControllerPlugin::Departure::UserShouldClearDepartureDataEvent>(
+                EventBusObserver().observedEvents[0])
+                .callsign);
+    }
+
+    TEST_F(UserShouldClearDepartureDataMonitorTest, ItDoesntFireEventIfUserIsOnDeliveryWithGroundProvidedBySomeoneElse)
+    {
+        std::vector<std::shared_ptr<UKControllerPlugin::Ownership::ServiceProvision>> provisions;
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Delivery, userCallsign));
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Ground, callsign));
+        ownership->SetProvidersForAirfield("EGKK", provisions);
+
+        monitor.OnEvent({"BAW123", "EGKK"});
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(UserShouldClearDepartureDataMonitorTest, ItDoesntFireEventIfUserIsOnDeliveryWithTowerProvidedBySomeoneElse)
+    {
+        std::vector<std::shared_ptr<UKControllerPlugin::Ownership::ServiceProvision>> provisions;
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Delivery, userCallsign));
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Tower, callsign));
+        ownership->SetProvidersForAirfield("EGKK", provisions);
+
+        monitor.OnEvent({"BAW123", "EGKK"});
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(UserShouldClearDepartureDataMonitorTest, ItDoesntFireEventIfUserIsOnGroundWithTowerProvidedBySomeoneElse)
+    {
+        std::vector<std::shared_ptr<UKControllerPlugin::Ownership::ServiceProvision>> provisions;
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Ground, userCallsign));
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Tower, callsign));
+        ownership->SetProvidersForAirfield("EGKK", provisions);
+
+        monitor.OnEvent({"BAW123", "EGKK"});
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(UserShouldClearDepartureDataMonitorTest, ItDoesntFireEventIfUserIsProvidingApproach)
+    {
+        std::vector<std::shared_ptr<UKControllerPlugin::Ownership::ServiceProvision>> provisions;
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Approach, userCallsign));
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Tower, userCallsign));
+        ownership->SetProvidersForAirfield("EGKK", provisions);
+
+        monitor.OnEvent({"BAW123", "EGKK"});
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+
+    TEST_F(UserShouldClearDepartureDataMonitorTest, ItDoesntFireEventIfTheresAHandoffPresent)
+    {
+        handoffs->Add(
+            std::make_shared<UKControllerPlugin::Handoff::ResolvedHandoff>("BAW123", nullptr, nullptr, nullptr));
+        std::vector<std::shared_ptr<UKControllerPlugin::Ownership::ServiceProvision>> provisions;
+        provisions.push_back(std::make_shared<UKControllerPlugin::Ownership::ServiceProvision>(
+            UKControllerPlugin::Ownership::ServiceType::Tower, userCallsign));
+        ownership->SetProvidersForAirfield("EGKK", provisions);
+
+        monitor.OnEvent({"BAW123", "EGKK"});
+
+        EXPECT_EQ(0, EventBusObserver().observedEvents.size());
+    }
+} // namespace UKControllerPluginTest::Departure

--- a/test/plugin/eventhandler/EventBusTest.cpp
+++ b/test/plugin/eventhandler/EventBusTest.cpp
@@ -1,0 +1,47 @@
+#include "eventhandler/EventBus.h"
+#include "eventhandler/EventHandler.h"
+#include "test/EventBusTestCase.h"
+
+using UKControllerPlugin::EventHandler::EventBus;
+
+namespace UKControllerPluginTest::EventHandler {
+    class EventBusTest : public EventBusTestCase
+    {
+        public:
+    };
+
+    class MockHandler : public UKControllerPlugin::EventHandler::EventHandler<int>
+    {
+        public:
+        void OnEvent(const int& event)
+        {
+            receivedValue = event;
+        }
+
+        int receivedValue = -1;
+    };
+
+    TEST_F(EventBusTest, ItProcessesAnEvent)
+    {
+        const auto handler = std::make_shared<MockHandler>();
+        EventBus::Bus().AddHandler<int>(handler, UKControllerPlugin::EventHandler::EventHandlerFlags::Sync);
+        EventBus::Bus().OnEvent(123);
+        EXPECT_EQ(123, handler->receivedValue);
+    }
+
+    TEST_F(EventBusTest, ItProcessesAnEventAsync)
+    {
+        const auto handler = std::make_shared<MockHandler>();
+        EventBus::Bus().AddHandler<int>(handler, UKControllerPlugin::EventHandler::EventHandlerFlags::Async);
+        EventBus::Bus().OnEvent(123);
+        EXPECT_EQ(123, handler->receivedValue);
+    }
+
+    TEST_F(EventBusTest, ItSendsAnEventForObservation)
+    {
+        EventBus::Bus().OnEvent(123);
+
+        EXPECT_EQ(1, EventBusObserver().observedEvents.size());
+        EXPECT_EQ(123, std::any_cast<int>(EventBusObserver().observedEvents[0]));
+    }
+} // namespace UKControllerPluginTest::EventHandler

--- a/test/plugin/eventhandler/EventBusTest.cpp
+++ b/test/plugin/eventhandler/EventBusTest.cpp
@@ -37,6 +37,16 @@ namespace UKControllerPluginTest::EventHandler {
         EXPECT_EQ(123, handler->receivedValue);
     }
 
+    TEST_F(EventBusTest, ItProcessesAnEventToMultipleHandlers)
+    {
+        const auto handler1 = std::make_shared<MockHandler>();
+        const auto handler2 = std::make_shared<MockHandler>();
+        EventBus::Bus().AddHandler<int>(handler2, UKControllerPlugin::EventHandler::EventHandlerFlags::Sync);
+        EventBus::Bus().OnEvent(123);
+        EXPECT_EQ(123, handler1->receivedValue);
+        EXPECT_EQ(123, handler2->receivedValue);
+    }
+
     TEST_F(EventBusTest, ItSendsAnEventForObservation)
     {
         EventBus::Bus().OnEvent(123);

--- a/test/plugin/eventhandler/EventBusTest.cpp
+++ b/test/plugin/eventhandler/EventBusTest.cpp
@@ -41,6 +41,7 @@ namespace UKControllerPluginTest::EventHandler {
     {
         const auto handler1 = std::make_shared<MockHandler>();
         const auto handler2 = std::make_shared<MockHandler>();
+        EventBus::Bus().AddHandler<int>(handler1, UKControllerPlugin::EventHandler::EventHandlerFlags::Sync);
         EventBus::Bus().AddHandler<int>(handler2, UKControllerPlugin::EventHandler::EventHandlerFlags::Sync);
         EventBus::Bus().OnEvent(123);
         EXPECT_EQ(123, handler1->receivedValue);

--- a/test/plugin/eventhandler/EventStreamTest.cpp
+++ b/test/plugin/eventhandler/EventStreamTest.cpp
@@ -1,0 +1,51 @@
+#include "eventhandler/EventStream.h"
+#include "eventhandler/EventHandler.h"
+#include "test/EventBusTestCase.h"
+
+using UKControllerPlugin::EventHandler::EventStream;
+
+namespace UKControllerPluginTest::EventHandler {
+    class EventStreamTest : public testing::Test
+    {
+        public:
+        EventStream<int> stream;
+    };
+
+    class MockHandler : public UKControllerPlugin::EventHandler::EventHandler<int>
+    {
+        public:
+        void OnEvent(const int& event)
+        {
+            receivedValue = event;
+        }
+
+        int receivedValue = -1;
+    };
+
+    TEST_F(EventStreamTest, ItProcessesAnEvent)
+    {
+        const auto handler = std::make_shared<MockHandler>();
+        stream.AddHandler(handler, UKControllerPlugin::EventHandler::EventHandlerFlags::Sync);
+        stream.OnEvent(123);
+        EXPECT_EQ(123, handler->receivedValue);
+    }
+
+    TEST_F(EventStreamTest, ItProcessesAnEventAsync)
+    {
+        const auto handler = std::make_shared<MockHandler>();
+        stream.AddHandler(handler, UKControllerPlugin::EventHandler::EventHandlerFlags::Async);
+        stream.OnEvent(123);
+        EXPECT_EQ(123, handler->receivedValue);
+    }
+
+    TEST_F(EventStreamTest, ItProcessesAnEventToMultipleHandlers)
+    {
+        const auto handler1 = std::make_shared<MockHandler>();
+        const auto handler2 = std::make_shared<MockHandler>();
+        stream.AddHandler(handler1, UKControllerPlugin::EventHandler::EventHandlerFlags::Sync);
+        stream.AddHandler(handler2, UKControllerPlugin::EventHandler::EventHandlerFlags::Sync);
+        stream.OnEvent(123);
+        EXPECT_EQ(123, handler1->receivedValue);
+        EXPECT_EQ(123, handler2->receivedValue);
+    }
+} // namespace UKControllerPluginTest::EventHandler

--- a/test/plugin/handoff/HandoffModuleTest.cpp
+++ b/test/plugin/handoff/HandoffModuleTest.cpp
@@ -2,6 +2,7 @@
 #include "controller/ActiveCallsignCollection.h"
 #include "euroscope/RunwayDialogAwareCollection.h"
 #include "flightplan/FlightPlanEventHandlerCollection.h"
+#include "handoff/HandoffCache.h"
 #include "handoff/HandoffModule.h"
 #include "integration/IntegrationServer.h"
 #include "integration/IntegrationPersistenceContainer.h"
@@ -36,6 +37,12 @@ namespace UKControllerPluginTest::Handoff {
         PersistenceContainer container;
         NiceMock<MockDependencyLoader> dependencyLoader;
     };
+
+    TEST_F(HandoffModuleTest, ItRegistersHandoffCacheOnContainer)
+    {
+        BootstrapPlugin(this->container, this->dependencyLoader);
+        ASSERT_EQ(0, this->container.handoffCache->Count());
+    }
 
     TEST_F(HandoffModuleTest, TestItRegistersTagItem)
     {

--- a/test/plugin/initialaltitude/ClearInitialAltitudeTest.cpp
+++ b/test/plugin/initialaltitude/ClearInitialAltitudeTest.cpp
@@ -1,0 +1,117 @@
+#include "mock/MockEuroScopeCFlightplanInterface.h"
+#include "mock/MockEuroscopePluginLoopbackInterface.h"
+#include "mock/MockSidMapperInterface.h"
+#include "sid/StandardInstrumentDeparture.h"
+#include "initialaltitude/ClearInitialAltitude.h"
+
+namespace UKControllerPluginTest::InitialAltitude {
+
+    class ClearInitialAltitudeTest : public testing::Test
+    {
+        public:
+        ClearInitialAltitudeTest()
+            : sid(std::make_shared<UKControllerPlugin::Sid::StandardInstrumentDeparture>(
+                  1, 2, "ADMAG2X", 6000, 125, 1)),
+              mockFlightplan(std::make_shared<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>>()),
+              clear(mockPlugin, sidMapper)
+        {
+            ON_CALL(mockPlugin, GetFlightplanForCallsign("BAW123")).WillByDefault(testing::Return(mockFlightplan));
+        }
+
+        std::shared_ptr<UKControllerPlugin::Sid::StandardInstrumentDeparture> sid;
+        testing::NiceMock<Sid::MockSidMapperInterface> sidMapper;
+        testing::NiceMock<Euroscope::MockEuroscopePluginLoopbackInterface> mockPlugin;
+        std::shared_ptr<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>> mockFlightplan;
+        UKControllerPlugin::InitialAltitude::ClearInitialAltitude clear;
+    };
+
+    TEST_F(ClearInitialAltitudeTest, ItClearsTheInitialAltitudeForUntrackedAircraft)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(false));
+
+        ON_CALL(*mockFlightplan, GetClearedAltitude).WillByDefault(testing::Return(6000));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        EXPECT_CALL(*mockFlightplan, SetClearedAltitude(0)).Times(1);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialAltitudeTest, ItClearsTheInitialAltitudeForAircraftTrackedByTheUser)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, GetClearedAltitude).WillByDefault(testing::Return(6000));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        EXPECT_CALL(*mockFlightplan, SetClearedAltitude(0)).Times(1);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialAltitudeTest, ItDoesntClearAltitudeIfChangedByController)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, GetClearedAltitude).WillByDefault(testing::Return(5000));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        EXPECT_CALL(*mockFlightplan, SetClearedAltitude(0)).Times(0);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialAltitudeTest, ItDoesntClearAltitudeIfNoMappedSid)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(true));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(nullptr));
+
+        ON_CALL(*mockFlightplan, GetClearedAltitude).WillByDefault(testing::Return(6000));
+
+        EXPECT_CALL(*mockFlightplan, SetClearedAltitude(0)).Times(0);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialAltitudeTest, ItDoesntClearAltitudeIfTrackedBySomeoneElse)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(false));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        ON_CALL(*mockFlightplan, GetClearedAltitude).WillByDefault(testing::Return(6000));
+
+        EXPECT_CALL(*mockFlightplan, SetClearedAltitude(0)).Times(0);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialAltitudeTest, ItDoesntClearAltitudeIfFlightplanNotFound)
+    {
+        ON_CALL(mockPlugin, GetFlightplanForCallsign("BAW123")).WillByDefault(testing::Return(nullptr));
+
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(true));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        ON_CALL(*mockFlightplan, GetClearedAltitude).WillByDefault(testing::Return(6000));
+
+        EXPECT_CALL(*mockFlightplan, SetClearedAltitude(0)).Times(0);
+
+        clear.OnEvent({"BAW123"});
+    }
+} // namespace UKControllerPluginTest::InitialAltitude

--- a/test/plugin/initialaltitude/InitialAltitudeModuleTest.cpp
+++ b/test/plugin/initialaltitude/InitialAltitudeModuleTest.cpp
@@ -1,9 +1,14 @@
 #include "initialaltitude/InitialAltitudeModule.h"
+#include "bootstrap/InitialisePlugin.h"
 #include "bootstrap/PersistenceContainer.h"
+#include "departure/UserShouldClearDepartureDataEvent.h"
+#include "eventhandler/EventBus.h"
 #include "flightplan/FlightPlanEventHandlerCollection.h"
 #include "euroscope/UserSettingAwareCollection.h"
+#include "initialaltitude/ClearInitialAltitude.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "controller/ActiveCallsignCollection.h"
+#include "test/EventBusTestCase.h"
 #include "timedevent/TimedEventCollection.h"
 
 using testing::NiceMock;
@@ -11,59 +16,72 @@ using testing::Test;
 using UKControllerPlugin::Bootstrap::PersistenceContainer;
 using UKControllerPlugin::Controller::ActiveCallsignCollection;
 using UKControllerPlugin::Euroscope::UserSettingAwareCollection;
+using UKControllerPlugin::EventHandler::EventBus;
 using UKControllerPlugin::Flightplan::FlightPlanEventHandlerCollection;
 using UKControllerPlugin::InitialAltitude::InitialAltitudeModule;
 using UKControllerPlugin::Plugin::FunctionCallEventHandler;
 using UKControllerPlugin::TimedEvent::TimedEventCollection;
 
-namespace UKControllerPluginTest {
-    namespace InitialAltitude {
+namespace UKControllerPluginTest::InitialAltitude {
 
-        class InitialAltitudeModuleTest : public Test
+    class InitialAltitudeModuleTest : public EventBusTestCase
+    {
+        public:
+        void SetUp()
         {
-            public:
-            void SetUp()
-            {
-                container.flightplanHandler = std::make_unique<FlightPlanEventHandlerCollection>();
-                container.userSettingHandlers = std::make_unique<UserSettingAwareCollection>();
-                container.pluginFunctionHandlers = std::make_unique<FunctionCallEventHandler>();
-                container.activeCallsigns = std::make_shared<ActiveCallsignCollection>();
-                container.timedHandler = std::make_unique<TimedEventCollection>();
-            }
-
-            PersistenceContainer container;
-        };
-
-        TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersFlightplanEvents)
-        {
-            InitialAltitudeModule::BootstrapPlugin(this->container);
-            EXPECT_EQ(1, container.flightplanHandler->CountHandlers());
+            EventBusTestCase::SetUp();
+            container.flightplanHandler = std::make_unique<FlightPlanEventHandlerCollection>();
+            container.userSettingHandlers = std::make_unique<UserSettingAwareCollection>();
+            container.pluginFunctionHandlers = std::make_unique<FunctionCallEventHandler>();
+            container.activeCallsigns = std::make_shared<ActiveCallsignCollection>();
+            container.timedHandler = std::make_unique<TimedEventCollection>();
         }
 
-        TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersActiveCallsignEvents)
-        {
-            InitialAltitudeModule::BootstrapPlugin(this->container);
-            EXPECT_EQ(1, container.activeCallsigns->CountHandlers());
-        }
+        PersistenceContainer container;
+    };
 
-        TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersRecycleTagFunction)
-        {
-            InitialAltitudeModule::BootstrapPlugin(this->container);
-            EXPECT_EQ(1, container.pluginFunctionHandlers->CountTagFunctions());
-            EXPECT_TRUE(container.pluginFunctionHandlers->HasTagFunction(9002));
-        }
+    TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersFlightplanEvents)
+    {
+        InitialAltitudeModule::BootstrapPlugin(this->container);
+        EXPECT_EQ(1, container.flightplanHandler->CountHandlers());
+    }
 
-        TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersUserSettingsEvents)
-        {
-            InitialAltitudeModule::BootstrapPlugin(this->container);
-            EXPECT_EQ(1, container.userSettingHandlers->Count());
-        }
+    TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersActiveCallsignEvents)
+    {
+        InitialAltitudeModule::BootstrapPlugin(this->container);
+        EXPECT_EQ(1, container.activeCallsigns->CountHandlers());
+    }
 
-        TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersTimedEvents)
-        {
-            InitialAltitudeModule::BootstrapPlugin(this->container);
-            EXPECT_EQ(1, container.timedHandler->CountHandlers());
-            EXPECT_EQ(1, container.timedHandler->CountHandlersForFrequency(10));
-        }
-    } // namespace InitialAltitude
-} // namespace UKControllerPluginTest
+    TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersRecycleTagFunction)
+    {
+        InitialAltitudeModule::BootstrapPlugin(this->container);
+        EXPECT_EQ(1, container.pluginFunctionHandlers->CountTagFunctions());
+        EXPECT_TRUE(container.pluginFunctionHandlers->HasTagFunction(9002));
+    }
+
+    TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersUserSettingsEvents)
+    {
+        InitialAltitudeModule::BootstrapPlugin(this->container);
+        EXPECT_EQ(1, container.userSettingHandlers->Count());
+    }
+
+    TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersTimedEvents)
+    {
+        InitialAltitudeModule::BootstrapPlugin(this->container);
+        EXPECT_EQ(1, container.timedHandler->CountHandlers());
+        EXPECT_EQ(1, container.timedHandler->CountHandlersForFrequency(10));
+    }
+
+    TEST_F(InitialAltitudeModuleTest, BootstrapPluginRegistersClearInitialAltitude)
+    {
+        InitialAltitudeModule::BootstrapPlugin(this->container);
+        const auto eventStream = std::any_cast<std::shared_ptr<UKControllerPlugin::EventHandler::EventStream<
+            UKControllerPlugin::Departure::UserShouldClearDepartureDataEvent>>>(
+            EventBus::Bus().GetAnyStream(typeid(UKControllerPlugin::Departure::UserShouldClearDepartureDataEvent)));
+        EXPECT_EQ(1, eventStream->Handlers().size());
+        const auto handler = eventStream->Handlers()[0];
+        EXPECT_EQ(UKControllerPlugin::EventHandler::EventHandlerFlags::Sync, handler.flags);
+        EXPECT_NO_THROW(static_cast<void>(
+            dynamic_cast<const UKControllerPlugin::InitialAltitude::ClearInitialAltitude&>(*handler.handler.get())));
+    }
+} // namespace UKControllerPluginTest::InitialAltitude

--- a/test/plugin/initialheading/ClearInitialHeadingTest.cpp
+++ b/test/plugin/initialheading/ClearInitialHeadingTest.cpp
@@ -1,0 +1,117 @@
+#include "mock/MockEuroScopeCFlightplanInterface.h"
+#include "mock/MockEuroscopePluginLoopbackInterface.h"
+#include "mock/MockSidMapperInterface.h"
+#include "sid/StandardInstrumentDeparture.h"
+#include "initialheading/ClearInitialHeading.h"
+
+namespace UKControllerPluginTest::InitialHeading {
+
+    class ClearInitialHeadingTest : public testing::Test
+    {
+        public:
+        ClearInitialHeadingTest()
+            : sid(std::make_shared<UKControllerPlugin::Sid::StandardInstrumentDeparture>(
+                  1, 2, "ADMAG2X", 6000, 125, 1)),
+              mockFlightplan(std::make_shared<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>>()),
+              clear(mockPlugin, sidMapper)
+        {
+            ON_CALL(mockPlugin, GetFlightplanForCallsign("BAW123")).WillByDefault(testing::Return(mockFlightplan));
+        }
+
+        std::shared_ptr<UKControllerPlugin::Sid::StandardInstrumentDeparture> sid;
+        testing::NiceMock<Sid::MockSidMapperInterface> sidMapper;
+        testing::NiceMock<Euroscope::MockEuroscopePluginLoopbackInterface> mockPlugin;
+        std::shared_ptr<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>> mockFlightplan;
+        UKControllerPlugin::InitialHeading::ClearInitialHeading clear;
+    };
+
+    TEST_F(ClearInitialHeadingTest, ItClearsTheInitialHeadingForUntrackedAircraft)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(false));
+
+        ON_CALL(*mockFlightplan, GetAssignedHeading).WillByDefault(testing::Return(125));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        EXPECT_CALL(*mockFlightplan, SetHeading(0)).Times(1);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialHeadingTest, ItClearsTheInitialHeadingForAircraftTrackedByTheUser)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, GetAssignedHeading).WillByDefault(testing::Return(125));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        EXPECT_CALL(*mockFlightplan, SetHeading(0)).Times(1);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialHeadingTest, ItDoesntClearHeadingIfChangedByController)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, GetAssignedHeading).WillByDefault(testing::Return(126));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        EXPECT_CALL(*mockFlightplan, SetHeading(0)).Times(0);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialHeadingTest, ItDoesntClearHeadingIfNoMappedSid)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(true));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(nullptr));
+
+        ON_CALL(*mockFlightplan, GetAssignedHeading).WillByDefault(testing::Return(125));
+
+        EXPECT_CALL(*mockFlightplan, SetHeading(0)).Times(0);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialHeadingTest, ItDoesntClearHeadingIfTrackedBySomeoneElse)
+    {
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(false));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        ON_CALL(*mockFlightplan, GetAssignedHeading).WillByDefault(testing::Return(125));
+
+        EXPECT_CALL(*mockFlightplan, SetHeading(0)).Times(0);
+
+        clear.OnEvent({"BAW123"});
+    }
+
+    TEST_F(ClearInitialHeadingTest, ItDoesntClearHeadingIfFlightplanNotFound)
+    {
+        ON_CALL(mockPlugin, GetFlightplanForCallsign("BAW123")).WillByDefault(testing::Return(nullptr));
+
+        ON_CALL(*mockFlightplan, IsTracked).WillByDefault(testing::Return(true));
+
+        ON_CALL(*mockFlightplan, IsTrackedByUser).WillByDefault(testing::Return(true));
+
+        ON_CALL(sidMapper, MapFlightplanToSid(testing::Ref(*mockFlightplan))).WillByDefault(testing::Return(sid));
+
+        ON_CALL(*mockFlightplan, GetAssignedHeading).WillByDefault(testing::Return(125));
+
+        EXPECT_CALL(*mockFlightplan, SetHeading(0)).Times(0);
+
+        clear.OnEvent({"BAW123"});
+    }
+} // namespace UKControllerPluginTest::InitialHeading

--- a/test/plugin/initialheading/InitialHeadingModuleTest.cpp
+++ b/test/plugin/initialheading/InitialHeadingModuleTest.cpp
@@ -28,6 +28,7 @@ namespace UKControllerPluginTest {
             public:
             void SetUp()
             {
+                EventBusTestCase::SetUp();
                 container.flightplanHandler = std::make_unique<FlightPlanEventHandlerCollection>();
                 container.userSettingHandlers = std::make_unique<UserSettingAwareCollection>();
                 container.pluginFunctionHandlers = std::make_unique<FunctionCallEventHandler>();

--- a/test/plugin/mock/MockEuroScopeCFlightplanInterface.h
+++ b/test/plugin/mock/MockEuroScopeCFlightplanInterface.h
@@ -15,6 +15,7 @@ namespace UKControllerPluginTest {
             MOCK_CONST_METHOD0(GetAircraftType, std::string(void));
             MOCK_CONST_METHOD0(GetCallsign, std::string(void));
             MOCK_CONST_METHOD0(GetClearedAltitude, int(void));
+            MOCK_CONST_METHOD0(GetAssignedHeading, int(void));
             MOCK_CONST_METHOD0(GetCruiseLevel, int(void));
             MOCK_CONST_METHOD0(GetDestination, std::string(void));
             MOCK_CONST_METHOD0(GetDistanceFromOrigin, double(void));

--- a/test/plugin/pch/pch.h
+++ b/test/plugin/pch/pch.h
@@ -24,6 +24,7 @@
 #include "ShlObj.h"
 #include "shtypes.h"
 
+#include <any>
 #include <algorithm>
 #include <chrono>
 #include <filesystem>
@@ -31,11 +32,13 @@
 #include <gdiplusgraphics.h>
 #include <gdiplustypes.h>
 #include <gdiplusenums.h>
+#include <list>
 #include <mutex>
 #include <queue>
 #include <regex>
 #include <set>
 #include <string>
+#include <typeindex>
 #include <unordered_set>
 
 // Euroscope

--- a/test/plugin/test/EventBusTestCase.h
+++ b/test/plugin/test/EventBusTestCase.h
@@ -1,0 +1,62 @@
+#pragma once
+#include "eventhandler/EventObserver.h"
+#include "eventhandler/EventBusFactory.h"
+#include "eventhandler/MutableEventBus.h"
+
+namespace UKControllerPluginTest {
+    class TestEventBusObserver : public UKControllerPlugin::EventHandler::EventObserver
+    {
+        public:
+        void OnEvent(std::any event) override
+        {
+            observedEvents.push_back(event);
+        }
+
+        std::vector<std::any> observedEvents{};
+    };
+
+    class TestEventBusFactory : public UKControllerPlugin::EventHandler::EventBusFactory
+    {
+        public:
+        TestEventBusFactory() : observer(std::make_shared<TestEventBusObserver>())
+        {
+        }
+
+        auto CreateBus() -> std::unique_ptr<UKControllerPlugin::EventHandler::EventBus> override
+        {
+            auto bus = std::unique_ptr<UKControllerPlugin::EventHandler::MutableEventBus>(
+                new UKControllerPlugin::EventHandler::MutableEventBus);
+            bus->SetObserver(observer);
+
+            return std::move(bus);
+        }
+
+        std::shared_ptr<TestEventBusObserver> observer;
+    };
+
+    class EventBusTestCase : public testing::Test
+    {
+        public:
+        virtual void SetUp()
+        {
+            testing::Test::SetUp();
+            busFactory = std::make_shared<TestEventBusFactory>();
+            UKControllerPlugin::EventHandler::MutableEventBus::MutableEventBus::SetFactory(busFactory);
+        }
+
+        virtual void TearDown()
+        {
+            UKControllerPlugin::EventHandler::MutableEventBus::MutableEventBus::Reset();
+            testing::Test::TearDown();
+        }
+
+        // For observing and making assertions on events
+        [[nodiscard]] auto EventBusObserver() const -> TestEventBusObserver&
+        {
+            return *busFactory->observer;
+        }
+
+        private:
+        std::shared_ptr<TestEventBusFactory> busFactory;
+    };
+} // namespace UKControllerPluginTest


### PR DESCRIPTION
- Add generic "EventBus" using the power of template polymorphism to allow us to create arbitrary event handlers and streams of events. This saves us from having to constantly create interfaces to handle each type of event, and collections of event handlers. The templating now just creates new instantiation of EventBus methods as new events are added.
- Using templates, we just add a handler to the "event bus", and then push any "event to it"... templates handles the rest.
- Add a monitor for aircraft departing, and trigger an event when they do.
- Add a monitor for the aircraft departing event to determine whether the user has to clear the data (no onward ATC, user is on the position closest to Tower). Trigger an event if this is the case.
- Add event handlers for the "User should clear departure data" event, which clear initial altitude and heading, if previously set.

Resolves #16 