### PR TITLE
Departure releases chat area

### DIFF
--- a/resource/UKControllerPlugin.rc
+++ b/resource/UKControllerPlugin.rc
@@ -106,20 +106,22 @@ BEGIN
     CONTROL         "Enable Prenote Notifications",GS_DIALOG_PRENOTE_CHECK,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,16,96,10
     CONTROL         "Automatically Assign Initial Altitudes",GS_DIALOG_IA_CHECK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,34,122,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,43,122,10
     CONTROL         "Automatically Assign Squawks",GS_DIALOG_SQUAWK_CHECK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,54,107,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,63,107,10
     CONTROL         "Enable QNH Change Notifications",GS_DIALOG_QNH_CHECK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,65,117,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,74,117,10
     CONTROL         "Display Unknown Times As Blank",GS_TIME_FORMAT_CHECK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,76,117,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,85,117,10
     CONTROL         "Automatically Assign Initial Headings",GS_DIALOG_IH_CHECK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,44,126,10
-    LTEXT           "Experimental settings, modify at your own risk:",IDC_GEN_SETTINGS_EXPERIMENTAL,14,90,136,8
-    COMBOBOX        IDC_RELEASE_CHANNEL,14,104,66,35,CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Update Channel",IDC_STATIC,87,106,50,8
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,53,126,10
+    LTEXT           "Experimental settings, modify at your own risk:",IDC_GEN_SETTINGS_EXPERIMENTAL,14,99,136,8
+    COMBOBOX        IDC_RELEASE_CHANNEL,14,113,66,35,CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Update Channel",IDC_STATIC,87,115,50,8
     CONTROL         "Notify Prenote Activity In Chat Area",IDC_PRENOTE_CHAT_MESSAGE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,25,118,10
+    CONTROL         "Notify Departure Release Activity In Chat Area",IDC_RELEASE_CHAT_MESSAGE,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,34,152,10
 END
 
 IDD_TIMER_CONFIGURATION DIALOGEX 0, 0, 179, 158

--- a/resource/resource.h
+++ b/resource/resource.h
@@ -202,6 +202,8 @@
 #define IDC_GEN_SETTINGS_EXPERIMENTAL   1142
 #define IDC_RELEASE_CHANNEL             1143
 #define IDC_API_KEY_STATIC              1144
+#define IDC_                            1145
+#define IDC_RELEASE_CHAT_MESSAGE        1145
 
 // Next default values for new objects
 // 
@@ -209,7 +211,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        145
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1145
+#define _APS_NEXT_CONTROL_VALUE         1146
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -77,6 +77,11 @@ set(src__bootstrap
     bootstrap/PersistenceContainer.cpp bootstrap/BootstrapProviderInterface.h bootstrap/BootstrapProviderCollection.h bootstrap/BootstrapProviderCollection.cpp bootstrap/BootstrapProviderCollection.h bootstrap/ModuleFactories.h bootstrap/ModuleFactories.cpp bootstrap/ModuleFactories.h bootstrap/BootstrapProviderCollectionFactory.cpp bootstrap/BootstrapProviderCollectionFactory.h bootstrap/ModuleBootstrap.cpp bootstrap/ModuleBootstrap.h)
 source_group("src\\bootstrap" FILES ${src__bootstrap})
 
