### PR TITLE
History trail performance

### DIFF
--- a/src/plugin/historytrail/AircraftHistoryTrail.cpp
+++ b/src/plugin/historytrail/AircraftHistoryTrail.cpp
@@ -1,42 +1,39 @@
-#include "historytrail/AircraftHistoryTrail.h"
+#include "AircraftHistoryTrail.h"
 
-namespace UKControllerPlugin {
-    namespace HistoryTrail {
+namespace UKControllerPlugin::HistoryTrail {
 
-        AircraftHistoryTrail::AircraftHistoryTrail(std::string callsign)
-        {
-            this->callsign = callsign;
+    AircraftHistoryTrail::AircraftHistoryTrail(std::string callsign) : callsign(std::move(callsign))
+    {
+    }
+
+    /*
+        Adds an item to the history trail. If the queue is already at the maximum size, we remove the oldest
+        item before adding the new one - so the trail will never get bigger than this->maxSize.
+
+        The new item goes to the front, whilst old items are popped off the back.
+    */
+    void AircraftHistoryTrail::AddItem(const HistoryTrailPoint& point)
+    {
+        this->trail.push_back(point);
+
+        if (this->trail.size() > this->maxSize && this->trail.size() > 0) {
+            this->trail.erase(this->trail.cbegin());
         }
+    }
 
-        /*
-            Adds an item to the history trail. If the queue is already at the maximum size, we remove the oldest
-            item before adding the new one - so the trail will never get bigger than this->maxSize.
+    /*
+        Returns the callsign associated with this history trail.
+    */
+    auto AircraftHistoryTrail::GetCallsign() const -> std::string
+    {
+        return this->callsign;
+    }
 
-            The new item goes to the front, whilst old items are popped off the back.
-        */
-        void AircraftHistoryTrail::AddItem(HistoryTrailPoint point)
-        {
-            this->trail.push_front(point);
-
-            if (this->trail.size() > this->maxSize) {
-                this->trail.pop_back();
-            }
-        }
-
-        /*
-            Returns the callsign associated with this history trail.
-        */
-        std::string AircraftHistoryTrail::GetCallsign(void) const
-        {
-            return this->callsign;
-        }
-
-        /*
-            Returns a copy of the current history trail.
-        */
-        const std::deque<HistoryTrailPoint>& AircraftHistoryTrail::GetTrail(void) const
-        {
-            return this->trail;
-        }
-    } // namespace HistoryTrail
-} // namespace UKControllerPlugin
+    /*
+        Returns a copy of the current history trail.
+    */
+    auto AircraftHistoryTrail::GetTrail() const -> const std::vector<HistoryTrailPoint>&
+    {
+        return this->trail;
+    }
+} // namespace UKControllerPlugin::HistoryTrail

--- a/src/plugin/historytrail/AircraftHistoryTrail.h
+++ b/src/plugin/historytrail/AircraftHistoryTrail.h
@@ -1,29 +1,27 @@
 #pragma once
-#include "historytrail/HistoryTrailPoint.h"
+#include "HistoryTrailPoint.h"
 
-namespace UKControllerPlugin {
-    namespace HistoryTrail {
-        /*
-            Class that encapsulates a standard C++ double-ended queue with a maximum size
-            to provide a list of aircraft positions.
-        */
-        class AircraftHistoryTrail
-        {
-            public:
-            explicit AircraftHistoryTrail(std::string callsign);
-            void AddItem(HistoryTrailPoint point);
-            std::string GetCallsign(void) const;
-            const std::deque<HistoryTrailPoint>& GetTrail(void) const;
+namespace UKControllerPlugin::HistoryTrail {
+    /*
+        Class that encapsulates a standard C++ double-ended queue with a maximum size
+        to provide a list of aircraft positions.
+    */
+    class AircraftHistoryTrail
+    {
+        public:
+        explicit AircraftHistoryTrail(std::string callsign);
+        void AddItem(const HistoryTrailPoint& point);
+        [[nodiscard]] auto GetCallsign() const -> std::string;
+        [[nodiscard]] auto GetTrail(void) const -> const std::vector<HistoryTrailPoint>&;
 
-            // The maximum number of items we can have in the history trail.
-            const unsigned int maxSize = 50;
+        // The maximum number of items we can have in the history trail.
+        const unsigned int maxSize = 50;
 
-            private:
-            // A queue of aircraft positions.
-            std::deque<HistoryTrailPoint> trail;
+        private:
+        // A queue of aircraft positions.
+        std::vector<HistoryTrailPoint> trail;
 
-            // Aircraft callsign corresponding to the history trail
-            std::string callsign;
-        };
-    } // namespace HistoryTrail
-} // namespace UKControllerPlugin
+        // Aircraft callsign corresponding to the history trail
+        std::string callsign;
+    };
+} // namespace UKControllerPlugin::HistoryTrail

--- a/src/plugin/historytrail/HistoryTrailRenderer.cpp
+++ b/src/plugin/historytrail/HistoryTrailRenderer.cpp
@@ -251,7 +251,6 @@ namespace UKControllerPlugin::HistoryTrail {
 
     void HistoryTrailRenderer::Render(GdiGraphicsInterface& graphics, EuroscopeRadarLoopbackInterface& radarScreen)
     {
-        auto nowTime = std::chrono::system_clock::now();
         Gdiplus::Color currentColourArgb = *this->startColour;
         this->pen->SetColor(currentColourArgb);
         this->brush->SetColor(currentColourArgb);
@@ -350,10 +349,6 @@ namespace UKControllerPlugin::HistoryTrail {
                 roundNumber++;
             }
         }
-
-        auto renderTimeInMs =
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - nowTime).count();
-        LogDebug("HistoryTrailRenderer::Render took " + std::to_string(renderTimeInMs) + " ms");
     }
 
     /*

--- a/src/plugin/historytrail/HistoryTrailRenderer.cpp
+++ b/src/plugin/historytrail/HistoryTrailRenderer.cpp
@@ -302,7 +302,7 @@ namespace UKControllerPlugin::HistoryTrail {
                 graphics.Translated(
                     static_cast<Gdiplus::REAL>(dotCoordinates.x),
                     static_cast<Gdiplus::REAL>(dotCoordinates.y),
-                    [&graphics, this, &dot, &roundNumber, &reducePerDot, &position] {
+                    [&graphics, this, &dot, &roundNumber, &position] {
                         // Adjust the dot size and position as required
                         if (this->degradingTrails) {
                             dot.X = -(this->historyTrailDotSizeFloat / 2) + (roundNumber * reducePerDot);

--- a/src/plugin/historytrail/HistoryTrailRenderer.cpp
+++ b/src/plugin/historytrail/HistoryTrailRenderer.cpp
@@ -1,13 +1,13 @@
-#include "historytrail/HistoryTrailRenderer.h"
-#include "euroscope/EuroscopeRadarLoopbackInterface.h"
-#include "graphics/GdiGraphicsInterface.h"
-#include "euroscope/UserSetting.h"
-#include "historytrail/AircraftHistoryTrail.h"
-#include "historytrail/HistoryTrailRepository.h"
-#include "historytrail/HistoryTrailData.h"
+#include "AircraftHistoryTrail.h"
+#include "HistoryTrailData.h"
+#include "HistoryTrailRenderer.h"
+#include "HistoryTrailRepository.h"
 #include "dialog/DialogManager.h"
-#include "euroscope/EuroscopePluginLoopbackInterface.h"
 #include "euroscope/EuroScopeCRadarTargetInterface.h"
+#include "euroscope/EuroscopePluginLoopbackInterface.h"
+#include "euroscope/EuroscopeRadarLoopbackInterface.h"
+#include "euroscope/UserSetting.h"
+#include "graphics/GdiGraphicsInterface.h"
 
 using UKControllerPlugin::Dialog::DialogManager;
 using UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface;
@@ -19,412 +19,410 @@ using UKControllerPlugin::HistoryTrail::HistoryTrailRepository;
 using UKControllerPlugin::Plugin::PopupMenuItem;
 using UKControllerPlugin::Windows::GdiGraphicsInterface;
 
-namespace UKControllerPlugin {
-    namespace HistoryTrail {
+namespace UKControllerPlugin::HistoryTrail {
 
-        HistoryTrailRenderer::HistoryTrailRenderer(
-            const HistoryTrailRepository& trails,
-            EuroscopePluginLoopbackInterface& plugin,
-            const DialogManager& dialogManager,
-            int toggleCallbackFunctionId)
-            : toggleCallbackFunctionId(toggleCallbackFunctionId), dialogManager(dialogManager), plugin(plugin),
-              trails(trails)
-        {
-            this->pen = std::make_unique<Gdiplus::Pen>(Gdiplus::Color(255, 255, 255, 255));
-            this->brush = std::make_unique<Gdiplus::SolidBrush>(Gdiplus::Color(255, 255, 255, 255));
+    HistoryTrailRenderer::HistoryTrailRenderer(
+        const HistoryTrailRepository& trails,
+        EuroscopePluginLoopbackInterface& plugin,
+        const DialogManager& dialogManager,
+        int toggleCallbackFunctionId)
+        : toggleCallbackFunctionId(toggleCallbackFunctionId), dialogManager(dialogManager), plugin(plugin),
+          trails(trails)
+    {
+        this->pen = std::make_unique<Gdiplus::Pen>(Gdiplus::Color(255, 255, 255, 255));
+        this->brush = std::make_unique<Gdiplus::SolidBrush>(Gdiplus::Color(255, 255, 255, 255));
+    }
+
+    /*
+        Load settings from the ASR.
+    */
+    void HistoryTrailRenderer::AsrLoadedEvent(UserSetting& userSetting)
+    {
+        this->visible = userSetting.GetBooleanEntry(this->visibleUserSettingKey, true);
+        this->historyTrailType = userSetting.GetIntegerEntry(this->trailTypeUserSettingKey, this->trailTypeDiamond);
+        this->historyTrailDotSize = userSetting.GetIntegerEntry(this->dotSizeUserSettingKey, 4);
+        this->historyTrailDotSizeFloat = static_cast<float>(this->historyTrailDotSize);
+        this->degradingTrails = userSetting.GetBooleanEntry(this->degradingUserSettingKey, true);
+        this->fadingTrails = userSetting.GetBooleanEntry(this->fadingUserSettingKey, true);
+        this->historyTrailLength = userSetting.GetIntegerEntry(this->trailLengthUserSettingKey, 15);
+        this->antialiasedTrails = userSetting.GetBooleanEntry(this->antialiasUserSettingKey, true);
+        this->startColour = std::make_unique<Gdiplus::Color>(255, 255, 130, 20);
+        this->startColour->SetFromCOLORREF(
+            userSetting.GetColourEntry(this->trailColourUserSettingKey, RGB(255, 130, 20)));
+        this->alphaPerDot = 255 / this->historyTrailLength;
+        this->minimumDisplayAltitude =
+            userSetting.GetIntegerEntry(this->minAltitudeFilterUserSettingKey, this->defaultMinAltitude);
+        this->maximumDisplayAltitude =
+            userSetting.GetIntegerEntry(this->maxAltitudeFilterUserSettingKey, this->defaultMaxAltitude);
+        this->filledDots = userSetting.GetBooleanEntry(this->dotFillUserSettingKey, false);
+        this->rotatedDots = userSetting.GetBooleanEntry(this->dotRotateUserSettingKey, false);
+
+        // Load the dot drawing function
+        this->drawDot = this->GetDrawDotFunction();
+    }
+
+    /*
+        Save settings to the ASR.
+    */
+    void HistoryTrailRenderer::AsrClosingEvent(UserSetting& userSetting)
+    {
+        userSetting.Save(this->visibleUserSettingKey, this->visibleUserSettingDescription, this->visible);
+        userSetting.Save(this->trailTypeUserSettingKey, this->trailTypeUserSettingDescription, this->historyTrailType);
+        userSetting.Save(this->dotSizeUserSettingKey, this->dotSizeUserSettingDescription, this->historyTrailDotSize);
+        userSetting.Save(this->degradingUserSettingKey, this->degradingUserSettingDescription, this->degradingTrails);
+        userSetting.Save(this->fadingUserSettingKey, this->fadingUserSettingDescription, this->fadingTrails);
+        userSetting.Save(
+            this->trailLengthUserSettingKey, this->trailLengthUserSettingDescription, this->historyTrailLength);
+        userSetting.Save(
+            this->trailColourUserSettingKey, this->trailColourUserSettingDescription, this->startColour->ToCOLORREF());
+        userSetting.Save(this->antialiasUserSettingKey, this->antialiasUserSettingDescription, this->antialiasedTrails);
+        userSetting.Save(
+            this->minAltitudeFilterUserSettingKey,
+            this->minAltitudeFilterUserSettingDescription,
+            this->minimumDisplayAltitude);
+        userSetting.Save(
+            this->maxAltitudeFilterUserSettingKey,
+            this->maxAltitudeFilterUserSettingDescription,
+            this->maximumDisplayAltitude);
+        userSetting.Save(this->dotFillUserSettingKey, this->dotFillUserSettingDescription, this->filledDots);
+        userSetting.Save(this->dotRotateUserSettingKey, this->dotRotateUserSettingDescription, this->rotatedDots);
+    }
+
+    /*
+        Called when the configuration menu item is selected. Create dialog.
+    */
+    void HistoryTrailRenderer::Configure(int functionId, std::string subject, RECT screenObjectArea)
+    {
+        COLORREF newColour =
+            RGB(this->startColour->GetRed(), this->startColour->GetGreen(), this->startColour->GetBlue());
+
+        HistoryTrailData data;
+        data.fade = &this->fadingTrails;
+        data.degrade = &this->degradingTrails;
+        data.antiAlias = &this->antialiasedTrails;
+        data.type = &this->historyTrailType;
+        data.length = &this->historyTrailLength;
+        data.colour = &newColour;
+        data.dotSize = &this->historyTrailDotSize;
+        data.maxAltitude = &this->maximumDisplayAltitude;
+        data.minAltitude = &this->minimumDisplayAltitude;
+        data.filledDots = &this->filledDots;
+        data.rotate = &this->rotatedDots;
+
+        this->dialogManager.OpenDialog(IDD_HISTORY_TRAIL, reinterpret_cast<LPARAM>(&data));
+
+        this->historyTrailDotSizeFloat = static_cast<float>(this->historyTrailDotSize);
+        this->startColour->SetFromCOLORREF(newColour);
+        this->alphaPerDot = 255 / this->historyTrailLength;
+
+        // Change the rendering function
+        this->drawDot = this->GetDrawDotFunction();
+    }
+
+    /*
+        Returns the alpha decrease per dot.
+    */
+    auto HistoryTrailRenderer::GetAlphaPerDot() const -> int
+    {
+        return this->alphaPerDot;
+    }
+
+    /*
+        Returns antialiasing mode.
+    */
+    auto HistoryTrailRenderer::GetAntiAliasedTrails() const -> bool
+    {
+        return this->antialiasedTrails;
+    }
+
+    /*
+        Returns the configuration menu item.
+    */
+    auto HistoryTrailRenderer::GetConfigurationMenuItem() const -> PopupMenuItem
+    {
+        PopupMenuItem returnVal;
+        returnVal.firstValue = this->menuItemDescription;
+        returnVal.secondValue = "";
+        returnVal.callbackFunctionId = this->toggleCallbackFunctionId;
+        returnVal.checked = EuroScopePlugIn::POPUP_ELEMENT_NO_CHECKBOX;
+        returnVal.disabled = false;
+        returnVal.fixedPosition = false;
+        return returnVal;
+    }
+
+    /*
+        Return whether to degrade trails.
+    */
+    auto HistoryTrailRenderer::GetDegradingTrails() const -> bool
+    {
+        return this->degradingTrails;
+    }
+
+    /*
+        Return whether to fade trails.
+    */
+    auto HistoryTrailRenderer::GetFadingTrails() const -> bool
+    {
+        return this->fadingTrails;
+    }
+
+    /*
+        Returns the length of trail to be rendered.
+    */
+    auto HistoryTrailRenderer::GetHistoryTrailLength() const -> int
+    {
+        return this->historyTrailLength;
+    }
+
+    /*
+        Returns the trail type.
+    */
+    auto HistoryTrailRenderer::GetHistoryTrailType() const -> int
+    {
+        return this->historyTrailType;
+    }
+
+    /*
+        Returns the dot size.
+    */
+    auto HistoryTrailRenderer::GetHistoryTrailDotSize() const -> int
+    {
+        return this->historyTrailDotSize;
+    }
+
+    /*
+        Get the maximum display altitude
+    */
+    auto HistoryTrailRenderer::GetMaximumAltitudeFilter() const -> int
+    {
+        return this->maximumDisplayAltitude;
+    }
+
+    /*
+        Get the minimum display altitude
+    */
+    auto HistoryTrailRenderer::GetMinimumAltitudeFilter() const -> int
+    {
+        return this->minimumDisplayAltitude;
+    }
+
+    auto HistoryTrailRenderer::GetFilledDots() const -> bool
+    {
+        return this->filledDots;
+    }
+
+    auto HistoryTrailRenderer::GetRotatedDots() const -> bool
+    {
+        return this->rotatedDots;
+    }
+
+    auto HistoryTrailRenderer::GetTrailColour() const -> Gdiplus::Color&
+    {
+        return *this->startColour;
+    }
+
+    /*
+        Returns whether or not history trails should be rendered.
+    */
+    auto HistoryTrailRenderer::IsVisible() const -> bool
+    {
+        return this->visible;
+    }
+
+    /*
+        These don't get moved.
+    */
+    void HistoryTrailRenderer::Move(RECT position, std::string objectDescription)
+    {
+    }
+
+    /*
+        Processes Euroscope dot commands.
+    */
+    auto HistoryTrailRenderer::ProcessCommand(std::string command) -> bool
+    {
+        if (command == this->dotCommand) {
+            this->Configure(0, command, {});
+            return true;
         }
 
-        /*
-            Load settings from the ASR.
-        */
-        void HistoryTrailRenderer::AsrLoadedEvent(UserSetting& userSetting)
-        {
-            this->visible = userSetting.GetBooleanEntry(this->visibleUserSettingKey, true);
-            this->historyTrailType = userSetting.GetIntegerEntry(this->trailTypeUserSettingKey, this->trailTypeDiamond);
-            this->historyTrailDotSize = userSetting.GetIntegerEntry(this->dotSizeUserSettingKey, 4);
-            this->historyTrailDotSizeFloat = static_cast<float>(this->historyTrailDotSize);
-            this->degradingTrails = userSetting.GetBooleanEntry(this->degradingUserSettingKey, true);
-            this->fadingTrails = userSetting.GetBooleanEntry(this->fadingUserSettingKey, true);
-            this->historyTrailLength = userSetting.GetIntegerEntry(this->trailLengthUserSettingKey, 15);
-            this->antialiasedTrails = userSetting.GetBooleanEntry(this->antialiasUserSettingKey, true);
-            this->startColour = std::make_unique<Gdiplus::Color>(255, 255, 130, 20);
-            this->startColour->SetFromCOLORREF(
-                userSetting.GetColourEntry(this->trailColourUserSettingKey, RGB(255, 130, 20)));
-            this->alphaPerDot = 255 / this->historyTrailLength;
-            this->minimumDisplayAltitude =
-                userSetting.GetIntegerEntry(this->minAltitudeFilterUserSettingKey, this->defaultMinAltitude);
-            this->maximumDisplayAltitude =
-                userSetting.GetIntegerEntry(this->maxAltitudeFilterUserSettingKey, this->defaultMaxAltitude);
-            this->filledDots = userSetting.GetBooleanEntry(this->dotFillUserSettingKey, false);
-            this->rotatedDots = userSetting.GetBooleanEntry(this->dotRotateUserSettingKey, false);
+        return false;
+    }
 
-            // Load the dot drawing function
-            this->drawDot = this->GetDrawDotFunction();
-        }
+    void HistoryTrailRenderer::Render(GdiGraphicsInterface& graphics, EuroscopeRadarLoopbackInterface& radarScreen)
+    {
+        auto nowTime = std::chrono::system_clock::now();
+        Gdiplus::Color currentColourArgb = *this->startColour;
+        this->pen->SetColor(currentColourArgb);
+        this->brush->SetColor(currentColourArgb);
 
-        /*
-            Save settings to the ASR.
-        */
-        void HistoryTrailRenderer::AsrClosingEvent(UserSetting& userSetting)
-        {
-            userSetting.Save(this->visibleUserSettingKey, this->visibleUserSettingDescription, this->visible);
-            userSetting.Save(
-                this->trailTypeUserSettingKey, this->trailTypeUserSettingDescription, this->historyTrailType);
-            userSetting.Save(
-                this->dotSizeUserSettingKey, this->dotSizeUserSettingDescription, this->historyTrailDotSize);
-            userSetting.Save(
-                this->degradingUserSettingKey, this->degradingUserSettingDescription, this->degradingTrails);
-            userSetting.Save(this->fadingUserSettingKey, this->fadingUserSettingDescription, this->fadingTrails);
-            userSetting.Save(
-                this->trailLengthUserSettingKey, this->trailLengthUserSettingDescription, this->historyTrailLength);
-            userSetting.Save(
-                this->trailColourUserSettingKey,
-                this->trailColourUserSettingDescription,
-                this->startColour->ToCOLORREF());
-            userSetting.Save(
-                this->antialiasUserSettingKey, this->antialiasUserSettingDescription, this->antialiasedTrails);
-            userSetting.Save(
-                this->minAltitudeFilterUserSettingKey,
-                this->minAltitudeFilterUserSettingDescription,
-                this->minimumDisplayAltitude);
-            userSetting.Save(
-                this->maxAltitudeFilterUserSettingKey,
-                this->maxAltitudeFilterUserSettingDescription,
-                this->maximumDisplayAltitude);
-            userSetting.Save(this->dotFillUserSettingKey, this->dotFillUserSettingDescription, this->filledDots);
-            userSetting.Save(this->dotRotateUserSettingKey, this->dotRotateUserSettingDescription, this->rotatedDots);
-        }
+        // Anti aliasing
+        graphics.SetAntialias((this->antialiasedTrails) ? true : false);
 
-        /*
-            Called when the configuration menu item is selected. Create dialog.
-        */
-        void HistoryTrailRenderer::Configure(int functionId, std::string subject, RECT screenObjectArea)
-        {
-            COLORREF newColour =
-                RGB(this->startColour->GetRed(), this->startColour->GetGreen(), this->startColour->GetBlue());
+        // The dot we are to make.
+        Gdiplus::RectF dot;
 
-            HistoryTrailData data;
-            data.fade = &this->fadingTrails;
-            data.degrade = &this->degradingTrails;
-            data.antiAlias = &this->antialiasedTrails;
-            data.type = &this->historyTrailType;
-            data.length = &this->historyTrailLength;
-            data.colour = &newColour;
-            data.dotSize = &this->historyTrailDotSize;
-            data.maxAltitude = &this->maximumDisplayAltitude;
-            data.minAltitude = &this->minimumDisplayAltitude;
-            data.filledDots = &this->filledDots;
-            data.rotate = &this->rotatedDots;
+        // The amount that we'll reduce the history dot by on all sides each time.
+        Gdiplus::REAL reducePerDot = (this->historyTrailDotSizeFloat / this->historyTrailLength) / 2;
 
-            this->dialogManager.OpenDialog(IDD_HISTORY_TRAIL, reinterpret_cast<LPARAM>(&data));
+        int roundNumber;
+        // Loop through the history trails.
 
-            this->historyTrailDotSizeFloat = static_cast<float>(this->historyTrailDotSize);
-            this->startColour->SetFromCOLORREF(newColour);
-            this->alphaPerDot = 255 / this->historyTrailLength;
-        }
-
-        /*
-            Returns the alpha decrease per dot.
-        */
-        int HistoryTrailRenderer::GetAlphaPerDot(void) const
-        {
-            return this->alphaPerDot;
-        }
-
-        /*
-            Returns antialiasing mode.
-        */
-        bool HistoryTrailRenderer::GetAntiAliasedTrails(void) const
-        {
-            return this->antialiasedTrails;
-        }
-
-        /*
-            Returns the configuration menu item.
-        */
-        PopupMenuItem HistoryTrailRenderer::GetConfigurationMenuItem(void) const
-        {
-            PopupMenuItem returnVal;
-            returnVal.firstValue = this->menuItemDescription;
-            returnVal.secondValue = "";
-            returnVal.callbackFunctionId = this->toggleCallbackFunctionId;
-            returnVal.checked = EuroScopePlugIn::POPUP_ELEMENT_NO_CHECKBOX;
-            returnVal.disabled = false;
-            returnVal.fixedPosition = false;
-            return returnVal;
-        }
-
-        /*
-            Return whether to degrade trails.
-        */
-        bool HistoryTrailRenderer::GetDegradingTrails(void) const
-        {
-            return this->degradingTrails;
-        }
-
-        /*
-            Return whether to fade trails.
-        */
-        bool HistoryTrailRenderer::GetFadingTrails(void) const
-        {
-            return this->fadingTrails;
-        }
-
-        /*
-            Returns the length of trail to be rendered.
-        */
-        int HistoryTrailRenderer::GetHistoryTrailLength(void) const
-        {
-            return this->historyTrailLength;
-        }
-
-        /*
-            Returns the trail type.
-        */
-        int HistoryTrailRenderer::GetHistoryTrailType(void) const
-        {
-            return this->historyTrailType;
-        }
-
-        /*
-            Returns the dot size.
-        */
-        int HistoryTrailRenderer::GetHistoryTrailDotSize(void) const
-        {
-            return this->historyTrailDotSize;
-        }
-
-        /*
-            Get the maximum display altitude
-        */
-        int HistoryTrailRenderer::GetMaximumAltitudeFilter(void) const
-        {
-            return this->maximumDisplayAltitude;
-        }
-
-        /*
-            Get the minimum display altitude
-        */
-        int HistoryTrailRenderer::GetMinimumAltitudeFilter(void) const
-        {
-            return this->minimumDisplayAltitude;
-        }
-
-        bool HistoryTrailRenderer::GetFilledDots() const
-        {
-            return this->filledDots;
-        }
-
-        bool HistoryTrailRenderer::GetRotatedDots() const
-        {
-            return this->rotatedDots;
-        }
-
-        Gdiplus::Color& HistoryTrailRenderer::GetTrailColour(void) const
-        {
-            return *this->startColour;
-        }
-
-        /*
-            Returns whether or not history trails should be rendered.
-        */
-        bool HistoryTrailRenderer::IsVisible(void) const
-        {
-            return this->visible;
-        }
-
-        /*
-            These don't get moved.
-        */
-        void HistoryTrailRenderer::Move(RECT position, std::string objectDescription)
-        {
-        }
-
-        /*
-            Processes Euroscope dot commands.
-        */
-        bool HistoryTrailRenderer::ProcessCommand(std::string command)
-        {
-            if (command == this->dotCommand) {
-                this->Configure(0, command, {});
-                return true;
+        std::shared_ptr<EuroScopeCRadarTargetInterface> radarTarget;
+        for (HistoryTrailRepository::const_iterator aircraft = this->trails.cbegin(); aircraft != this->trails.cend();
+             ++aircraft) {
+            // Check the radar target exists
+            radarTarget = this->plugin.GetRadarTargetForCallsign(aircraft->second->GetCallsign());
+            if (!radarTarget) {
+                continue;
             }
 
-            return false;
-        }
+            // If they're not going fast enough or are off the screen, don't display the trail.
+            if (radarScreen.GetGroundspeedForCallsign(aircraft->second->GetCallsign()) < this->minimumSpeed ||
+                aircraft->second->GetTrail().empty() ||
+                radarScreen.PositionOffScreen(aircraft->second->GetTrail().begin()->position) ||
+                radarTarget->GetFlightLevel() < this->minimumDisplayAltitude ||
+                radarTarget->GetFlightLevel() > this->maximumDisplayAltitude) {
+                continue;
+            }
 
-        void HistoryTrailRenderer::Render(GdiGraphicsInterface& graphics, EuroscopeRadarLoopbackInterface& radarScreen)
-        {
-            Gdiplus::Color currentColourArgb = *this->startColour;
+            // Round number used to govern fade and degrade, reset the colour
+            roundNumber = 0;
+            currentColourArgb = *this->startColour;
             this->pen->SetColor(currentColourArgb);
             this->brush->SetColor(currentColourArgb);
 
-            // Anti aliasing
-            graphics.SetAntialias((this->antialiasedTrails) ? true : false);
+            // Reset the dot height and width
+            dot.Width = this->historyTrailDotSizeFloat;
+            dot.Height = this->historyTrailDotSizeFloat;
 
-            // The dot we are to make.
-            Gdiplus::RectF dot;
+            // Loop through the points and display.
+            for (auto position = aircraft->second->GetTrail().begin(); position != aircraft->second->GetTrail().end();
+                 ++position) {
 
-            // The amount that we'll reduce the history dot by on all sides each time.
-            Gdiplus::REAL reducePerDot = (this->historyTrailDotSizeFloat / this->historyTrailLength) / 2;
-
-            int roundNumber;
-            // Loop through the history trails.
-
-            std::shared_ptr<EuroScopeCRadarTargetInterface> radarTarget;
-            for (HistoryTrailRepository::const_iterator aircraft = this->trails.cbegin();
-                 aircraft != this->trails.cend();
-                 ++aircraft) {
-                // Check the radar target exists
-                radarTarget = this->plugin.GetRadarTargetForCallsign(aircraft->second->GetCallsign());
-                if (!radarTarget) {
+                // Skip the first dot, that's the aircrafts current position
+                if (position == aircraft->second->GetTrail().begin()) {
                     continue;
                 }
 
-                // If they're not going fast enough or are off the screen, don't display the trail.
-                if (radarScreen.GetGroundspeedForCallsign(aircraft->second->GetCallsign()) < this->minimumSpeed ||
-                    aircraft->second->GetTrail().empty() ||
-                    radarScreen.PositionOffScreen(aircraft->second->GetTrail().begin()->position) ||
-                    radarTarget->GetFlightLevel() < this->minimumDisplayAltitude ||
-                    radarTarget->GetFlightLevel() > this->maximumDisplayAltitude) {
-                    continue;
-                }
+                // Translate to screen location
+                POINT dotCoordinates = radarScreen.ConvertCoordinateToScreenPoint(position->position);
+                graphics.Translated(
+                    static_cast<Gdiplus::REAL>(dotCoordinates.x),
+                    static_cast<Gdiplus::REAL>(dotCoordinates.y),
+                    [&graphics, this, &dot, &roundNumber, &reducePerDot, &position] {
+                        // Adjust the dot size and position as required
+                        if (this->degradingTrails) {
+                            dot.X = -(this->historyTrailDotSizeFloat / 2) + (roundNumber * reducePerDot);
+                            dot.Y = -(this->historyTrailDotSizeFloat / 2) + (roundNumber * reducePerDot);
+                            dot.Width = dot.Width - reducePerDot;
+                            dot.Height = dot.Height - reducePerDot;
+                        } else {
+                            dot.X = -(this->historyTrailDotSizeFloat / 2);
+                            dot.Y = -(this->historyTrailDotSizeFloat / 2);
+                        }
 
-                // Round number used to govern fade and degrade, reset the colour
-                roundNumber = 0;
-                currentColourArgb = *this->startColour;
-                this->pen->SetColor(currentColourArgb);
-                this->brush->SetColor(currentColourArgb);
-
-                // Reset the dot height and width
-                dot.Width = this->historyTrailDotSizeFloat;
-                dot.Height = this->historyTrailDotSizeFloat;
-
-                // Loop through the points and display.
-                for (auto position = aircraft->second->GetTrail().begin();
-                     position != aircraft->second->GetTrail().end();
-                     ++position) {
-
-                    // Skip the first dot, that's the aircrafts current position
-                    if (position == aircraft->second->GetTrail().begin()) {
-                        continue;
-                    }
-
-                    // Translate to screen location
-                    POINT dotCoordinates = radarScreen.ConvertCoordinateToScreenPoint(position->position);
-                    graphics.Translated(
-                        static_cast<Gdiplus::REAL>(dotCoordinates.x),
-                        static_cast<Gdiplus::REAL>(dotCoordinates.y),
-                        [&graphics, this, &dot, &roundNumber, &reducePerDot, &position] {
-                            // Adjust the dot size and position as required
-                            if (this->degradingTrails) {
-                                dot.X = -(this->historyTrailDotSizeFloat / 2) + (roundNumber * reducePerDot);
-                                dot.Y = -(this->historyTrailDotSizeFloat / 2) + (roundNumber * reducePerDot);
-                                dot.Width = dot.Width - reducePerDot;
-                                dot.Height = dot.Height - reducePerDot;
-                            } else {
-                                dot.X = -(this->historyTrailDotSizeFloat / 2);
-                                dot.Y = -(this->historyTrailDotSizeFloat / 2);
-                            }
-
-                            if (this->rotatedDots) {
-                                graphics.Rotated(
-                                    static_cast<Gdiplus::REAL>(position->heading),
-                                    [&graphics, &dot, this]() { this->drawDot(graphics, dot); });
-                            } else {
+                        if (this->rotatedDots) {
+                            graphics.Rotated(static_cast<Gdiplus::REAL>(position->heading), [&graphics, &dot, this]() {
                                 this->drawDot(graphics, dot);
-                            }
-                        });
+                            });
+                        } else {
+                            this->drawDot(graphics, dot);
+                        }
+                    });
 
-                    // If the trails are set to fade, reduce the alpha value for the next run
-                    if (this->fadingTrails) {
-                        currentColourArgb = Gdiplus::Color(
-                            255 - (roundNumber * this->alphaPerDot),
-                            currentColourArgb.GetRed(),
-                            currentColourArgb.GetGreen(),
-                            currentColourArgb.GetBlue());
-                        this->pen->SetColor(currentColourArgb);
-                        this->brush->SetColor(currentColourArgb);
-                    }
-
-                    // If we've done enough dots, we stop.
-                    if (roundNumber == this->historyTrailLength) {
-                        break;
-                    }
-
-                    roundNumber++;
+                // If the trails are set to fade, reduce the alpha value for the next run
+                if (this->fadingTrails) {
+                    currentColourArgb = Gdiplus::Color(
+                        255 - (roundNumber * this->alphaPerDot),
+                        currentColourArgb.GetRed(),
+                        currentColourArgb.GetGreen(),
+                        currentColourArgb.GetBlue());
+                    this->pen->SetColor(currentColourArgb);
+                    this->brush->SetColor(currentColourArgb);
                 }
+
+                // If we've done enough dots, we stop.
+                if (roundNumber == this->historyTrailLength) {
+                    break;
+                }
+
+                roundNumber++;
             }
         }
 
-        /*
-            History Trails cannot have their position reset. Do nothing.
-        */
-        void HistoryTrailRenderer::ResetPosition(void)
-        {
-        }
+        auto renderTimeInMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - nowTime).count();
+        LogDebug("HistoryTrailRenderer::Render took " + std::to_string(renderTimeInMs) + " ms");
+    }
 
-        auto HistoryTrailRenderer::GetDoDotFunction() const
-            -> std::function<void(GdiGraphicsInterface&, const Gdiplus::RectF&)>
-        {
-            return this->filledDots && this->historyTrailType != this->trailTypeLine ? this->GetFillDotFunction()
-                                                                                     : this->GetDrawDotFunction();
-        }
+    /*
+        History Trails cannot have their position reset. Do nothing.
+    */
+    void HistoryTrailRenderer::ResetPosition()
+    {
+    }
 
-        auto HistoryTrailRenderer::GetDrawDotFunction() const
-            -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>
-        {
-            // Diamonds
-            if (this->historyTrailType == this->trailTypeDiamond) {
-                return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
-                    graphics.DrawDiamond(area, *this->pen);
-                };
-            }
+    auto HistoryTrailRenderer::GetDoDotFunction() const
+        -> std::function<void(GdiGraphicsInterface&, const Gdiplus::RectF&)>
+    {
+        return this->filledDots && this->historyTrailType != this->trailTypeLine ? this->GetFillDotFunction()
+                                                                                 : this->GetDrawDotFunction();
+    }
 
-            // Circles
-            if (this->historyTrailType == this->trailTypeCircle) {
-                return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
-                    graphics.DrawCircle(area, *this->pen);
-                };
-            }
-
-            // Lines
-            if (this->historyTrailType == this->trailTypeLine) {
-                return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
-                    graphics.DrawLine(
-                        *this->pen,
-                        Gdiplus::PointF{area.GetLeft(), area.GetBottom()},
-                        Gdiplus::PointF{area.GetRight(), area.GetTop()});
-                };
-            }
-
-            // Rectangles
+    auto HistoryTrailRenderer::GetDrawDotFunction() const
+        -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>
+    {
+        // Diamonds
+        if (this->historyTrailType == this->trailTypeDiamond) {
             return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
-                graphics.DrawRect(area, *this->pen);
+                graphics.DrawDiamond(area, *this->pen);
             };
         }
 
-        auto HistoryTrailRenderer::GetFillDotFunction() const
-            -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>
-        {
-            // Diamonds
-            if (this->historyTrailType == this->trailTypeDiamond) {
-                return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
-                    graphics.FillDiamond(area, *this->brush);
-                };
-            }
-
-            // Circles
-            if (this->historyTrailType == this->trailTypeCircle) {
-                return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
-                    graphics.FillCircle(area, *this->brush);
-                };
-            }
-
-            // Rects
+        // Circles
+        if (this->historyTrailType == this->trailTypeCircle) {
             return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
-                graphics.FillRect(area, *this->brush);
+                graphics.DrawCircle(area, *this->pen);
             };
         }
