### PR TITLE
fix: history trail dots disappearing

### DIFF
--- a/src/plugin/historytrail/HistoryTrailRenderer.cpp
+++ b/src/plugin/historytrail/HistoryTrailRenderer.cpp
@@ -279,7 +279,7 @@ namespace UKControllerPlugin::HistoryTrail {
             // If there's one or fewer dots, they're not going fast enough or are off the screen, don't display the
             // trail.
             if (trail.size() < 2 || radarScreen.GetGroundspeedForCallsign(callsign) < this->minimumSpeed ||
-                radarScreen.PositionOffScreen(aircraft->GetTrail().begin()->position) ||
+                radarScreen.PositionOffScreen(aircraft->GetTrail().rbegin()->position) ||
                 radarTarget->GetFlightLevel() < this->minimumDisplayAltitude ||
                 radarTarget->GetFlightLevel() > this->maximumDisplayAltitude) {
                 continue;


### PR DESCRIPTION
Caused by the change in direction of the trail dots, when the trails got sufficiently long, the "begin" dot, which was the last in the trail would go offscreen, causing the trail not to be shown.