+set(src__collection
+        
+        collection/PluginCollectionTypesFwd.h)
+source_group("src\\collection" FILES ${src__collection})
+
 set(src__command
     "command/CommandHandlerCollection.cpp"
     "command/CommandHandlerCollection.h"
@@ -960,6 +965,7 @@ set(ALL_FILES
     ${src__api}
     ${src__approach}
     ${src__bootstrap}
+    ${src__collection}
     ${src__command}
     ${src__components}
     ${src__controller}

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -814,7 +814,7 @@ set(src__releases
     releases/EnrouteRelease.cpp releases/EnrouteReleaseType.cpp
     releases/RejectDepartureReleaseDialog.cpp releases/RejectDepartureReleaseDialog.h
     releases/ReleaseApprovalRemarksUserMessage.cpp releases/ReleaseApprovalRemarksUserMessage.h
-    releases/ReleaseRejectionRemarksUserMessage.cpp releases/ReleaseRejectionRemarksUserMessage.h)
+    releases/ReleaseRejectionRemarksUserMessage.cpp releases/ReleaseRejectionRemarksUserMessage.h releases/DepartureReleaseRequestedEvent.h releases/SendReleaseRequestedChatAreaMessage.cpp releases/SendReleaseRequestedChatAreaMessage.h releases/DepartureReleaseRelevanceChecker.h releases/ReleaseIsTargetedAtUser.cpp releases/ReleaseIsTargetedAtUser.h)
 source_group("src\\releases" FILES ${src__releases})
 
 set(src__runway

--- a/src/plugin/collection/PluginCollectionTypesFwd.h
+++ b/src/plugin/collection/PluginCollectionTypesFwd.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace UKControllerPluginUtils::Collection {
+    template <typename KeyType, typename ValueType> class Collection;
+} // namespace UKControllerPluginUtils::Collection
+
+namespace UKControllerPlugin::Releases {
+    class DepartureReleaseRequest;
+
+    using DepartureReleaseRequestCollection =
+        UKControllerPluginUtils::Collection::Collection<int, DepartureReleaseRequest>;
+} // namespace UKControllerPlugin::Releases

--- a/src/plugin/euroscope/GeneralSettingsDialog.cpp
+++ b/src/plugin/euroscope/GeneralSettingsDialog.cpp
@@ -41,6 +41,11 @@ namespace UKControllerPlugin {
 
             CheckDlgButton(
                 hwnd,
+                IDC_RELEASE_CHAT_MESSAGE,
+                this->GetCheckboxStateFromSettings(GeneralSettingsEntries::releaseChatAreaMessagesSettingsKey));
+
+            CheckDlgButton(
+                hwnd,
                 GS_DIALOG_IA_CHECK,
                 this->GetCheckboxStateFromSettings(GeneralSettingsEntries::initialAltitudeToggleSettingsKey));
 
@@ -104,6 +109,12 @@ namespace UKControllerPlugin {
                 GeneralSettingsEntries::prenoteChatAreaMessagesSettingsKey,
                 GeneralSettingsEntries::prenoteChatAreaMessagesSettingsDescription,
                 this->GetSettingFromCheckboxState(hwnd, IDC_PRENOTE_CHAT_MESSAGE));
+
+            // Releases in chat area
+            this->userSettings.Save(
+                GeneralSettingsEntries::releaseChatAreaMessagesSettingsKey,
+                GeneralSettingsEntries::releaseChatAreaMessagesSettingsDescription,
+                this->GetSettingFromCheckboxState(hwnd, IDC_RELEASE_CHAT_MESSAGE));
 
             // Initial Altitudes Toggle
             this->userSettings.Save(

--- a/src/plugin/euroscope/GeneralSettingsEntries.cpp
+++ b/src/plugin/euroscope/GeneralSettingsEntries.cpp
@@ -10,6 +10,9 @@ namespace UKControllerPlugin {
         const std::string GeneralSettingsEntries::prenoteChatAreaMessagesSettingsKey = "sendPrenotesToChat";
         const std::string GeneralSettingsEntries::prenoteChatAreaMessagesSettingsDescription =
             "Show prenote activity in chat area";
+        const std::string GeneralSettingsEntries::releaseChatAreaMessagesSettingsKey = "sendReleasesToChat";
+        const std::string GeneralSettingsEntries::releaseChatAreaMessagesSettingsDescription =
+            "Show release activity in chat area";
 
         // SQUAWKS
         const std::string GeneralSettingsEntries::squawkToggleSettingsKey = "autoAssignSquawks";

--- a/src/plugin/euroscope/GeneralSettingsEntries.h
+++ b/src/plugin/euroscope/GeneralSettingsEntries.h
@@ -13,6 +13,8 @@ namespace UKControllerPlugin {
             static const std::string usePrenoteSettingsDescription;
             static const std::string prenoteChatAreaMessagesSettingsKey;
             static const std::string prenoteChatAreaMessagesSettingsDescription;
+            static const std::string releaseChatAreaMessagesSettingsKey;
+            static const std::string releaseChatAreaMessagesSettingsDescription;
 
             // SQUAWKS
             static const std::string squawkToggleSettingsKey;

--- a/src/plugin/releases/DepartureReleaseEventHandler.h
+++ b/src/plugin/releases/DepartureReleaseEventHandler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "collection/PluginCollectionTypesFwd.h"
 #include "push/PushEventProcessorInterface.h"
 #include "releases/CompareDepartureReleases.h"
 #include "tag/TagItemInterface.h"
@@ -44,6 +45,7 @@ namespace UKControllerPlugin {
         {
             public:
             DepartureReleaseEventHandler(
+                const std::shared_ptr<DepartureReleaseRequestCollection> releaseRequests,
                 const Api::ApiInterface& api,
                 TaskManager::TaskRunnerInterface& taskRunner,
                 Euroscope::EuroscopePluginLoopbackInterface& plugin,
@@ -137,7 +139,7 @@ namespace UKControllerPlugin {
             static const int RELEASE_DECISION_MADE_DELETE_AFTER_SECONDS = 90;
 
             // Release requests in progress
-            std::map<int, std::shared_ptr<DepartureReleaseRequest>> releaseRequests;
+            const std::shared_ptr<DepartureReleaseRequestCollection> releaseRequests;
 
             // Controller positions
             const Controller::ControllerPositionCollection& controllers;

--- a/src/plugin/releases/DepartureReleaseRelevanceChecker.h
+++ b/src/plugin/releases/DepartureReleaseRelevanceChecker.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace UKControllerPlugin::Releases {
+
+    class DepartureReleaseRequest;
+
+    /**
+     * Checks if a release request is relevant to the current user.
+     */
+    class DepartureReleaseRelevanceChecker
+    {
+        public:
+        virtual ~DepartureReleaseRelevanceChecker() = default;
+        [[nodiscard]] virtual bool IsRelevant(const DepartureReleaseRequest& releaseRequest) const = 0;
+    };
+} // namespace UKControllerPlugin::Releases

--- a/src/plugin/releases/DepartureReleaseRequest.cpp
+++ b/src/plugin/releases/DepartureReleaseRequest.cpp
@@ -135,4 +135,9 @@ namespace UKControllerPlugin::Releases {
     {
         return this->remarks;
     }
+
+    auto DepartureReleaseRequest::CollectionKey() const -> int
+    {
+        return this->id;
+    }
 } // namespace UKControllerPlugin::Releases

--- a/src/plugin/releases/DepartureReleaseRequest.h
+++ b/src/plugin/releases/DepartureReleaseRequest.h
@@ -13,6 +13,7 @@ namespace UKControllerPlugin::Releases {
             std::chrono::system_clock::time_point requestExpiresAt);
 
         void Acknowledge();
+        [[nodiscard]] auto CollectionKey() const -> int;
         void Reject(std::string remarks);
         void Approve(
             std::chrono::system_clock::time_point releasedAtTime,

--- a/src/plugin/releases/DepartureReleaseRequestedEvent.h
+++ b/src/plugin/releases/DepartureReleaseRequestedEvent.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace UKControllerPlugin::Releases {
+
+    class DepartureReleaseRequest;
+
+    using DepartureReleaseRequestedEvent = struct DepartureReleaseRequestedEvent
+    {
+        std::shared_ptr<DepartureReleaseRequest> releaseRequest;
+    };
+} // namespace UKControllerPlugin::Releases

--- a/src/plugin/releases/ReleaseIsTargetedAtUser.cpp
+++ b/src/plugin/releases/ReleaseIsTargetedAtUser.cpp
@@ -1,0 +1,25 @@
+#include "ReleaseIsTargetedAtUser.h"
+#include "controller/ActiveCallsignCollection.h"
+#include "controller/ActiveCallsign.h"
+#include "controller/ControllerPosition.h"
+#include "releases/DepartureReleaseRequest.h"
+
+namespace UKControllerPlugin::Releases {
+
+    ReleaseIsTargetedAtUser::ReleaseIsTargetedAtUser(
+        std::shared_ptr<const Controller::ActiveCallsignCollection> activeCallsigns)
+        : activeCallsigns(std::move(activeCallsigns))
+    {
+        assert(this->activeCallsigns && "activeCallsigns must not be null");
+    }
+
+    /**
+     * Check that the user has a callsign, and that the callsign has the same normalised controller position
+     * as the target of the release request.
+     */
+    bool ReleaseIsTargetedAtUser::IsRelevant(const DepartureReleaseRequest& releaseRequest) const
+    {
+        return activeCallsigns->UserHasCallsign() &&
+               activeCallsigns->GetUserCallsign().GetNormalisedPosition().GetId() == releaseRequest.TargetController();
+    }
+} // namespace UKControllerPlugin::Releases

--- a/src/plugin/releases/ReleaseIsTargetedAtUser.h
+++ b/src/plugin/releases/ReleaseIsTargetedAtUser.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "releases/DepartureReleaseRelevanceChecker.h"
+
+namespace UKControllerPlugin::Controller {
+    class ActiveCallsignCollection;
+} // namespace UKControllerPlugin::Controller
+
+namespace UKControllerPlugin::Releases {
+
+    class ReleaseIsTargetedAtUser : public DepartureReleaseRelevanceChecker
+    {
+        public:
+        explicit ReleaseIsTargetedAtUser(std::shared_ptr<const Controller::ActiveCallsignCollection> activeCallsigns);
+        [[nodiscard]] bool IsRelevant(const DepartureReleaseRequest& releaseRequest) const override;
+
+        private:
+        // The active callsigns
+        const std::shared_ptr<const Controller::ActiveCallsignCollection> activeCallsigns;
+    };
+
+} // namespace UKControllerPlugin::Releases

--- a/src/plugin/releases/ReleaseModule.cpp
+++ b/src/plugin/releases/ReleaseModule.cpp
@@ -2,11 +2,14 @@
 #include "CompareEnrouteReleaseTypes.h"
 #include "DepartureReleaseEventHandler.h"
 #include "DepartureReleaseRequestView.h"
+#include "DepartureReleaseRequestedEvent.h"
 #include "EnrouteReleaseEventHandler.h"
 #include "EnrouteReleaseTypesSerializer.h"
 #include "RejectDepartureReleaseDialog.h"
+#include "ReleaseIsTargetedAtUser.h"
 #include "ReleaseModule.h"
 #include "RequestDepartureReleaseDialog.h"
+#include "SendReleaseRequestedChatAreaMessage.h"
 #include "bootstrap/PersistenceContainer.h"
 #include "collection/Collection.h"
 #include "controller/HandoffEventHandlerCollection.h"
@@ -14,6 +17,8 @@
 #include "dialog/DialogManager.h"
 #include "euroscope/CallbackFunction.h"
 #include "euroscope/EuroscopePluginLoopbackInterface.h"
+#include "eventhandler/EventBus.h"
+#include "eventhandler/EventHandlerFlags.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "plugin/UKPlugin.h"
 #include "push/PushEventProcessorCollection.h"
@@ -229,6 +234,13 @@ namespace UKControllerPlugin::Releases {
 
         // Add to handlers
         container.timedHandler->RegisterEvent(departureHandler, departureReleaseEventFrequency);
+
+        // Event handlers for displaying chat area messages
+        auto releaseIsTargetedAtUser = std::make_shared<ReleaseIsTargetedAtUser>(container.activeCallsigns);
+        UKControllerPluginUtils::EventHandler::EventBus::Bus().AddHandler<DepartureReleaseRequestedEvent>(
+            std::make_shared<SendReleaseRequestedChatAreaMessage>(
+                releaseIsTargetedAtUser, *container.plugin, *container.pluginUserSettingHandler),
+            UKControllerPluginUtils::EventHandler::EventHandlerFlags::Sync);
     }
 
     void

--- a/src/plugin/releases/ReleaseModule.cpp
+++ b/src/plugin/releases/ReleaseModule.cpp
@@ -8,6 +8,7 @@
 #include "ReleaseModule.h"
 #include "RequestDepartureReleaseDialog.h"
 #include "bootstrap/PersistenceContainer.h"
+#include "collection/Collection.h"
 #include "controller/HandoffEventHandlerCollection.h"
 #include "dependency/DependencyLoaderInterface.h"
 #include "dialog/DialogManager.h"
@@ -113,7 +114,9 @@ namespace UKControllerPlugin::Releases {
         // Create the event handler
         const int releaseDecisionCallbackId = container.pluginFunctionHandlers->ReserveNextDynamicFunctionId();
         const int releaseCancellationCallbackId = container.pluginFunctionHandlers->ReserveNextDynamicFunctionId();
+        auto releaseCollection = std::make_shared<UKControllerPlugin::Releases::DepartureReleaseRequestCollection>();
         auto departureHandler = std::make_shared<DepartureReleaseEventHandler>(
+            releaseCollection,
             *container.api,
             *container.taskRunner,
             *container.plugin,

--- a/src/plugin/releases/SendReleaseRequestedChatAreaMessage.cpp
+++ b/src/plugin/releases/SendReleaseRequestedChatAreaMessage.cpp
@@ -1,0 +1,42 @@
+#include "DepartureReleaseRelevanceChecker.h"
+#include "DepartureReleaseRequest.h"
+#include "DepartureReleaseRequestedEvent.h"
+#include "SendReleaseRequestedChatAreaMessage.h"
+#include "euroscope/EuroscopePluginLoopbackInterface.h"
+#include "euroscope/GeneralSettingsEntries.h"
+#include "euroscope/UserSetting.h"
+
+namespace UKControllerPlugin::Releases {
+
+    SendReleaseRequestedChatAreaMessage::SendReleaseRequestedChatAreaMessage(
+        std::shared_ptr<const DepartureReleaseRelevanceChecker> relevanceChecker,
+        Euroscope::EuroscopePluginLoopbackInterface& plugin,
+        Euroscope::UserSetting& userSettings)
+        : relevanceChecker(std::move(relevanceChecker)), plugin(plugin), userSettings(userSettings)
+    {
+        assert(this->relevanceChecker && "relevanceChecker must not be null");
+    }
+
+    void SendReleaseRequestedChatAreaMessage::OnEvent(const DepartureReleaseRequestedEvent& event)
+    {
+        if (!this->relevanceChecker->IsRelevant(*event.releaseRequest)) {
+            LogDebug("Not sending release requested chat area message because it is not relevant");
+            return;
+        }
+
+        if (!userSettings.GetBooleanEntry(Euroscope::GeneralSettingsEntries::releaseChatAreaMessagesSettingsKey)) {
+            LogDebug("Not sending release requested chat area message because user does not want chat area messages");
+            return;
+        }
+
+        plugin.ChatAreaMessage(
+            "UKCP_COORDINATION",
+            "UKCP",
+            "Departure release requested for " + event.releaseRequest->Callsign() + ".",
+            true,
+            true,
+            true,
+            true,
+            true);
+    }
+} // namespace UKControllerPlugin::Releases

--- a/src/plugin/releases/SendReleaseRequestedChatAreaMessage.h
+++ b/src/plugin/releases/SendReleaseRequestedChatAreaMessage.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "eventhandler/EventHandler.h"
+
+namespace UKControllerPlugin::Euroscope {
+    class EuroscopePluginLoopbackInterface;
+    class UserSetting;
+} // namespace UKControllerPlugin::Euroscope
+
+namespace UKControllerPlugin::Releases {
+
+    class DepartureReleaseRelevanceChecker;
+    struct DepartureReleaseRequestedEvent;
+
+    class SendReleaseRequestedChatAreaMessage
+        : public UKControllerPluginUtils::EventHandler::EventHandler<DepartureReleaseRequestedEvent>
+    {
+        public:
+        SendReleaseRequestedChatAreaMessage(
+            std::shared_ptr<const DepartureReleaseRelevanceChecker> relevanceChecker,
+            Euroscope::EuroscopePluginLoopbackInterface& plugin,
+            Euroscope::UserSetting& userSettings);
+        void OnEvent(const DepartureReleaseRequestedEvent& event) override;
+
+        private:
+        // Checks prenote relevance
+        const std::shared_ptr<const DepartureReleaseRelevanceChecker> relevanceChecker;
+
+        // For sending messages
+        Euroscope::EuroscopePluginLoopbackInterface& plugin;
+
+        // For checking user settings
+        Euroscope::UserSetting& userSettings;
+    };
+
+} // namespace UKControllerPlugin::Releases

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -69,7 +69,7 @@ source_group("api" FILES ${api})
 
 set(collection
         collection/Collection.h
-        collection/Collection.tpp)
+        collection/Collection.tpp collection/CollectionIterator.h collection/CollectionIterator.tpp)
 source_group("src\\collection" FILES ${collection})
 
 set(curl

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -67,6 +67,11 @@ set(api
     api/ApiKeyRedirectUrlBuilder.cpp api/ApiKeyRedirectUrlBuilder.h)
 source_group("api" FILES ${api})
 
+set(collection
+        collection/Collection.h
+        collection/Collection.tpp)
+source_group("src\\collection" FILES ${collection})
+
 set(curl
     "curl/CurlApi.cpp"
     "curl/CurlApi.h"
@@ -185,6 +190,7 @@ source_group("windows" FILES ${windows})
 
 set(ALL_FILES
     ${api}
+    ${collection}
     ${curl}
     ${data}
     ${dialog}

--- a/src/utils/collection/Collection.h
+++ b/src/utils/collection/Collection.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace UKControllerPluginUtils::Collection {
+    template <typename KeyType, typename ValueType> class Collection
+    {
+        public:
+        void Add(std::shared_ptr<ValueType> item);
+        [[nodiscard]] auto Get(const KeyType& key) const -> std::shared_ptr<ValueType>;
+        [[nodiscard]] auto Get(const std::shared_ptr<ValueType>& item) const -> std::shared_ptr<ValueType>;
+        [[nodiscard]] auto Contains(const KeyType& key) const -> bool;
+        [[nodiscard]] auto Contains(const std::shared_ptr<ValueType>& item) const -> bool;
+        [[nodiscard]] auto Count() const -> size_t;
+        void RemoveByKey(const KeyType& key);
+        void Remove(const std::shared_ptr<ValueType>& item);
+
+        private:
+        [[nodiscard]] auto GetLock() const -> std::lock_guard<std::mutex>
+        {
+            return std::lock_guard(this->mutex);
+        }
+
+        std::map<KeyType, std::shared_ptr<ValueType>> items;
+
+        mutable std::mutex mutex;
+    };
+} // namespace UKControllerPluginUtils::Collection
+
+#include "Collection.tpp"

--- a/src/utils/collection/Collection.h
+++ b/src/utils/collection/Collection.h
@@ -1,10 +1,13 @@
 #pragma once
+#include "CollectionIterator.h"
 
 namespace UKControllerPluginUtils::Collection {
     template <typename KeyType, typename ValueType> class Collection
     {
         public:
         void Add(std::shared_ptr<ValueType> item);
+        [[nodiscard]] auto FirstOrDefault(const std::function<bool(const std::shared_ptr<ValueType>&)>& predicate) const
+            -> const std::shared_ptr<ValueType>;
         [[nodiscard]] auto Get(const KeyType& key) const -> std::shared_ptr<ValueType>;
         [[nodiscard]] auto Get(const std::shared_ptr<ValueType>& item) const -> std::shared_ptr<ValueType>;
         [[nodiscard]] auto Contains(const KeyType& key) const -> bool;
@@ -12,16 +15,41 @@ namespace UKControllerPluginUtils::Collection {
         [[nodiscard]] auto Count() const -> size_t;
         void RemoveByKey(const KeyType& key);
         void Remove(const std::shared_ptr<ValueType>& item);
+        void RemoveWhere(const std::function<bool(const std::shared_ptr<ValueType>&)>& predicate);
+
+        /*
+         * Iterators
+         */
+        [[nodiscard]] auto begin()
+            -> CollectionIterator<KeyType, ValueType, typename std::map<KeyType, std::shared_ptr<ValueType>>::iterator>;
+        [[nodiscard]] auto end()
+            -> CollectionIterator<KeyType, ValueType, typename std::map<KeyType, std::shared_ptr<ValueType>>::iterator>;
+        [[nodiscard]] auto cbegin() const -> CollectionIterator<
+            KeyType,
+            ValueType,
+            typename std::map<KeyType, std::shared_ptr<ValueType>>::const_iterator>;
+        [[nodiscard]] auto cend() const -> CollectionIterator<
+            KeyType,
+            ValueType,
+            typename std::map<KeyType, std::shared_ptr<ValueType>>::const_iterator>;
+        [[nodiscard]] auto rbegin() -> CollectionIterator<
+            KeyType,
+            ValueType,
+            typename std::map<KeyType, std::shared_ptr<ValueType>>::reverse_iterator>;
+        [[nodiscard]] auto rend() -> CollectionIterator<
+            KeyType,
+            ValueType,
+            typename std::map<KeyType, std::shared_ptr<ValueType>>::reverse_iterator>;
 
         private:
-        [[nodiscard]] auto GetLock() const -> std::lock_guard<std::mutex>
+        [[nodiscard]] auto GetLock() const -> std::lock_guard<std::recursive_mutex>
         {
             return std::lock_guard(this->mutex);
         }
 
         std::map<KeyType, std::shared_ptr<ValueType>> items;
 
-        mutable std::mutex mutex;
+        mutable std::recursive_mutex mutex;
     };
 } // namespace UKControllerPluginUtils::Collection
 

--- a/src/utils/collection/Collection.tpp
+++ b/src/utils/collection/Collection.tpp
@@ -1,0 +1,68 @@
+namespace UKControllerPluginUtils::Collection {
+    template <typename KeyType, typename ValueType>
+    void Collection<KeyType, ValueType>::Add(std::shared_ptr<ValueType> item)
+    {
+        const auto lock = this->GetLock();
+
+        if (this->items.contains(item->CollectionKey())) {
+            return;
+        }
+
+        this->items[item->CollectionKey()] = item;
+    }
+
+    template <typename KeyType, typename ValueType>
+    auto Collection<KeyType, ValueType>::Get(const KeyType& key) const -> std::shared_ptr<ValueType>
+    {
+        const auto lock = this->GetLock();
+        if (!this->items.contains(key)) {
+            return nullptr;
+        }
+
+        return this->items.at(key);
+    }
+
+    template <typename KeyType, typename ValueType>
+    auto Collection<KeyType, ValueType>::Get(const std::shared_ptr<ValueType>& item) const -> std::shared_ptr<ValueType>
+    {
+        // No need to lock here, as Get() is already thread-safe.
+        return this->Get(item->CollectionKey());
+    }
+
+    template <typename KeyType, typename ValueType>
+    auto Collection<KeyType, ValueType>::Contains(const KeyType& key) const -> bool
+    {
+        const auto lock = this->GetLock();
+        return this->items.contains(key);
+    }
+
+    template <typename KeyType, typename ValueType>
+    auto Collection<KeyType, ValueType>::Contains(const std::shared_ptr<ValueType>& item) const -> bool
+    {
+        // No need to lock here, as Contains() is already thread-safe.
+        return this->Contains(item->CollectionKey());
+    }
+
+    template <typename KeyType, typename ValueType> auto Collection<KeyType, ValueType>::Count() const -> size_t
+    {
+        const auto lock = this->GetLock();
+        return this->items.size();
+    }
+
+    template <typename KeyType, typename ValueType> void Collection<KeyType, ValueType>::RemoveByKey(const KeyType& key)
+    {
+        const auto lock = this->GetLock();
+        this->items.erase(key);
+    }
+
+    template <typename KeyType, typename ValueType>
+    void Collection<KeyType, ValueType>::Remove(const std::shared_ptr<ValueType>& item)
+    {
+        if (item == nullptr) {
+            return;
+        }
+
+        // No need to lock here, as RemoveByKey() is already thread-safe.
+        this->RemoveByKey(item->CollectionKey());
+    }
+} // namespace UKControllerPluginUtils::Collection

--- a/src/utils/collection/CollectionIterator.h
+++ b/src/utils/collection/CollectionIterator.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace UKControllerPluginUtils::Collection {
+    template <typename KeyType, typename ValueType, typename IteratorType> class CollectionIterator
+    {
+        public:
+        CollectionIterator(std::recursive_mutex& lockingMutex, IteratorType current);
+        CollectionIterator(const CollectionIterator& old);
+        ~CollectionIterator();
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = ValueType;
+        using pointer = ValueType*;   // or also value_type*
+        using reference = ValueType&; // or also value_type&
+
+        auto operator*() const -> ValueType&;
+        auto operator->() const -> ValueType*;
+        auto operator++() -> CollectionIterator<KeyType, ValueType, IteratorType>&;
+        auto operator++(int) -> CollectionIterator<KeyType, ValueType, IteratorType>;
+        auto operator==(const CollectionIterator<KeyType, ValueType, IteratorType>& compare) const -> bool;
+        auto operator!=(const CollectionIterator<KeyType, ValueType, IteratorType>& compare) const -> bool;
+
+        private:
+        std::unique_lock<std::recursive_mutex> lock;
+
+        // The current iterator position
+        IteratorType current;
+    };
+} // namespace UKControllerPluginUtils::Collection
+
+#include "CollectionIterator.tpp"

--- a/src/utils/collection/CollectionIterator.tpp
+++ b/src/utils/collection/CollectionIterator.tpp
@@ -1,0 +1,63 @@
+namespace UKControllerPluginUtils::Collection {
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    CollectionIterator<KeyType, ValueType, IteratorType>::CollectionIterator(
+        std::recursive_mutex& lockingMutex, IteratorType current)
+    {
+        this->lock = std::unique_lock(lockingMutex);
+        this->current = std::move(current);
+    }
+
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    CollectionIterator<KeyType, ValueType, IteratorType>::CollectionIterator(const CollectionIterator& old)
+    {
+        this->lock = std::unique_lock(*old.lock.mutex());
+        this->current = old.current;
+    }
+
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    CollectionIterator<KeyType, ValueType, IteratorType>::~CollectionIterator() = default;
+
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    auto CollectionIterator<KeyType, ValueType, IteratorType>::operator*() const -> ValueType&
+    {
+        return *current->second;
+    }
+
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    auto CollectionIterator<KeyType, ValueType, IteratorType>::operator->() const -> ValueType*
+    {
+        return current->second.get();
+    }
+
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    auto CollectionIterator<KeyType, ValueType, IteratorType>::operator++()
+        -> CollectionIterator<KeyType, ValueType, IteratorType>&
+    {
+        current++;
+        return *this;
+    }
+
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    auto CollectionIterator<KeyType, ValueType, IteratorType>::operator++(int)
+        -> CollectionIterator<KeyType, ValueType, IteratorType>
+    {
+        CollectionIterator<KeyType, ValueType, IteratorType> temp = *this;
+        ++(*this);
+
+        return temp;
+    }
+
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    auto CollectionIterator<KeyType, ValueType, IteratorType>::operator==(
+        const CollectionIterator<KeyType, ValueType, IteratorType>& compare) const -> bool
+    {
+        return compare.current == current;
+    }
+
+    template <typename KeyType, typename ValueType, typename IteratorType>
+    auto CollectionIterator<KeyType, ValueType, IteratorType>::operator!=(
+        const CollectionIterator<KeyType, ValueType, IteratorType>& compare) const -> bool
+    {
+        return compare.current != current;
+    }
+} // namespace UKControllerPluginUtils::Collection

--- a/src/utils/pch/pch.h
+++ b/src/utils/pch/pch.h
@@ -26,6 +26,7 @@
 #include <codecvt>
 #include <deque>
 #include <Mmsystem.h>
+#include <iterator>
 #include <filesystem>
 #include <fstream>
 #include <memory>

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -508,7 +508,7 @@ set(test__releases
     "releases/EnrouteReleaseTypesSerializerTest.cpp"
     "releases/ReleaseModuleTest.cpp"
     releases/ReleaseApprovalRemarksUserMessageTest.cpp
-    releases/ReleaseRejectionRemarksUserMessageTest.cpp)
+    releases/ReleaseRejectionRemarksUserMessageTest.cpp releases/ReleaseIsTargetedAtUserTest.cpp releases/SendReleaseRequestedChatAreaMessageTest.cpp)
 source_group("test\\releases" FILES ${test__releases})
 
 set(test__runway

--- a/test/plugin/departure/DepartureCoordinationListTest.cpp
+++ b/test/plugin/departure/DepartureCoordinationListTest.cpp
@@ -1,3 +1,4 @@
+#include "collection/Collection.h"
 #include "controller/ActiveCallsignCollection.h"
 #include "controller/ControllerPosition.h"
 #include "controller/ControllerPositionCollection.h"
@@ -24,6 +25,7 @@ namespace UKControllerPluginTest::Departure {
               list(std::make_shared<DepartureCoordinationList>(
                   handler, prenotes, mockPlugin, controllers, activeCallsigns, 3)),
               handler(
+                  std::make_shared<UKControllerPlugin::Releases::DepartureReleaseRequestCollection>(),
                   mockApi,
                   taskRunner,
                   mockPlugin,

--- a/test/plugin/departure/ToggleDepartureCoordinationListTest.cpp
+++ b/test/plugin/departure/ToggleDepartureCoordinationListTest.cpp
@@ -1,3 +1,4 @@
+#include "collection/Collection.h"
 #include "controller/ActiveCallsignCollection.h"
 #include "controller/ControllerPositionCollection.h"
 #include "departure/DepartureCoordinationList.h"
@@ -19,17 +20,19 @@ namespace UKControllerPluginTest::Departure {
     {
         public:
         ToggleDepartureCoordinationListTest()
-            : messager(mockPlugin), handler(
-                                        mockApi,
-                                        taskRunner,
-                                        mockPlugin,
-                                        controllers,
-                                        activeCallsigns,
-                                        dialogManager,
-                                        windows,
-                                        messager,
-                                        103,
-                                        104),
+            : messager(mockPlugin),
+              handler(
+                  std::make_shared<UKControllerPlugin::Releases::DepartureReleaseRequestCollection>(),
+                  mockApi,
+                  taskRunner,
+                  mockPlugin,
+                  controllers,
+                  activeCallsigns,
+                  dialogManager,
+                  windows,
+                  messager,
+                  103,
+                  104),
               list(std::make_shared<DepartureCoordinationList>(
                   handler, prenotes, mockPlugin, controllers, activeCallsigns, 3)),
               dialogManager(dialogProvider)

--- a/test/plugin/releases/DepartureReleaseEventHandlerTest.cpp
+++ b/test/plugin/releases/DepartureReleaseEventHandlerTest.cpp
@@ -8,10 +8,12 @@
 #include "releases/DepartureReleaseColours.h"
 #include "releases/DepartureReleaseEventHandler.h"
 #include "releases/DepartureReleaseRequest.h"
+#include "releases/DepartureReleaseRequestedEvent.h"
 #include "releases/DepartureReleaseRequestView.h"
 #include "time/ParseTimeStrings.h"
 #include "time/SystemClock.h"
 #include "tag/TagData.h"
+#include "test/EventBusTestCase.h"
 
 using testing::_;
 using testing::NiceMock;
@@ -30,7 +32,7 @@ using UKControllerPlugin::Time::TimeNow;
 
 namespace UKControllerPluginTest::Releases {
 
-    class DepartureReleaseEventHandlerTest : public Test
+    class DepartureReleaseEventHandlerTest : public UKControllerPluginUtilsTest::EventBusTestCase
     {
         public:
         DepartureReleaseEventHandlerTest()
@@ -778,6 +780,10 @@ namespace UKControllerPluginTest::Releases {
         EXPECT_EQ(2, release->RequestingController());
         EXPECT_EQ(3, release->TargetController());
         EXPECT_EQ(ParseTimeString("2021-05-12 19:55:00"), release->RequestExpiryTime());
+
+        AssertSingleEventDispatched();
+        AssertFirstEventDispatched<UKControllerPlugin::Releases::DepartureReleaseRequestedEvent>(
+            [release](const auto& event) { EXPECT_EQ(release, event.releaseRequest); });
     }
 
     TEST_F(DepartureReleaseEventHandlerTest, ItDoesntPlaySoundOnRequestIfUserNotActive)

--- a/test/plugin/releases/DepartureReleaseEventHandlerTest.cpp
+++ b/test/plugin/releases/DepartureReleaseEventHandlerTest.cpp
@@ -1,4 +1,5 @@
 #include "api/ApiException.h"
+#include "collection/Collection.h"
 #include "controller/ActiveCallsignCollection.h"
 #include "controller/ControllerPosition.h"
 #include "controller/ControllerPositionCollection.h"
@@ -35,7 +36,17 @@ namespace UKControllerPluginTest::Releases {
         DepartureReleaseEventHandlerTest()
             : dialogManager(dialogProvider), messager(mockPlugin),
               handler(
-                  api, mockTaskRunner, mockPlugin, controllers, activeCallsigns, dialogManager, windows, messager, 3, 4)
+                  std::make_shared<UKControllerPlugin::Releases::DepartureReleaseRequestCollection>(),
+                  api,
+                  mockTaskRunner,
+                  mockPlugin,
+                  controllers,
+                  activeCallsigns,
+                  dialogManager,
+                  windows,
+                  messager,
+                  3,
+                  4)
         {
             request = std::make_shared<DepartureReleaseRequest>(
                 1, "BAW123", 3, 2, std::chrono::system_clock::now() + std::chrono::minutes(5));

--- a/test/plugin/releases/DepartureReleaseRequestTest.cpp
+++ b/test/plugin/releases/DepartureReleaseRequestTest.cpp
@@ -26,6 +26,11 @@ namespace UKControllerPluginTes::Releases {
         EXPECT_EQ(1, request->Id());
     }
 
+    TEST_F(DepartureReleaseRequestTest, ItUsesIdAsCollectionKey)
+    {
+        EXPECT_EQ(1, request->CollectionKey());
+    }
+
     TEST_F(DepartureReleaseRequestTest, ItHasACallsign)
     {
         EXPECT_EQ("BAW123", request->Callsign());

--- a/test/plugin/releases/ReleaseIsTargetedAtUserTest.cpp
+++ b/test/plugin/releases/ReleaseIsTargetedAtUserTest.cpp
@@ -1,0 +1,54 @@
+#include "controller/ActiveCallsign.h"
+#include "controller/ActiveCallsignCollection.h"
+#include "controller/ControllerPosition.h"
+#include "releases/DepartureReleaseRequest.h"
+#include "releases/ReleaseIsTargetedAtUser.h"
+
+namespace UKControllerPluginTest::Releases {
+    class ReleaseIsTargetedAtUserTest : public ::testing::Test
+    {
+        protected:
+        ReleaseIsTargetedAtUserTest()
+            : position1(std::make_shared<UKControllerPlugin::Controller::ControllerPosition>(
+                  1, "EGGD_APP", 125.650, std::vector<std::string>{}, true, true)),
+              position2(std::make_shared<UKControllerPlugin::Controller::ControllerPosition>(
+                  2, "EGGD_TWR", 133.850, std::vector<std::string>{}, true, true)),
+              userCallsign("EGGD_APP", "EGGD_APP", *position1, true),
+              nonUserCallsign("EGGD_TWR", "EGGD_TWR", *position2, false),
+              callsignCollection(std::make_shared<UKControllerPlugin::Controller::ActiveCallsignCollection>()),
+              releaseIsTargetedAtUser(callsignCollection)
+        {
+            callsignCollection->AddCallsign(nonUserCallsign);
+        }
+
+        std::shared_ptr<UKControllerPlugin::Controller::ControllerPosition> position1;
+        std::shared_ptr<UKControllerPlugin::Controller::ControllerPosition> position2;
+        UKControllerPlugin::Controller::ActiveCallsign userCallsign;
+        UKControllerPlugin::Controller::ActiveCallsign nonUserCallsign;
+        std::shared_ptr<UKControllerPlugin::Controller::ActiveCallsignCollection> callsignCollection;
+        UKControllerPlugin::Releases::ReleaseIsTargetedAtUser releaseIsTargetedAtUser;
+    };
+
+    TEST_F(ReleaseIsTargetedAtUserTest, IsRelevantReturnsTrueWhenCallsignIsUser)
+    {
+        callsignCollection->AddUserCallsign(userCallsign);
+        UKControllerPlugin::Releases::DepartureReleaseRequest releaseRequest(
+            1, "BAW555", 99, 1, std::chrono::system_clock::now());
+        EXPECT_TRUE(releaseIsTargetedAtUser.IsRelevant(releaseRequest));
+    }
+
+    TEST_F(ReleaseIsTargetedAtUserTest, IsRelevantReturnsFalseWhenCallsignIsNotUser)
+    {
+        callsignCollection->AddUserCallsign(userCallsign);
+        UKControllerPlugin::Releases::DepartureReleaseRequest releaseRequest(
+            1, "BAW555", 99, 2, std::chrono::system_clock::now());
+        EXPECT_FALSE(releaseIsTargetedAtUser.IsRelevant(releaseRequest));
+    }
+
+    TEST_F(ReleaseIsTargetedAtUserTest, IsRelevantReturnsFalseWhenUserCallsignIsNotInCollection)
+    {
+        UKControllerPlugin::Releases::DepartureReleaseRequest releaseRequest(
+            1, "BAW555", 99, 1, std::chrono::system_clock::now());
+        EXPECT_FALSE(releaseIsTargetedAtUser.IsRelevant(releaseRequest));
+    }
+} // namespace UKControllerPluginTest::Releases

--- a/test/plugin/releases/SendReleaseRequestedChatAreaMessageTest.cpp
+++ b/test/plugin/releases/SendReleaseRequestedChatAreaMessageTest.cpp
@@ -1,0 +1,88 @@
+#include "mock/MockEuroscopePluginLoopbackInterface.h"
+#include "mock/MockPluginSettingsProvider.h"
+#include "mock/MockUserSettingProviderInterface.h"
+#include "releases/DepartureReleaseRequestedEvent.h"
+#include "releases/DepartureReleaseRequest.h"
+#include "releases/DepartureReleaseRelevanceChecker.h"
+#include "releases/SendReleaseRequestedChatAreaMessage.h"
+#include "euroscope/UserSetting.h"
+
+namespace UKControllerPluginTest::Releases {
+
+    class MockUserRelevanceChecker : public UKControllerPlugin::Releases::DepartureReleaseRelevanceChecker
+    {
+        public:
+        MOCK_METHOD(
+            bool, IsRelevant, (const UKControllerPlugin::Releases::DepartureReleaseRequest&), (const, override));
+    };
+
+    class SendReleaseRequestedChatAreaMessageTest : public ::testing::Test
+    {
+        public:
+        SendReleaseRequestedChatAreaMessageTest()
+            : releaseRequest(std::make_shared<UKControllerPlugin::Releases::DepartureReleaseRequest>(
+                  1, "BAW555", 99, 1, std::chrono::system_clock::now())),
+              userSettings(userSettingProvider), sendMessage(relevanceChecker, plugin, userSettings)
+        {
+        }
+
+        std::shared_ptr<UKControllerPlugin::Releases::DepartureReleaseRequest> releaseRequest;
+        testing::NiceMock<Euroscope::MockEuroscopePluginLoopbackInterface> plugin;
+        testing::NiceMock<Euroscope::MockUserSettingProviderInterface> userSettingProvider;
+        std::shared_ptr<testing::NiceMock<MockUserRelevanceChecker>> relevanceChecker =
+            std::make_shared<testing::NiceMock<MockUserRelevanceChecker>>();
+        UKControllerPlugin::Euroscope::UserSetting userSettings;
+        UKControllerPlugin::Releases::SendReleaseRequestedChatAreaMessage sendMessage;
+    };
+
+    TEST_F(SendReleaseRequestedChatAreaMessageTest, DoesNotSendMessageIfNotRelevant)
+    {
+        UKControllerPlugin::Releases::DepartureReleaseRequestedEvent event{releaseRequest};
+
+        ON_CALL(userSettingProvider, KeyExists("sendReleasesToChat")).WillByDefault(testing::Return(true));
+        ON_CALL(userSettingProvider, GetKey("sendReleasesToChat")).WillByDefault(testing::Return("1"));
+        EXPECT_CALL(*relevanceChecker, IsRelevant(testing::Ref(*releaseRequest))).WillOnce(testing::Return(false));
+        EXPECT_CALL(plugin, ChatAreaMessage).Times(0);
+
+        sendMessage.OnEvent(event);
+    }
+
+    TEST_F(SendReleaseRequestedChatAreaMessageTest, DoesNotSendMessageIfSettingNotEnabled)
+    {
+        UKControllerPlugin::Releases::DepartureReleaseRequestedEvent event{releaseRequest};
+
+        ON_CALL(userSettingProvider, KeyExists("sendReleasesToChat")).WillByDefault(testing::Return(false));
+        EXPECT_CALL(*relevanceChecker, IsRelevant(testing::Ref(*releaseRequest))).WillOnce(testing::Return(true));
+        EXPECT_CALL(plugin, ChatAreaMessage).Times(0);
+
+        sendMessage.OnEvent(event);
+    }
+
+    TEST_F(SendReleaseRequestedChatAreaMessageTest, DoesNotSendMessageIfSettingDisabled)
+    {
+        UKControllerPlugin::Releases::DepartureReleaseRequestedEvent event{releaseRequest};
+
+        ON_CALL(userSettingProvider, KeyExists("sendReleasesToChat")).WillByDefault(testing::Return(true));
+        ON_CALL(userSettingProvider, GetKey("sendReleasesToChat")).WillByDefault(testing::Return("0"));
+        EXPECT_CALL(*relevanceChecker, IsRelevant(testing::Ref(*releaseRequest))).WillOnce(testing::Return(true));
+        EXPECT_CALL(plugin, ChatAreaMessage).Times(0);
+
+        sendMessage.OnEvent(event);
+    }
+
+    TEST_F(SendReleaseRequestedChatAreaMessageTest, SendsMessageIfRelevantAndSettingEnabled)
+    {
+        UKControllerPlugin::Releases::DepartureReleaseRequestedEvent event{releaseRequest};
+
+        ON_CALL(userSettingProvider, KeyExists("sendReleasesToChat")).WillByDefault(testing::Return(true));
+        ON_CALL(userSettingProvider, GetKey("sendReleasesToChat")).WillByDefault(testing::Return("1"));
+        EXPECT_CALL(*relevanceChecker, IsRelevant(testing::Ref(*releaseRequest))).WillOnce(testing::Return(true));
+        EXPECT_CALL(
+            plugin,
+            ChatAreaMessage(
+                "UKCP_COORDINATION", "UKCP", "Departure release requested for BAW555.", true, true, true, true, true))
+            .Times(1);
+
+        sendMessage.OnEvent(event);
+    }
+} // namespace UKControllerPluginTest::Releases

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -25,6 +25,11 @@ set(test__api
     api/ResponseTest.cpp api/ApiConfigurationListenerTest.cpp api/SetApiKeyInConfigTest.cpp api/SetApiKeyInSettingsTest.cpp api/ApiKeyRedirectUrlBuilderTest.cpp)
 source_group("test\\api" FILES ${test__api})
 
+set(test__collection
+        
+        collection/CollectionTest.cpp)
+source_group("test\\collection" FILES ${test__collection})
+
 set(test__curl
     "curl/CurlRequestTest.cpp"
     "curl/CurlResponseTest.cpp"
@@ -100,6 +105,7 @@ source_group("test\\update" FILES ${test__update})
 
 set(ALL_FILES
     ${test__api}
+    ${test__collection}
     ${test__curl}
     ${test__data}
     ${test__dialog}

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -27,7 +27,7 @@ source_group("test\\api" FILES ${test__api})
 
 set(test__collection
         
-        collection/CollectionTest.cpp)
+        collection/CollectionTest.cpp collection/CollectionIteratorTest.cpp)
 source_group("test\\collection" FILES ${test__collection})
 
 set(test__curl

--- a/test/utils/collection/CollectionIteratorTest.cpp
+++ b/test/utils/collection/CollectionIteratorTest.cpp
@@ -1,0 +1,99 @@
+#include "collection/CollectionIterator.h"
+
+namespace UKControllerPluginUtilsTest::Collection {
+    class CollectionIteratorTest : public testing::Test
+    {
+        public:
+        CollectionIteratorTest()
+            : item1(std::make_shared<std::string>("item1")), item2(std::make_shared<std::string>("item2")),
+              item3(std::make_shared<std::string>("item3")), map({{1, item1}, {2, item2}, {3, item3}})
+        {
+        }
+
+        [[nodiscard]] auto GetIterator() -> UKControllerPluginUtils::Collection::
+            CollectionIterator<int, std::string, std::map<int, std::shared_ptr<std::string>>::const_iterator>
+        {
+            return UKControllerPluginUtils::Collection::
+                CollectionIterator<int, std::string, std::map<int, std::shared_ptr<std::string>>::const_iterator>(
+                    mutex, map.cbegin());
+        }
+
+        std::shared_ptr<std::string> item1;
+        std::shared_ptr<std::string> item2;
+        std::shared_ptr<std::string> item3;
+        std::recursive_mutex mutex;
+        std::map<int, std::shared_ptr<std::string>> map;
+    };
+
+    TEST_F(CollectionIteratorTest, ItReturnsTheCurrentValue)
+    {
+        EXPECT_EQ("item1", *GetIterator());
+    }
+
+    TEST_F(CollectionIteratorTest, ItHasPointerOperator)
+    {
+        EXPECT_EQ("item1", std::string(GetIterator()->c_str()));
+    }
+
+    TEST_F(CollectionIteratorTest, ItHasPostfixIncrement)
+    {
+        auto iterator = GetIterator();
+
+        EXPECT_EQ("item1", *(iterator++));
+        EXPECT_EQ("item2", *(iterator));
+    }
+
+    TEST_F(CollectionIteratorTest, ItHasPrefixIncrement)
+    {
+        auto iterator = GetIterator();
+
+        EXPECT_EQ("item2", *(++iterator));
+        EXPECT_EQ("item2", *(iterator));
+    }
+
+    TEST_F(CollectionIteratorTest, ItHasEquality)
+    {
+        std::recursive_mutex otherMutex;
+        auto iterator = GetIterator();
+        auto iterator2 = UKControllerPluginUtils::Collection::
+            CollectionIterator<int, std::string, std::map<int, std::shared_ptr<std::string>>::const_iterator>(
+                otherMutex, map.cbegin());
+
+        EXPECT_TRUE(iterator == iterator2);
+    }
+
+    TEST_F(CollectionIteratorTest, ItDoesntHaveEquality)
+    {
+        std::recursive_mutex otherMutex;
+        auto iterator = GetIterator();
+        iterator++;
+        auto iterator2 = UKControllerPluginUtils::Collection::
+            CollectionIterator<int, std::string, std::map<int, std::shared_ptr<std::string>>::const_iterator>(
+                otherMutex, map.cbegin());
+
+        EXPECT_FALSE(iterator == iterator2);
+    }
+
+    TEST_F(CollectionIteratorTest, ItHasInequality)
+    {
+        std::recursive_mutex otherMutex;
+        auto iterator = GetIterator();
+        auto iterator2 = UKControllerPluginUtils::Collection::
+            CollectionIterator<int, std::string, std::map<int, std::shared_ptr<std::string>>::const_iterator>(
+                otherMutex, map.cbegin());
+        iterator++;
+
+        EXPECT_TRUE(iterator != iterator2);
+    }
+
+    TEST_F(CollectionIteratorTest, ItDoesntHaveInequality)
+    {
+        std::recursive_mutex otherMutex;
+        auto iterator = GetIterator();
+        auto iterator2 = UKControllerPluginUtils::Collection::
+            CollectionIterator<int, std::string, std::map<int, std::shared_ptr<std::string>>::const_iterator>(
+                otherMutex, map.cbegin());
+
+        EXPECT_FALSE(iterator != iterator2);
+    }
+} // namespace UKControllerPluginUtilsTest::Collection

--- a/test/utils/collection/CollectionTest.cpp
+++ b/test/utils/collection/CollectionTest.cpp
@@ -37,6 +37,24 @@ namespace UKControllerPluginUtilsTest::Collection {
         EXPECT_EQ(1, collection.Count());
     }
 
+    TEST_F(CollectionTest, ItFindsFirstItem)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        auto item2 = std::make_shared<MockCollectionValue>(2);
+        collection.Add(item);
+        collection.Add(item2);
+        EXPECT_EQ(item2, collection.FirstOrDefault([](const auto& item) { return item->CollectionKey() == 2; }));
+    }
+
+    TEST_F(CollectionTest, ItReturnsNullptrIfNoItemFound)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        auto item2 = std::make_shared<MockCollectionValue>(2);
+        collection.Add(item);
+        collection.Add(item2);
+        EXPECT_EQ(nullptr, collection.FirstOrDefault([](const auto& item) { return item->CollectionKey() == 3; }));
+    }
+
     TEST_F(CollectionTest, ItGetsItemsByKey)
     {
         auto item = std::make_shared<MockCollectionValue>(1);
@@ -137,5 +155,117 @@ namespace UKControllerPluginUtilsTest::Collection {
         collection.Add(item);
         collection.Remove(nullptr);
         EXPECT_EQ(1, collection.Count());
+    }
+
+    TEST_F(CollectionTest, ItRemovesItemsMatchingPredicate)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        auto item2 = std::make_shared<MockCollectionValue>(2);
+        collection.Add(item);
+        collection.Add(item2);
+        collection.RemoveWhere([](const auto& item) { return item->CollectionKey() == 2; });
+        EXPECT_EQ(1, collection.Count());
+        EXPECT_EQ(item, collection.Get(1));
+        EXPECT_EQ(nullptr, collection.Get(2));
+    }
+
+    TEST_F(CollectionTest, ItDoesNotRemoveItemsMatchingPredicateIfNone)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        auto item2 = std::make_shared<MockCollectionValue>(2);
+        collection.Add(item);
+        collection.Add(item2);
+        collection.RemoveWhere([](const auto& item) { return item->CollectionKey() == 3; });
+        EXPECT_EQ(2, collection.Count());
+        EXPECT_EQ(item, collection.Get(1));
+        EXPECT_EQ(item2, collection.Get(2));
+    }
+
+    TEST_F(CollectionTest, ItReturnsABeginIterator)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(1, (*collection.begin()).id);
+    }
+
+    TEST_F(CollectionTest, ItCanBeIterated)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        auto item2 = std::make_shared<MockCollectionValue>(2);
+        collection.Add(item);
+        collection.Add(item2);
+        std::vector<MockCollectionValue> items;
+        for (const auto& item : collection) {
+            items.push_back(item);
+        }
+        EXPECT_EQ(2, items.size());
+        EXPECT_EQ(1, items[0].id);
+        EXPECT_EQ(2, items[1].id);
+    }
+
+    TEST_F(CollectionTest, ItReturnsAnEndIterator)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(collection.end(), ++collection.begin());
+    }
+
+    TEST_F(CollectionTest, ItReturnsAConstBeginIterator)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(1, (*collection.cbegin()).id);
+    }
+
+    TEST_F(CollectionTest, ItCanBeIteratedWithConstIterator)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        auto item2 = std::make_shared<MockCollectionValue>(2);
+        collection.Add(item);
+        collection.Add(item2);
+        std::vector<MockCollectionValue> items;
+        for (const auto& item : collection) {
+            items.push_back(item);
+        }
+        EXPECT_EQ(2, items.size());
+        EXPECT_EQ(1, items[0].id);
+        EXPECT_EQ(2, items[1].id);
+    }
+
+    TEST_F(CollectionTest, ItReturnsAConstEndIterator)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(collection.cend(), ++collection.cbegin());
+    }
+
+    TEST_F(CollectionTest, ItReturnsAReverseBeginIterator)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(1, (*collection.rbegin()).id);
+    }
+
+    TEST_F(CollectionTest, ItCanBeReverseIterated)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        auto item2 = std::make_shared<MockCollectionValue>(2);
+        collection.Add(item);
+        collection.Add(item2);
+        std::vector<MockCollectionValue> items;
+        for (auto it = collection.rbegin(); it != collection.rend(); ++it) {
+            items.push_back(*it);
+        }
+
+        EXPECT_EQ(2, items.size());
+        EXPECT_EQ(2, items[0].id);
+        EXPECT_EQ(1, items[1].id);
+    }
+
+    TEST_F(CollectionTest, ItReturnsAReverseEndIterator)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(collection.rend(), ++collection.rbegin());
     }
 } // namespace UKControllerPluginUtilsTest::Collection

--- a/test/utils/collection/CollectionTest.cpp
+++ b/test/utils/collection/CollectionTest.cpp
@@ -1,0 +1,141 @@
+#include "collection/Collection.h"
+
+namespace UKControllerPluginUtilsTest::Collection {
+
+    struct MockCollectionValue
+    {
+        MockCollectionValue(int id) : id(id)
+        {
+        }
+
+        [[nodiscard]] auto CollectionKey() const -> int
+        {
+            return id;
+        }
+
+        int id;
+    };
+
+    class CollectionTest : public ::testing::Test
+    {
+        public:
+        UKControllerPluginUtils::Collection::Collection<int, MockCollectionValue> collection;
+    };
+
+    TEST_F(CollectionTest, ItAddsItems)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(1, collection.Count());
+    }
+
+    TEST_F(CollectionTest, ItDoesntAddDuplicateItems)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        collection.Add(item);
+        EXPECT_EQ(1, collection.Count());
+    }
+
+    TEST_F(CollectionTest, ItGetsItemsByKey)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(item, collection.Get(1));
+    }
+
+    TEST_F(CollectionTest, ItReturnsNullptrIfNoItemFoundByKey)
+    {
+        EXPECT_EQ(nullptr, collection.Get(1));
+    }
+
+    TEST_F(CollectionTest, ItGetsItemsByItem)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_EQ(item, collection.Get(item));
+    }
+
+    TEST_F(CollectionTest, ItReturnsNullptrIfNoItemFoundByItem)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        EXPECT_EQ(nullptr, collection.Get(item));
+    }
+
+    TEST_F(CollectionTest, ItContainsItemsByKey)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_TRUE(collection.Contains(1));
+    }
+
+    TEST_F(CollectionTest, ItDoesNotContainItemsByKey)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_FALSE(collection.Contains(2));
+    }
+
+    TEST_F(CollectionTest, ItContainsItemsByItem)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        EXPECT_TRUE(collection.Contains(item));
+    }
+
+    TEST_F(CollectionTest, ItDoesNotContainItemsByItem)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        auto item2 = std::make_shared<MockCollectionValue>(2);
+        collection.Add(item);
+        EXPECT_FALSE(collection.Contains(item2));
+    }
+
+    TEST_F(CollectionTest, ItRemovesItemsByKey)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        collection.RemoveByKey(1);
+        EXPECT_EQ(0, collection.Count());
+    }
+
+    TEST_F(CollectionTest, ItRemovesItemsByItem)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        collection.Remove(item);
+        EXPECT_EQ(0, collection.Count());
+    }
+
+    TEST_F(CollectionTest, ItDoesNotRemoveItemsByKeyIfNotPresent)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        collection.RemoveByKey(2);
+        EXPECT_EQ(1, collection.Count());
+    }
+
+    TEST_F(CollectionTest, ItDoesNotRemoveItemsByItemIfNotPresent)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        collection.Remove(std::make_shared<MockCollectionValue>(2));
+        EXPECT_EQ(1, collection.Count());
+    }
+
+    TEST_F(CollectionTest, ItDoesNotRemoveItemsByKeyIfNull)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        collection.RemoveByKey(0);
+        EXPECT_EQ(1, collection.Count());
+    }
+
+    TEST_F(CollectionTest, ItDoesNotRemoveItemsByItemIfNull)
+    {
+        auto item = std::make_shared<MockCollectionValue>(1);
+        collection.Add(item);
+        collection.Remove(nullptr);
+        EXPECT_EQ(1, collection.Count());
+    }
+} // namespace UKControllerPluginUtilsTest::Collection


### PR DESCRIPTION
- Allow users to be notified in the chat area when a departure release request comes through for them
- Add a general setting preference for the setting (defaults to off)

Close #410 