-    } // namespace HistoryTrail
-} // namespace UKControllerPlugin
+
+        // Lines
+        if (this->historyTrailType == this->trailTypeLine) {
+            return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
+                graphics.DrawLine(
+                    *this->pen,
+                    Gdiplus::PointF{area.GetLeft(), area.GetBottom()},
+                    Gdiplus::PointF{area.GetRight(), area.GetTop()});
+            };
+        }
+
+        // Rectangles
+        return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
+            graphics.DrawRect(area, *this->pen);
+        };
+    }
+
+    auto HistoryTrailRenderer::GetFillDotFunction() const
+        -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>
+    {
+        // Diamonds
+        if (this->historyTrailType == this->trailTypeDiamond) {
+            return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
+                graphics.FillDiamond(area, *this->brush);
+            };
+        }
+
+        // Circles
+        if (this->historyTrailType == this->trailTypeCircle) {
+            return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
+                graphics.FillCircle(area, *this->brush);
+            };
+        }
+
+        // Rects
+        return [this](Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area) {
+            graphics.FillRect(area, *this->brush);
+        };
+    }
+} // namespace UKControllerPlugin::HistoryTrail

--- a/src/plugin/historytrail/HistoryTrailRenderer.h
+++ b/src/plugin/historytrail/HistoryTrailRenderer.h
@@ -220,6 +220,9 @@ namespace UKControllerPlugin::HistoryTrail {
         // The altitude at and above which not to display
         int maximumDisplayAltitude;
 
+        // How much we reduce the size of the dots each time if we're on degrading dots
+        Gdiplus::REAL reducePerDot;
+
         // The dot command for opening the configuration modal.
         const std::string dotCommand = ".ukcp h";
 

--- a/src/plugin/historytrail/HistoryTrailRenderer.h
+++ b/src/plugin/historytrail/HistoryTrailRenderer.h
@@ -1,8 +1,8 @@
 #pragma once
-#include "radarscreen/RadarRenderableInterface.h"
+#include "command/CommandHandlerInterface.h"
 #include "euroscope/AsrEventHandlerInterface.h"
 #include "radarscreen/ConfigurableDisplayInterface.h"
-#include "command/CommandHandlerInterface.h"
+#include "radarscreen/RadarRenderableInterface.h"
 
 // Forward declarations
 namespace UKControllerPlugin {
@@ -30,203 +30,200 @@ namespace Gdiplus {
 } // namespace Gdiplus
 // END
 
-namespace UKControllerPlugin {
-    namespace HistoryTrail {
+namespace UKControllerPlugin::HistoryTrail {
 
-        /*
-            A class for rendering history trails to the screen.
-        */
-        class HistoryTrailRenderer : public RadarScreen::ConfigurableDisplayInterface,
-                                     public RadarScreen::RadarRenderableInterface,
-                                     public Euroscope::AsrEventHandlerInterface,
-                                     public Command::CommandHandlerInterface
-        {
-            public:
-            HistoryTrailRenderer(
-                const HistoryTrailRepository& trails,
-                Euroscope::EuroscopePluginLoopbackInterface& plugin,
-                const Dialog::DialogManager& dialogManager,
-                int toggleCallbackFunctionId);
-            void AsrLoadedEvent(Euroscope::UserSetting& userSetting) override;
-            void AsrClosingEvent(Euroscope::UserSetting& userSetting) override;
-            void Configure(int functionId, std::string subject, RECT screenObjectArea) override;
-            int GetAlphaPerDot(void) const;
-            bool GetAntiAliasedTrails(void) const;
-            Plugin::PopupMenuItem GetConfigurationMenuItem(void) const override;
-            bool GetDegradingTrails(void) const;
-            bool GetFadingTrails(void) const;
-            int GetHistoryTrailLength(void) const;
-            int GetHistoryTrailType(void) const;
-            int GetHistoryTrailDotSize(void) const;
-            int GetMaximumAltitudeFilter(void) const;
-            int GetMinimumAltitudeFilter(void) const;
-            bool GetFilledDots() const;
-            bool GetRotatedDots() const;
-            Gdiplus::Color& GetTrailColour(void) const;
-            bool IsVisible(void) const override;
-            void Move(RECT position, std::string objectDescription) override;
-            bool ProcessCommand(std::string command) override;
-            void Render(
-                Windows::GdiGraphicsInterface& graphics,
-                Euroscope::EuroscopeRadarLoopbackInterface& radarScreen) override;
-            void ResetPosition(void) override;
+    /*
+        A class for rendering history trails to the screen.
+    */
+    class HistoryTrailRenderer : public RadarScreen::ConfigurableDisplayInterface,
+                                 public RadarScreen::RadarRenderableInterface,
+                                 public Euroscope::AsrEventHandlerInterface,
+                                 public Command::CommandHandlerInterface
+    {
+        public:
+        HistoryTrailRenderer(
+            const HistoryTrailRepository& trails,
+            Euroscope::EuroscopePluginLoopbackInterface& plugin,
+            const Dialog::DialogManager& dialogManager,
+            int toggleCallbackFunctionId);
+        void AsrLoadedEvent(Euroscope::UserSetting& userSetting) override;
+        void AsrClosingEvent(Euroscope::UserSetting& userSetting) override;
+        void Configure(int functionId, std::string subject, RECT screenObjectArea) override;
+        [[nodiscard]] auto GetAlphaPerDot() const -> int;
+        [[nodiscard]] auto GetAntiAliasedTrails() const -> bool;
+        [[nodiscard]] auto GetConfigurationMenuItem() const -> Plugin::PopupMenuItem override;
+        [[nodiscard]] auto GetDegradingTrails() const -> bool;
+        [[nodiscard]] auto GetFadingTrails() const -> bool;
+        [[nodiscard]] auto GetHistoryTrailLength() const -> int;
+        [[nodiscard]] auto GetHistoryTrailType() const -> int;
+        [[nodiscard]] auto GetHistoryTrailDotSize() const -> int;
+        [[nodiscard]] auto GetMaximumAltitudeFilter() const -> int;
+        [[nodiscard]] auto GetMinimumAltitudeFilter() const -> int;
+        [[nodiscard]] auto GetFilledDots() const -> bool;
+        [[nodiscard]] auto GetRotatedDots() const -> bool;
+        [[nodiscard]] auto GetTrailColour() const -> Gdiplus::Color&;
+        [[nodiscard]] auto IsVisible() const -> bool override;
+        void Move(RECT position, std::string objectDescription) override;
+        auto ProcessCommand(std::string command) -> bool override;
+        void Render(
+            Windows::GdiGraphicsInterface& graphics, Euroscope::EuroscopeRadarLoopbackInterface& radarScreen) override;
+        void ResetPosition() override;
 
-            // The function ID for the toggle callback
-            const int toggleCallbackFunctionId;
+        // The function ID for the toggle callback
+        const int toggleCallbackFunctionId;
 
-            // The resource id for the HistoryTrail dialog;
-            const int configurationDialogId = IDD_HISTORY_TRAIL;
+        // The resource id for the HistoryTrail dialog;
+        const int configurationDialogId = IDD_HISTORY_TRAIL;
 
-            // Visibility ASR settings
-            const std::string visibleUserSettingKey = "HistoryTrailDisplay";
+        // Visibility ASR settings
+        const std::string visibleUserSettingKey = "HistoryTrailDisplay";
 
-            const std::string visibleUserSettingDescription = "Display UKCP History Trails";
+        const std::string visibleUserSettingDescription = "Display UKCP History Trails";
 
-            // Trail type ASR settings
-            const std::string trailTypeUserSettingKey = "HistoryTrailType";
+        // Trail type ASR settings
+        const std::string trailTypeUserSettingKey = "HistoryTrailType";
 
-            const std::string trailTypeUserSettingDescription = "UKCP History Trail Type";
+        const std::string trailTypeUserSettingDescription = "UKCP History Trail Type";
 
-            // Dot size ASR settings
-            const std::string dotSizeUserSettingKey = "HistoryTrailDotSize";
+        // Dot size ASR settings
+        const std::string dotSizeUserSettingKey = "HistoryTrailDotSize";
 
-            const std::string dotSizeUserSettingDescription = "UKCP History Trail Dot Size";
+        const std::string dotSizeUserSettingDescription = "UKCP History Trail Dot Size";
 
-            // Degrading ASR settings
-            const std::string degradingUserSettingKey = "HistoryTrailDegrade";
+        // Degrading ASR settings
+        const std::string degradingUserSettingKey = "HistoryTrailDegrade";
 
-            const std::string degradingUserSettingDescription = "UKCP History Trail Degrade";
+        const std::string degradingUserSettingDescription = "UKCP History Trail Degrade";
 
-            // Fading ASR settings
-            const std::string fadingUserSettingKey = "HistoryTrailFade";
+        // Fading ASR settings
+        const std::string fadingUserSettingKey = "HistoryTrailFade";
 
-            const std::string fadingUserSettingDescription = "UKCP History Trail Fade";
+        const std::string fadingUserSettingDescription = "UKCP History Trail Fade";
 
-            // AA ASR settings
-            const std::string antialiasUserSettingKey = "HistoryTrailAntiAlias";
+        // AA ASR settings
+        const std::string antialiasUserSettingKey = "HistoryTrailAntiAlias";
 
-            const std::string antialiasUserSettingDescription = "UKCP History Trail Antialias";
+        const std::string antialiasUserSettingDescription = "UKCP History Trail Antialias";
 
-            // Trail length ASR settings
-            const std::string trailLengthUserSettingKey = "HistoryTrailLength";
+        // Trail length ASR settings
+        const std::string trailLengthUserSettingKey = "HistoryTrailLength";
 
-            const std::string trailLengthUserSettingDescription = "UKCP History Trail Length";
+        const std::string trailLengthUserSettingDescription = "UKCP History Trail Length";
 
-            // Trail colour ASR settings
-            const std::string trailColourUserSettingKey = "HistoryTrailColour";
+        // Trail colour ASR settings
+        const std::string trailColourUserSettingKey = "HistoryTrailColour";
 
-            const std::string trailColourUserSettingDescription = "UKCP History Trail Colour";
+        const std::string trailColourUserSettingDescription = "UKCP History Trail Colour";
 
-            // Min altitude filter settings
-            const std::string minAltitudeFilterUserSettingKey = "HistoryTrailMinAltitudeFilter";
-            const std::string minAltitudeFilterUserSettingDescription = "UKCP Minimum History Trail Altitude";
+        // Min altitude filter settings
+        const std::string minAltitudeFilterUserSettingKey = "HistoryTrailMinAltitudeFilter";
+        const std::string minAltitudeFilterUserSettingDescription = "UKCP Minimum History Trail Altitude";
 
-            // Max altitude filter settings
-            const std::string maxAltitudeFilterUserSettingKey = "HistoryTrailMaxAltitudeFilter";
-            const std::string maxAltitudeFilterUserSettingDescription = "UKCP Maximum History Trail Altitude";
+        // Max altitude filter settings
+        const std::string maxAltitudeFilterUserSettingKey = "HistoryTrailMaxAltitudeFilter";
+        const std::string maxAltitudeFilterUserSettingDescription = "UKCP Maximum History Trail Altitude";
 
-            // Dot filler settings
-            const std::string dotFillUserSettingKey = "HistoryTrailDotFill";
-            const std::string dotFillUserSettingDescription = "UKCP History Trail Filled Dots";
+        // Dot filler settings
+        const std::string dotFillUserSettingKey = "HistoryTrailDotFill";
+        const std::string dotFillUserSettingDescription = "UKCP History Trail Filled Dots";
 
-            // Dot rotation settings
-            const std::string dotRotateUserSettingKey = "HistoryTrailDotTotate";
-            const std::string dotRotateUserSettingDescription = "UKCP History Trail Rotated Dots";
+        // Dot rotation settings
+        const std::string dotRotateUserSettingKey = "HistoryTrailDotTotate";
+        const std::string dotRotateUserSettingDescription = "UKCP History Trail Rotated Dots";
 
-            // The module menu text
-            const std::string menuItemDescription = "Configure History Trails";
+        // The module menu text
+        const std::string menuItemDescription = "Configure History Trails";
 
-            // The minimum groundspeed to display history trails for.
-            const int minimumSpeed = 50;
+        // The minimum groundspeed to display history trails for.
+        const int minimumSpeed = 50;
 
-            // Diamond trail type
-            const int trailTypeDiamond = 0;
+        // Diamond trail type
+        const int trailTypeDiamond = 0;
 
-            // Square trail type
-            const int trailTypeSquare = 1;
+        // Square trail type
+        const int trailTypeSquare = 1;
 
-            // Circle trail type
-            const int trailTypeCircle = 2;
+        // Circle trail type
+        const int trailTypeCircle = 2;
 
-            // Line trail type
-            const int trailTypeLine = 3;
+        // Line trail type
+        const int trailTypeLine = 3;
 
-            // Default minimum altitude for altitude filter
-            const int defaultMinAltitude = 0;
+        // Default minimum altitude for altitude filter
+        const int defaultMinAltitude = 0;
 
-            // Default max altitude for altitude filter
-            const int defaultMaxAltitude = 99999;
+        // Default max altitude for altitude filter
+        const int defaultMaxAltitude = 99999;
 
-            private:
-            [[nodiscard]] auto GetDoDotFunction() const
-                -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
-            [[nodiscard]] auto GetFillDotFunction() const
-                -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
-            [[nodiscard]] auto GetDrawDotFunction() const
-                -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
+        private:
+        [[nodiscard]] auto GetDoDotFunction() const
+            -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
+        [[nodiscard]] auto GetFillDotFunction() const
+            -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
+        [[nodiscard]] auto GetDrawDotFunction() const
+            -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
 
-            // Handles dialogs
-            const Dialog::DialogManager& dialogManager;
+        // Handles dialogs
+        const Dialog::DialogManager& dialogManager;
 
-            // The plugin, so we can check altitudes
-            Euroscope::EuroscopePluginLoopbackInterface& plugin;
+        // The plugin, so we can check altitudes
+        Euroscope::EuroscopePluginLoopbackInterface& plugin;
 
-            // The history trail repository
-            const HistoryTrailRepository& trails;
+        // The history trail repository
+        const HistoryTrailRepository& trails;
 
-            // The colour to draw the trails with (or just the first colour, if fading)
-            std::unique_ptr<Gdiplus::Color> startColour;
+        // The colour to draw the trails with (or just the first colour, if fading)
+        std::unique_ptr<Gdiplus::Color> startColour;
 
-            // The pen with which to draw the trails
-            std::unique_ptr<Gdiplus::Pen> pen;
+        // The pen with which to draw the trails
+        std::unique_ptr<Gdiplus::Pen> pen;
 
-            // The brush with which to draw the trails
-            std::unique_ptr<Gdiplus::SolidBrush> brush;
+        // The brush with which to draw the trails
+        std::unique_ptr<Gdiplus::SolidBrush> brush;
 
-            // Whether or not we should render the trails.
-            bool visible;
+        // Whether or not we should render the trails.
+        bool visible;
 
-            // The type of history trail.
-            int historyTrailType;
+        // The type of history trail.
+        int historyTrailType;
 
-            // History trail dotsize as a float
-            float historyTrailDotSizeFloat;
+        // History trail dotsize as a float
+        float historyTrailDotSizeFloat;
 
-            // The size of each history trail dot
-            int historyTrailDotSize;
+        // The size of each history trail dot
+        int historyTrailDotSize;
 
-            // Whether trails should degrade over time
-            bool degradingTrails;
+        // Whether trails should degrade over time
+        bool degradingTrails;
 
-            // Whether or not trails should fade over time
-            bool fadingTrails;
+        // Whether or not trails should fade over time
+        bool fadingTrails;
 
-            // Whether or not trails should use antialiasing
-            bool antialiasedTrails;
+        // Whether or not trails should use antialiasing
+        bool antialiasedTrails;
 
-            // Should the dots be filled
-            bool filledDots;
+        // Should the dots be filled
+        bool filledDots;
 
-            // Should the dots be rotated
-            bool rotatedDots;
+        // Should the dots be rotated
+        bool rotatedDots;
 
-            // The length of trail to render
-            int historyTrailLength;
+        // The length of trail to render
+        int historyTrailLength;
 
-            // The amount of alpha to reduce per dot
-            int alphaPerDot;
+        // The amount of alpha to reduce per dot
+        int alphaPerDot;
 
-            // The altitude at and below which not to display
-            int minimumDisplayAltitude;
+        // The altitude at and below which not to display
+        int minimumDisplayAltitude;
 
-            // The altitude at and above which not to display
-            int maximumDisplayAltitude;
+        // The altitude at and above which not to display
+        int maximumDisplayAltitude;
 
-            // The dot command for opening the configuration modal.
-            const std::string dotCommand = ".ukcp h";
+        // The dot command for opening the configuration modal.
+        const std::string dotCommand = ".ukcp h";
 
-            // Function for drawing the dot - saved as a lambda so we dont have to keep checking the trail type
-            std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)> drawDot;
-        };
-    } // namespace HistoryTrail
-} // namespace UKControllerPlugin
+        // Function for drawing the dot - saved as a lambda so we dont have to keep checking the trail type
+        std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)> drawDot;
+    };
+} // namespace UKControllerPlugin::HistoryTrail

--- a/src/plugin/historytrail/HistoryTrailRenderer.h
+++ b/src/plugin/historytrail/HistoryTrailRenderer.h
@@ -158,10 +158,12 @@ namespace UKControllerPlugin {
             const int defaultMaxAltitude = 99999;
 
             private:
-            void DrawDot(Windows::GdiGraphicsInterface& graphics, Gdiplus::Pen& pen, const Gdiplus::RectF& area);
-
-            void FillDot(Windows::GdiGraphicsInterface& graphics, Gdiplus::Brush& brush, const Gdiplus::RectF& area);
-            void DoDot(Windows::GdiGraphicsInterface& graphics, const Gdiplus::RectF& area);
+            [[nodiscard]] auto GetDoDotFunction() const
+                -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
+            [[nodiscard]] auto GetFillDotFunction() const
+                -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
+            [[nodiscard]] auto GetDrawDotFunction() const
+                -> std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)>;
 
             // Handles dialogs
             const Dialog::DialogManager& dialogManager;
@@ -222,6 +224,9 @@ namespace UKControllerPlugin {
 
             // The dot command for opening the configuration modal.
             const std::string dotCommand = ".ukcp h";
+
+            // Function for drawing the dot - saved as a lambda so we dont have to keep checking the trail type
+            std::function<void(Windows::GdiGraphicsInterface&, const Gdiplus::RectF&)> drawDot;
         };
     } // namespace HistoryTrail
 } // namespace UKControllerPlugin

--- a/src/plugin/historytrail/HistoryTrailRepository.h
+++ b/src/plugin/historytrail/HistoryTrailRepository.h
@@ -1,41 +1,43 @@
 #pragma once
 
-namespace UKControllerPlugin {
-    namespace HistoryTrail {
+namespace UKControllerPlugin::HistoryTrail {
 
-        // Pre-declarations in the namespace
-        class AircraftHistoryTrail;
-        // END
+    // Pre-declarations in the namespace
+    class AircraftHistoryTrail;
+    // END
 
-        /*
-            This class stores all the history trails currently in use by the plugin.
-            It provides a public interface that allows other classes to register and unregister
-            aircraft, update aircraft positions and retrieve the trail.
-        */
-        class HistoryTrailRepository
+    /*
+        This class stores all the history trails currently in use by the plugin.
+        It provides a public interface that allows other classes to register and unregister
+        aircraft, update aircraft positions and retrieve the trail.
+    */
+    class HistoryTrailRepository
+    {
+        public:
+        [[nodiscard]] auto GetAircraft(const std::string& callsign) -> std::shared_ptr<AircraftHistoryTrail>;
+        [[nodiscard]] auto HasAircraft(const std::string& callsign) const -> bool;
+        void UnregisterAircraft(const std::string& callsign);
+        void RegisterAircraft(std::shared_ptr<AircraftHistoryTrail>);
+
+        // Public type definitions for a custom iterator over the class.
+        using HistoryTrails = std::vector<std::shared_ptr<AircraftHistoryTrail>>;
+        using const_iterator = HistoryTrails::const_iterator;
+
+        [[nodiscard]] auto cbegin() const -> const_iterator
         {
-            public:
-            HistoryTrailRepository(void);
-            ~HistoryTrailRepository(void);
-            std::shared_ptr<AircraftHistoryTrail> GetAircraft(std::string callsign);
-            bool HasAircraft(std::string callsign) const;
-            void UnregisterAircraft(std::string callsign);
-            void RegisterAircraft(std::shared_ptr<AircraftHistoryTrail>);
+            return trailData.cbegin();
+        }
 
-            // Public type definitions for a custom iterator over the class.
-            typedef std::map<std::string, std::shared_ptr<AircraftHistoryTrail>> HistoryTrails;
-            typedef HistoryTrails::const_iterator const_iterator;
-            const_iterator cbegin(void) const
-            {
-                return trailData.cbegin();
-            }
-            const_iterator cend(void) const
-            {
-                return trailData.cend();
-            }
+        [[nodiscard]] auto cend() const -> const_iterator
+        {
+            return trailData.cend();
+        }
 
-            // Map of callsign to history trail
-            HistoryTrails trailData;
-        };
-    } // namespace HistoryTrail
-} // namespace UKControllerPlugin
+        // Map of callsign to history trail
+        HistoryTrails trailData;
+
+        private:
+        // Unordered map of callsign to trail, for ease of lookup and update.
+        std::unordered_map<std::string, std::shared_ptr<AircraftHistoryTrail>> trailMap;
+    };
+} // namespace UKControllerPlugin::HistoryTrail

--- a/test/plugin/historytrail/AircraftHistoryTrailTest.cpp
+++ b/test/plugin/historytrail/AircraftHistoryTrailTest.cpp
@@ -1,133 +1,130 @@
 #include "historytrail/AircraftHistoryTrail.h"
-#include "euroscope/EuroScopePlugIn.h"
 
 using UKControllerPlugin::HistoryTrail::AircraftHistoryTrail;
 
-namespace UKControllerPluginTest {
-    namespace HistoryTrail {
+namespace UKControllerPluginTest::HistoryTrail {
 
-        TEST(HistoryTrail, AddItemAddsItemQueueEmpty)
-        {
-            AircraftHistoryTrail history("test");
+    TEST(HistoryTrail, AddItemAddsItemQueueEmpty)
+    {
+        AircraftHistoryTrail history("test");
 
-            // Create a fake position
-            EuroScopePlugIn::CPosition positionTest;
-            positionTest.m_Latitude = 1;
-            positionTest.m_Longitude = 2;
+        // Create a fake position
+        EuroScopePlugIn::CPosition positionTest;
+        positionTest.m_Latitude = 1;
+        positionTest.m_Longitude = 2;
 
-            // Add to the history trail, then get the trail to check values.
-            history.AddItem({123, positionTest});
-            auto trail = history.GetTrail();
+        // Add to the history trail, then get the trail to check values.
+        history.AddItem({123, positionTest});
+        auto trail = history.GetTrail();
 
-            // Check the trail.
-            EXPECT_EQ(1, trail.size());
-            EXPECT_EQ(1, trail.front().position.m_Latitude);
-            EXPECT_EQ(2, trail.front().position.m_Longitude);
-            EXPECT_EQ(123, trail.front().heading);
-        }
+        // Check the trail.
+        EXPECT_EQ(1, trail.size());
+        EXPECT_EQ(1, trail.front().position.m_Latitude);
+        EXPECT_EQ(2, trail.front().position.m_Longitude);
+        EXPECT_EQ(123, trail.front().heading);
+    }
 
-        TEST(HistoryTrail, AddItemAddsItemIfQueueNotFull)
-        {
-            AircraftHistoryTrail history("test");
+    TEST(HistoryTrail, AddItemAddsItemIfQueueNotFull)
+    {
+        AircraftHistoryTrail history("test");
 
-            // Create a fake position
-            EuroScopePlugIn::CPosition positionTest;
-            positionTest.m_Latitude = 1;
-            positionTest.m_Longitude = 2;
+        // Create a fake position
+        EuroScopePlugIn::CPosition positionTest;
+        positionTest.m_Latitude = 1;
+        positionTest.m_Longitude = 2;
 
-            // Add to the history trail, then get the trail to check values.
-            history.AddItem({123, positionTest});
-            auto trail = history.GetTrail();
+        // Add to the history trail, then get the trail to check values.
+        history.AddItem({123, positionTest});
+        auto trail = history.GetTrail();
 
-            // Check the trail.
-            EXPECT_EQ(1, trail.size());
-            EXPECT_EQ(1, trail.front().position.m_Latitude);
-            EXPECT_EQ(2, trail.front().position.m_Longitude);
-            EXPECT_EQ(123, trail.front().heading);
-        }
+        // Check the trail.
+        EXPECT_EQ(1, trail.size());
+        EXPECT_EQ(1, trail.front().position.m_Latitude);
+        EXPECT_EQ(2, trail.front().position.m_Longitude);
+        EXPECT_EQ(123, trail.front().heading);
+    }
 
-        TEST(HistoryTrail, AddItemAddsItemIfQueueNotFullBoundary)
-        {
-            AircraftHistoryTrail history("test");
+    TEST(HistoryTrail, AddItemAddsItemIfQueueNotFullBoundary)
+    {
+        AircraftHistoryTrail history("test");
 
-            // Create a fake position
-            EuroScopePlugIn::CPosition positionTest;
-            positionTest.m_Latitude = 1;
-            positionTest.m_Longitude = 2;
+        // Create a fake position
+        EuroScopePlugIn::CPosition positionTest;
+        positionTest.m_Latitude = 1;
+        positionTest.m_Longitude = 2;
 
-            // Add to the history trail, then get the trail to check values.
-            history.AddItem({123, positionTest});
-            auto trail = history.GetTrail();
+        // Add to the history trail, then get the trail to check values.
+        history.AddItem({123, positionTest});
+        auto trail = history.GetTrail();
 
-            // Check the trail.
-            EXPECT_EQ(1, trail.size());
-            EXPECT_EQ(1, trail.front().position.m_Latitude);
-            EXPECT_EQ(2, trail.front().position.m_Longitude);
-            EXPECT_EQ(123, trail.front().heading);
-        }
+        // Check the trail.
+        EXPECT_EQ(1, trail.size());
+        EXPECT_EQ(1, trail.front().position.m_Latitude);
+        EXPECT_EQ(2, trail.front().position.m_Longitude);
+        EXPECT_EQ(123, trail.front().heading);
+    }
 
-        TEST(HistoryTrail, AddItemTrailItemsMaintainOrder)
-        {
-            AircraftHistoryTrail history("test");
+    TEST(HistoryTrail, AddItemTrailItemsMaintainOrder)
+    {
+        AircraftHistoryTrail history("test");
 
-            // Create a fake position
-            EuroScopePlugIn::CPosition positionTestFirst;
-            positionTestFirst.m_Latitude = 1;
-            positionTestFirst.m_Longitude = 2;
+        // Create a fake position
+        EuroScopePlugIn::CPosition positionTestFirst;
+        positionTestFirst.m_Latitude = 1;
+        positionTestFirst.m_Longitude = 2;
 
-            EuroScopePlugIn::CPosition positionTestSecond;
-            positionTestSecond.m_Latitude = 3;
-            positionTestSecond.m_Longitude = 4;
+        EuroScopePlugIn::CPosition positionTestSecond;
+        positionTestSecond.m_Latitude = 3;
+        positionTestSecond.m_Longitude = 4;
 
-            // Add to the history trail, then get the trail to check values.
+        // Add to the history trail, then get the trail to check values.
+        history.AddItem({123, positionTestFirst});
+        history.AddItem({456, positionTestSecond});
+        auto trail = history.GetTrail();
+
+        // Check the trail.
+        EXPECT_EQ(2, trail.size());
+
+        // First item
+        EXPECT_EQ(1, trail.back().position.m_Latitude);
+        EXPECT_EQ(2, trail.back().position.m_Longitude);
+        EXPECT_EQ(123, trail.back().heading);
+
+        // Second item
+        trail.pop_back();
+        EXPECT_EQ(3, trail.back().position.m_Latitude);
+        EXPECT_EQ(4, trail.back().position.m_Longitude);
+        EXPECT_EQ(456, trail.back().heading);
+    }
+
+    TEST(HistoryTrail, AddItemTrailRemovesLastItemIfFull)
+    {
+        AircraftHistoryTrail history("test");
+
+        // Create a fake position
+        EuroScopePlugIn::CPosition positionTestFirst;
+        positionTestFirst.m_Latitude = 1;
+        positionTestFirst.m_Longitude = 2;
+
+        EuroScopePlugIn::CPosition positionTestSecond;
+        positionTestSecond.m_Latitude = 3;
+        positionTestSecond.m_Longitude = 4;
+
+        // Fill up the trail with the first value
+        for (unsigned int i = 0; i < history.maxSize; i++) {
             history.AddItem({123, positionTestFirst});
-            history.AddItem({456, positionTestSecond});
-            auto trail = history.GetTrail();
-
-            // Check the trail.
-            EXPECT_EQ(2, trail.size());
-
-            // First item
-            EXPECT_EQ(1, trail.back().position.m_Latitude);
-            EXPECT_EQ(2, trail.back().position.m_Longitude);
-            EXPECT_EQ(123, trail.back().heading);
-
-            // Second item
-            trail.pop_back();
-            EXPECT_EQ(3, trail.back().position.m_Latitude);
-            EXPECT_EQ(4, trail.back().position.m_Longitude);
-            EXPECT_EQ(456, trail.back().heading);
         }
 
-        TEST(HistoryTrail, AddItemTrailRemovesLastItemIfFull)
-        {
-            AircraftHistoryTrail history("test");
+        // Add a second value to test with
+        history.AddItem({456, positionTestSecond});
+        auto trail = history.GetTrail();
 
-            // Create a fake position
-            EuroScopePlugIn::CPosition positionTestFirst;
-            positionTestFirst.m_Latitude = 1;
-            positionTestFirst.m_Longitude = 2;
+        // Check the trail.
+        EXPECT_EQ(history.maxSize, trail.size());
 
-            EuroScopePlugIn::CPosition positionTestSecond;
-            positionTestSecond.m_Latitude = 3;
-            positionTestSecond.m_Longitude = 4;
-
-            // Fill up the trail with the first value
-            for (unsigned int i = 0; i < history.maxSize; i++) {
-                history.AddItem({123, positionTestFirst});
-            }
-
-            // Add a second value to test with
-            history.AddItem({456, positionTestSecond});
-            auto trail = history.GetTrail();
-
-            // Check the trail.
-            EXPECT_EQ(history.maxSize, trail.size());
-
-            // First item
-            EXPECT_EQ(3, trail.front().position.m_Latitude);
-            EXPECT_EQ(4, trail.front().position.m_Longitude);
-            EXPECT_EQ(456, trail.front().heading);
-        }
-    } // namespace HistoryTrail
-} // namespace UKControllerPluginTest
+        // First item
+        EXPECT_EQ(3, trail.front().position.m_Latitude);
+        EXPECT_EQ(4, trail.front().position.m_Longitude);
+        EXPECT_EQ(456, trail.front().heading);
+    }
+} // namespace UKControllerPluginTest::HistoryTrail

--- a/test/plugin/historytrail/AircraftHistoryTrailTest.cpp
+++ b/test/plugin/historytrail/AircraftHistoryTrailTest.cpp
@@ -86,12 +86,11 @@ namespace UKControllerPluginTest::HistoryTrail {
         EXPECT_EQ(2, trail.size());
 
         // First item
-        EXPECT_EQ(1, trail.back().position.m_Latitude);
-        EXPECT_EQ(2, trail.back().position.m_Longitude);
-        EXPECT_EQ(123, trail.back().heading);
+        EXPECT_EQ(1, trail.front().position.m_Latitude);
+        EXPECT_EQ(2, trail.front().position.m_Longitude);
+        EXPECT_EQ(123, trail.front().heading);
 
         // Second item
-        trail.pop_back();
         EXPECT_EQ(3, trail.back().position.m_Latitude);
         EXPECT_EQ(4, trail.back().position.m_Longitude);
         EXPECT_EQ(456, trail.back().heading);
@@ -123,8 +122,8 @@ namespace UKControllerPluginTest::HistoryTrail {
         EXPECT_EQ(history.maxSize, trail.size());
 
         // First item
-        EXPECT_EQ(3, trail.front().position.m_Latitude);
-        EXPECT_EQ(4, trail.front().position.m_Longitude);
-        EXPECT_EQ(456, trail.front().heading);
+        EXPECT_EQ(3, trail.back().position.m_Latitude);
+        EXPECT_EQ(4, trail.back().position.m_Longitude);
+        EXPECT_EQ(456, trail.back().heading);
     }
 } // namespace UKControllerPluginTest::HistoryTrail

--- a/test/plugin/historytrail/HistoryTrailRepositoryTest.cpp
+++ b/test/plugin/historytrail/HistoryTrailRepositoryTest.cpp
@@ -1,42 +1,41 @@
-#include "historytrail/HistoryTrailRepository.h"
 #include "historytrail/AircraftHistoryTrail.h"
+#include "historytrail/HistoryTrailRepository.h"
 
 using ::testing::Test;
 using UKControllerPlugin::HistoryTrail::AircraftHistoryTrail;
 using UKControllerPlugin::HistoryTrail::HistoryTrailRepository;
 
-namespace UKControllerPluginTest {
-    namespace HistoryTrail {
+namespace UKControllerPluginTest::HistoryTrail {
+    class HistoryTrailRepositoryTest : public Test
+    {
+        public:
+        HistoryTrailRepository repository;
+    };
 
-        class HistoryTrailRepositoryTest : public Test
-        {
-            public:
-            HistoryTrailRepository repository;
-        };
+    TEST_F(HistoryTrailRepositoryTest, ItDoesntHaveAircraftItDoesntHave)
+    {
+        EXPECT_FALSE(repository.HasAircraft("test"));
+    }
 
-        TEST_F(HistoryTrailRepositoryTest, ItDoesntHaveAircraftItDoesntHave)
-        {
-            EXPECT_FALSE(repository.HasAircraft("test"));
-        }
+    TEST_F(HistoryTrailRepositoryTest, ItCanRegisterAnAircraft)
+    {
+        repository.RegisterAircraft(std::make_shared<AircraftHistoryTrail>("test"));
+        EXPECT_TRUE(repository.HasAircraft("test"));
+        EXPECT_EQ(1, repository.trailData.size());
+    }
 
-        TEST_F(HistoryTrailRepositoryTest, ItCanRegisterAnAircraft)
-        {
-            repository.RegisterAircraft(std::make_shared<AircraftHistoryTrail>("test"));
-            EXPECT_TRUE(repository.HasAircraft("test"));
-        }
+    TEST_F(HistoryTrailRepositoryTest, ItCanUnregisterAnAircraft)
+    {
+        repository.RegisterAircraft(std::make_shared<AircraftHistoryTrail>("test"));
+        repository.UnregisterAircraft("test");
+        EXPECT_FALSE(repository.HasAircraft("test"));
+        EXPECT_EQ(0, repository.trailData.size());
+    }
 
-        TEST_F(HistoryTrailRepositoryTest, ItCanUnregisterAnAircraft)
-        {
-            repository.RegisterAircraft(std::make_shared<AircraftHistoryTrail>("test"));
-            repository.UnregisterAircraft("test");
-            EXPECT_FALSE(repository.HasAircraft("test"));
-        }
-
-        TEST_F(HistoryTrailRepositoryTest, ItCanReturnAircraft)
-        {
-            std::shared_ptr<AircraftHistoryTrail> trail = std::make_shared<AircraftHistoryTrail>("test");
-            repository.RegisterAircraft(trail);
-            EXPECT_EQ(trail, repository.GetAircraft("test"));
-        }
-    } // namespace HistoryTrail
-} // namespace UKControllerPluginTest
+    TEST_F(HistoryTrailRepositoryTest, ItCanReturnAircraft)
+    {
+        std::shared_ptr<AircraftHistoryTrail> trail = std::make_shared<AircraftHistoryTrail>("test");
+        repository.RegisterAircraft(trail);
+        EXPECT_EQ(trail, repository.GetAircraft("test"));
+    }
+} // namespace UKControllerPluginTest::HistoryTrail


### PR DESCRIPTION
Improves performance of history trail rendering by approx. 25%

- Rather than do a bunch of if-statements on each dot to decide what kind of dot to draw on each pass, we can calculate (as a lambda) what the draw is ahead of time, whenever the ASR is loaded, or the configuration menu is saved.
- Rather than check if the dot is the first on each iteration, we start iterating from the second.
- Skip iteration altogether if there's only one dot.
- The "reduce per dot" for degrading trails can be calculated up-front.
- Change the storage mechanism of trails themselves to be a Vector rather than a Deque - this is better suited to the types of iteration we do in history trails.