### PR TITLE
ECFMP Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "third_party/cpp-httplib"]
 	path = third_party/cpp-httplib
 	url = git@github.com:yhirose/cpp-httplib.git
+[submodule "third_party/ecfmp"]
+	path = third_party/ecfmp
+	url = git@github.com:ECFMP/plugin.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 ################################################################################
 # Sub-projects
 ################################################################################
+add_subdirectory(third_party/ecfmp/src)
 add_subdirectory(src/loader)
 add_subdirectory(src/plugin)
 add_subdirectory(src/updater)

--- a/docs/TAG_FUNCTIONS.md
+++ b/docs/TAG_FUNCTIONS.md
@@ -23,3 +23,4 @@
 9020 - Trigger Missed Approach
 9021 - Acknowledge Missed Approach
 9022 - Open Squawk Assignment Menu
+9023 - Display Relevant ECFMP Flow Measures

--- a/docs/TAG_ITEMS.md
+++ b/docs/TAG_ITEMS.md
@@ -30,3 +30,4 @@
 128 - SELCAL Code
 129 - SELCAL Code With Separator
 130 - Missed Approach Indicator
+131 - Relevant ECFMP Flow Measures 

--- a/resource/UKControllerPlugin.rc
+++ b/resource/UKControllerPlugin.rc
@@ -359,6 +359,15 @@ BEGIN
     LTEXT           "Please go to your web browser and log in to the UK Controller Plugin page. This window will close automatically once your API key has been received. If you are unable to find the page, you can click the button below to re-open it.",IDC_API_KEY_STATIC,7,7,249,89
 END
 
+IDD_FLOW_MEASURE_LIST DIALOGEX 0, 0, 367, 297
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Dialog"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "Close",IDOK,310,276,50,14
+    EDITTEXT        IDC_FLOW_MEASURES_INFO,7,7,353,264,ES_MULTILINE | ES_AUTOHSCROLL | ES_READONLY | WS_VSCROLL
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -497,6 +506,14 @@ BEGIN
         TOPMARGIN, 7
         BOTTOMMARGIN, 120
     END
+
+    IDD_FLOW_MEASURE_LIST, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 360
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 290
+    END
 END
 #endif    // APSTUDIO_INVOKED
 
@@ -582,6 +599,11 @@ BEGIN
 END
 
 IDD_API_KEY_REPLACE AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_FLOW_MEASURE_LIST AFX_DIALOG_LAYOUT
 BEGIN
     0
 END

--- a/resource/resource.h
+++ b/resource/resource.h
@@ -30,6 +30,7 @@
 #define IDD_MISSED_APPROACH_ACKNOWLEDGE 139
 #define IDD_DEPARTURE_RELEASE_REJECT    141
 #define IDD_API_KEY_REPLACE             143
+#define IDD_FLOW_MEASURE_LIST           145
 #define IDC_CHECK_DEGRADING             1001
 #define IDC_CHECK_FADING                1002
 #define IDC_CHECK_AA                    1003
@@ -133,6 +134,7 @@
 #define IDC_DEPARTURE_RELEASE_APPROVE_CALLSIGN 1087
 #define MISSED_APPROACH_DRAW_DURATION   1087
 #define IDC_RELEASE_REJECT_REMARKS      1087
+#define IDC_FLOW_MEASURES_DETAILS       1087
 #define IDC_NOTES_STATIC                1088
 #define IDC_HOLD_PARAMS_MIN_STATIC      1089
 #define IDC_NOTIFICATION_BODY           1089
@@ -140,6 +142,7 @@
 #define IDC_HOLD_MIN_SPIN               1091
 #define IDC_HOLD_MAX                    1092
 #define IDC_HOLD_MAXIMUM                1092
+#define IDC_FLOW_MEASURES_INFO          1092
 #define IDC_SPIN2                       1093
 #define IDC_HOLD_MAX_SPIN               1093
 #define IDC_NOTIFICATION_LINK           1094
@@ -209,7 +212,7 @@
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        145
+#define _APS_NEXT_RESOURCE_VALUE        147
 #define _APS_NEXT_COMMAND_VALUE         40001
 #define _APS_NEXT_CONTROL_VALUE         1146
 #define _APS_NEXT_SYMED_VALUE           101

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -1,9 +1,6 @@
 set(PROJECT_NAME UKControllerPluginCore)
 project(UKControllerPluginCore)
 
-### Include ECFMP
-add_subdirectory("${PROJECT_SOURCE_DIR}/../../third_party/ecfmp/src" "third_party/ecfmp")
-
 ################################################################################
 # Source groups
 ################################################################################
@@ -179,6 +176,10 @@ set(src__dependency
     "dependency/UpdateDependencies.h"
 )
 source_group("src\\dependency" FILES ${src__dependency})
+
+set(src__ecfmp
+        
+        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h)
 
 set(src__euroscope
     "euroscope/AsrEventHandlerCollection.cpp"
@@ -979,6 +980,7 @@ set(ALL_FILES
     ${src__datablock}
     ${src__departure}
     ${src__dependency}
+    ${src__ecfmp}
     ${src__euroscope}
     ${src__eventhandler}
     ${src__flightinformationservice}

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -1,4 +1,8 @@
 set(PROJECT_NAME UKControllerPluginCore)
+project(UKControllerPluginCore)
+
+### Include ECFMP
+add_subdirectory("${PROJECT_SOURCE_DIR}/../../third_party/ecfmp/src" "third_party/ecfmp")
 
 ################################################################################
 # Source groups
@@ -1155,11 +1159,13 @@ endif()
 ################################################################################
 add_dependencies(${PROJECT_NAME}
     UKControllerPluginUtils
+    ecfmp_sdk
 )
 
 # Link with other targets.
 target_link_libraries(${PROJECT_NAME} PUBLIC
     UKControllerPluginUtils
+    ecfmp_sdk
 )
 
 set(ADDITIONAL_LIBRARY_DEPENDENCIES

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -179,7 +179,7 @@ source_group("src\\dependency" FILES ${src__dependency})
 
 set(src__ecfmp
         
-        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h ecfmp/AircraftFlowMeasureMap.cpp ecfmp/AircraftFlowMeasureMap.h ecfmp/AircraftFlowMeasureMapInterface.h ecfmp/AircraftFlowMeasureTagItem.cpp ecfmp/AircraftFlowMeasureTagItem.h ecfmp/ListAircraftFlowMeasures.cpp ecfmp/ListAircraftFlowMeasures.h ecfmp/AircraftFlowMeasuresDialog.cpp ecfmp/AircraftFlowMeasuresDialog.h ecfmp/HomeFirsFlowMeasureFilter.cpp ecfmp/HomeFirsFlowMeasureFilter.h)
+        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h ecfmp/AircraftFlowMeasureMap.cpp ecfmp/AircraftFlowMeasureMap.h ecfmp/AircraftFlowMeasureMapInterface.h ecfmp/AircraftFlowMeasureTagItem.cpp ecfmp/AircraftFlowMeasureTagItem.h ecfmp/ListAircraftFlowMeasures.cpp ecfmp/ListAircraftFlowMeasures.h ecfmp/AircraftFlowMeasuresDialog.cpp ecfmp/AircraftFlowMeasuresDialog.h ecfmp/HomeFirsFlowMeasureFilter.cpp ecfmp/HomeFirsFlowMeasureFilter.h ecfmp/ControllerFlowMeasureRelevance.cpp ecfmp/ControllerFlowMeasureRelevance.h ecfmp/ECFMPCustomMeasureFilterWrapper.cpp ecfmp/ECFMPCustomMeasureFilterWrapper.h ecfmp/ECFMPCustomMeasureFilter.h)
 
 set(src__euroscope
     "euroscope/AsrEventHandlerCollection.cpp"

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -179,7 +179,7 @@ source_group("src\\dependency" FILES ${src__dependency})
 
 set(src__ecfmp
         
-        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h ecfmp/AircraftFlowMeasureMap.cpp ecfmp/AircraftFlowMeasureMap.h ecfmp/AircraftFlowMeasureMapInterface.h ecfmp/AircraftFlowMeasureTagItem.cpp ecfmp/AircraftFlowMeasureTagItem.h)
+        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h ecfmp/AircraftFlowMeasureMap.cpp ecfmp/AircraftFlowMeasureMap.h ecfmp/AircraftFlowMeasureMapInterface.h ecfmp/AircraftFlowMeasureTagItem.cpp ecfmp/AircraftFlowMeasureTagItem.h ecfmp/ListAircraftFlowMeasures.cpp ecfmp/ListAircraftFlowMeasures.h ecfmp/AircraftFlowMeasuresDialog.cpp ecfmp/AircraftFlowMeasuresDialog.h ecfmp/HomeFirsFlowMeasureFilter.cpp ecfmp/HomeFirsFlowMeasureFilter.h)
 
 set(src__euroscope
     "euroscope/AsrEventHandlerCollection.cpp"

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -179,7 +179,7 @@ source_group("src\\dependency" FILES ${src__dependency})
 
 set(src__ecfmp
         
-        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h)
+        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h ecfmp/AircraftFlowMeasureMap.cpp ecfmp/AircraftFlowMeasureMap.h ecfmp/AircraftFlowMeasureMapInterface.h)
 
 set(src__euroscope
     "euroscope/AsrEventHandlerCollection.cpp"

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -179,7 +179,7 @@ source_group("src\\dependency" FILES ${src__dependency})
 
 set(src__ecfmp
         
-        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h ecfmp/AircraftFlowMeasureMap.cpp ecfmp/AircraftFlowMeasureMap.h ecfmp/AircraftFlowMeasureMapInterface.h)
+        ecfmp/ECFMPModuleFactory.cpp ecfmp/ECFMPModuleFactory.h ecfmp/Logger.cpp ecfmp/Logger.h ecfmp/HttpClient.cpp ecfmp/HttpClient.h ecfmp/ECFMPBootstrapProvider.cpp ecfmp/ECFMPBootstrapProvider.h ecfmp/TriggerEcfmpEventLoop.cpp ecfmp/TriggerEcfmpEventLoop.h ecfmp/AircraftFlowMeasureMap.cpp ecfmp/AircraftFlowMeasureMap.h ecfmp/AircraftFlowMeasureMapInterface.h ecfmp/AircraftFlowMeasureTagItem.cpp ecfmp/AircraftFlowMeasureTagItem.h)
 
 set(src__euroscope
     "euroscope/AsrEventHandlerCollection.cpp"

--- a/src/plugin/bootstrap/BootstrapProviderCollectionFactory.cpp
+++ b/src/plugin/bootstrap/BootstrapProviderCollectionFactory.cpp
@@ -1,6 +1,7 @@
 #include "BootstrapProviderCollection.h"
 #include "BootstrapProviderCollectionFactory.h"
 #include "approach/ApproachBootstrapProvider.h"
+#include "ecfmp/ECFMPBootstrapProvider.h"
 #include "intention/IntentionCodeBootstrapProvider.h"
 
 namespace UKControllerPlugin::Bootstrap {
@@ -8,6 +9,7 @@ namespace UKControllerPlugin::Bootstrap {
     {
         auto collection = std::make_unique<BootstrapProviderCollection>();
         collection->AddProvider(std::make_unique<Approach::ApproachBootstrapProvider>());
+        collection->AddProvider(std::make_unique<ECFMP::ECFMPBootstrapProvider>());
         collection->AddProvider(std::make_unique<IntentionCode::IntentionCodeBootstrapProvider>());
 
         return collection;

--- a/src/plugin/bootstrap/ModuleFactories.cpp
+++ b/src/plugin/bootstrap/ModuleFactories.cpp
@@ -1,5 +1,6 @@
 #include "ModuleFactories.h"
 #include "approach/ApproachModuleFactory.h"
+#include "ecfmp/ECFMPModuleFactory.h"
 #include "intention/IntentionCodeModuleFactory.h"
 
 namespace UKControllerPlugin::Bootstrap {
@@ -23,5 +24,14 @@ namespace UKControllerPlugin::Bootstrap {
         }
 
         return *intentionCode;
+    }
+
+    auto ModuleFactories::ECFMP() -> ECFMP::ECFMPModuleFactory&
+    {
+        if (!ecfmp) {
+            ecfmp = std::make_unique<ECFMP::ECFMPModuleFactory>();
+        }
+
+        return *ecfmp;
     }
 } // namespace UKControllerPlugin::Bootstrap

--- a/src/plugin/bootstrap/ModuleFactories.h
+++ b/src/plugin/bootstrap/ModuleFactories.h
@@ -4,6 +4,9 @@ namespace UKControllerPlugin {
     namespace Approach {
         class ApproachModuleFactory;
     } // namespace Approach
+    namespace ECFMP {
+        class ECFMPModuleFactory;
+    } // namespace ECFMP
     namespace IntentionCode {
         class IntentionCodeModuleFactory;
     } // namespace IntentionCode
@@ -23,11 +26,14 @@ namespace UKControllerPlugin::Bootstrap {
         ModuleFactories();
         ~ModuleFactories();
         [[nodiscard]] auto Approach() -> Approach::ApproachModuleFactory&;
+        [[nodiscard]] auto ECFMP() -> ECFMP::ECFMPModuleFactory&;
         [[nodiscard]] auto IntentionCode() -> IntentionCode::IntentionCodeModuleFactory&;
 
         private:
         // The approach module
         std::unique_ptr<Approach::ApproachModuleFactory> approach;
+
+        std::unique_ptr<ECFMP::ECFMPModuleFactory> ecfmp;
 
         // The intention code  module
         std::unique_ptr<IntentionCode::IntentionCodeModuleFactory> intentionCode;

--- a/src/plugin/ecfmp/AircraftFlowMeasureMap.cpp
+++ b/src/plugin/ecfmp/AircraftFlowMeasureMap.cpp
@@ -1,0 +1,143 @@
+#include "AircraftFlowMeasureMap.h"
+#include "ECFMP/flowmeasure/FlowMeasure.h"
+#include "euroscope/EuroScopeCFlightPlanInterface.h"
+#include "euroscope/EuroScopeCRadarTargetInterface.h"
+#include "euroscope/EuroscopePluginLoopbackInterface.h"
+
+namespace UKControllerPlugin::ECFMP {
+
+    struct AircraftFlowMeasureMap::Impl
+    {
+        Impl(Euroscope::EuroscopePluginLoopbackInterface& plugin) : plugin(plugin)
+        {
+        }
+
+        void RemoveFlightplanFromCollection(Euroscope::EuroScopeCFlightPlanInterface& flightplan)
+        {
+            // No flow measures are relevant to this flight plan
+            if (!callsignFlowMeasureMap.contains(flightplan.GetCallsign())) {
+                return;
+            }
+
+            // Remove the flight plan from the flow measure's callsign map
+            for (const auto& flowMeasure : callsignFlowMeasureMap.at(flightplan.GetCallsign())) {
+                flowMeasureCallsignMap.at(flowMeasure).erase(flightplan.GetCallsign());
+            }
+
+            // Remove the callsign from the callsign map
+            callsignFlowMeasureMap.erase(flightplan.GetCallsign());
+        }
+
+        void RemoveFlowMeasureFromCollection(const ::ECFMP::FlowMeasure::FlowMeasure& measure)
+        {
+            // Measure never became active
+            if (!flowMeasureIdMap.contains(measure.Id())) {
+                return;
+            }
+
+            const auto collectionMeasure = flowMeasureIdMap.at(measure.Id());
+
+            // Remove from the callsign map
+            for (const auto& callsign : flowMeasureCallsignMap.at(collectionMeasure)) {
+                callsignFlowMeasureMap.at(callsign).erase(collectionMeasure);
+            }
+
+            // Remove from the map by measure and id
+            flowMeasureCallsignMap.erase(collectionMeasure);
+            flowMeasureIdMap.erase(measure.Id());
+        }
+
+        void FlowMeasureActivated(const std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>& measure)
+        {
+            if (flowMeasureIdMap.contains(measure->Id())) {
+                LogWarning("Flow measure with id " + std::to_string(measure->Id()) + " already exists in the map");
+                return;
+            }
+
+            // Add the flow measure to the map by id
+            flowMeasureIdMap.emplace(measure->Id(), measure);
+
+            // Check each of the flightplans and see if it applies to them
+            plugin.ApplyFunctionToAllFlightplans([&measure, this](
+                                                     const Euroscope::EuroScopeCFlightPlanInterface& flightplan,
+                                                     const Euroscope::EuroScopeCRadarTargetInterface& radarTarget) {
+                if (measure->ApplicableToAircraft(flightplan.GetEuroScopeObject(), radarTarget.GetEuroScopeObject())) {
+                    callsignFlowMeasureMap[flightplan.GetCallsign()].insert(measure);
+                    flowMeasureCallsignMap[measure].insert(flightplan.GetCallsign());
+                }
+            });
+        }
+
+        void MapFlightplanToActiveFlowMeasures(
+            Euroscope::EuroScopeCFlightPlanInterface& flightPlan,
+            Euroscope::EuroScopeCRadarTargetInterface& radarTarget)
+        {
+            for (const auto& [id, measure] : flowMeasureIdMap) {
+                if (measure->ApplicableToAircraft(flightPlan.GetEuroScopeObject(), radarTarget.GetEuroScopeObject())) {
+                    callsignFlowMeasureMap[flightPlan.GetCallsign()].insert(measure);
+                    flowMeasureCallsignMap[measure].insert(flightPlan.GetCallsign());
+                }
+            }
+        }
+
+        // The plugin, used to map over flightplans
+        Euroscope::EuroscopePluginLoopbackInterface& plugin;
+
+        // Map of callsigns to flow measures and vice versa
+        std::map<int, std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>> flowMeasureIdMap;
+        std::map<std::string, std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>>
+            callsignFlowMeasureMap;
+        std::map<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>, std::unordered_set<std::string>>
+            flowMeasureCallsignMap;
+
+        // An empty set for use when we dont have a callsign
+        std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>> emptyFlowMeasureSet;
+    };
+
+    AircraftFlowMeasureMap::AircraftFlowMeasureMap(Euroscope::EuroscopePluginLoopbackInterface& plugin)
+        : impl(std::make_unique<Impl>(plugin))
+    {
+    }
+
+    AircraftFlowMeasureMap::~AircraftFlowMeasureMap() = default;
+
+    void AircraftFlowMeasureMap::OnEvent(const ::ECFMP::Plugin::FlowMeasureActivatedEvent& event)
+    {
+        impl->FlowMeasureActivated(event.flowMeasure);
+    }
+
+    void AircraftFlowMeasureMap::OnEvent(const ::ECFMP::Plugin::FlowMeasureExpiredEvent& event)
+    {
+        impl->RemoveFlowMeasureFromCollection(*event.flowMeasure);
+    }
+
+    void AircraftFlowMeasureMap::OnEvent(const ::ECFMP::Plugin::FlowMeasureWithdrawnEvent& event)
+    {
+        impl->RemoveFlowMeasureFromCollection(*event.flowMeasure);
+    }
+
+    void AircraftFlowMeasureMap::FlightPlanEvent(
+        Euroscope::EuroScopeCFlightPlanInterface& flightPlan, Euroscope::EuroScopeCRadarTargetInterface& radarTarget)
+    {
+        impl->RemoveFlightplanFromCollection(flightPlan);
+        impl->MapFlightplanToActiveFlowMeasures(flightPlan, radarTarget);
+    }
+
+    void AircraftFlowMeasureMap::FlightPlanDisconnectEvent(Euroscope::EuroScopeCFlightPlanInterface& flightPlan)
+    {
+        impl->RemoveFlightplanFromCollection(flightPlan);
+    }
+
+    const std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>&
+    AircraftFlowMeasureMap::GetFlowMeasuresForCallsign(const std::string& callsign)
+    {
+        return impl->callsignFlowMeasureMap.contains(callsign) ? impl->callsignFlowMeasureMap.at(callsign)
+                                                               : impl->emptyFlowMeasureSet;
+    }
+
+    void AircraftFlowMeasureMap::ControllerFlightPlanDataEvent(
+        Euroscope::EuroScopeCFlightPlanInterface& flightPlan, int dataType)
+    {
+        // No-op
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/AircraftFlowMeasureMap.cpp
+++ b/src/plugin/ecfmp/AircraftFlowMeasureMap.cpp
@@ -129,7 +129,7 @@ namespace UKControllerPlugin::ECFMP {
     }
 
     const std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>&
-    AircraftFlowMeasureMap::GetFlowMeasuresForCallsign(const std::string& callsign)
+    AircraftFlowMeasureMap::GetFlowMeasuresForCallsign(const std::string& callsign) const
     {
         return impl->callsignFlowMeasureMap.contains(callsign) ? impl->callsignFlowMeasureMap.at(callsign)
                                                                : impl->emptyFlowMeasureSet;

--- a/src/plugin/ecfmp/AircraftFlowMeasureMap.cpp
+++ b/src/plugin/ecfmp/AircraftFlowMeasureMap.cpp
@@ -1,4 +1,5 @@
 #include "AircraftFlowMeasureMap.h"
+#include "controller/ActiveCallsign.h"
 #include "ECFMP/flowmeasure/FlowMeasure.h"
 #include "euroscope/EuroScopeCFlightPlanInterface.h"
 #include "euroscope/EuroScopeCRadarTargetInterface.h"
@@ -80,6 +81,13 @@ namespace UKControllerPlugin::ECFMP {
             }
         }
 
+        void ClearMaps()
+        {
+            flowMeasureIdMap.clear();
+            callsignFlowMeasureMap.clear();
+            flowMeasureCallsignMap.clear();
+        }
+
         // The plugin, used to map over flightplans
         Euroscope::EuroscopePluginLoopbackInterface& plugin;
 
@@ -139,5 +147,25 @@ namespace UKControllerPlugin::ECFMP {
         Euroscope::EuroScopeCFlightPlanInterface& flightPlan, int dataType)
     {
         // No-op
+    }
+
+    void AircraftFlowMeasureMap::ActiveCallsignAdded(const Controller::ActiveCallsign& callsign)
+    {
+        // Only interested in user callsigns
+        if (!callsign.GetIsUser()) {
+            return;
+        }
+
+        impl->ClearMaps();
+    }
+
+    void AircraftFlowMeasureMap::ActiveCallsignRemoved(const Controller::ActiveCallsign& callsign)
+    {
+        // Only interested in user callsigns
+        if (!callsign.GetIsUser()) {
+            return;
+        }
+
+        impl->ClearMaps();
     }
 } // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/AircraftFlowMeasureMap.h
+++ b/src/plugin/ecfmp/AircraftFlowMeasureMap.h
@@ -30,7 +30,7 @@ namespace UKControllerPlugin::ECFMP {
         void OnEvent(const ::ECFMP::Plugin::FlowMeasureActivatedEvent& event) override;
         void OnEvent(const ::ECFMP::Plugin::FlowMeasureExpiredEvent& event) override;
         void OnEvent(const ::ECFMP::Plugin::FlowMeasureWithdrawnEvent& event) override;
-        auto GetFlowMeasuresForCallsign(const std::string& callsign)
+        auto GetFlowMeasuresForCallsign(const std::string& callsign) const
             -> const std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>& override;
 
         private:

--- a/src/plugin/ecfmp/AircraftFlowMeasureMap.h
+++ b/src/plugin/ecfmp/AircraftFlowMeasureMap.h
@@ -1,9 +1,8 @@
 #pragma once
-#include <string>
-#include <unordered_set>
 #include "ECFMP/SdkEvents.h"
 #include "ECFMP/flowmeasure/FlowMeasure.h"
 #include "AircraftFlowMeasureMapInterface.h"
+#include "controller/ActiveCallsignEventHandlerInterface.h"
 #include "euroscope/EuroscopePluginLoopbackInterface.h"
 #include "flightplan/FlightPlanEventHandlerInterface.h"
 
@@ -16,7 +15,8 @@ namespace UKControllerPlugin::ECFMP {
                                    public ::ECFMP::EventBus::EventListener<::ECFMP::Plugin::FlowMeasureExpiredEvent>,
                                    public ::ECFMP::EventBus::EventListener<::ECFMP::Plugin::FlowMeasureWithdrawnEvent>,
                                    public Flightplan::FlightPlanEventHandlerInterface,
-                                   public AircraftFlowMeasureMapInterface
+                                   public AircraftFlowMeasureMapInterface,
+                                   public Controller::ActiveCallsignEventHandlerInterface
     {
         public:
         AircraftFlowMeasureMap(Euroscope::EuroscopePluginLoopbackInterface& plugin);
@@ -26,6 +26,8 @@ namespace UKControllerPlugin::ECFMP {
             UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface& radarTarget) override;
         void
         FlightPlanDisconnectEvent(UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightPlan) override;
+        void ActiveCallsignAdded(const Controller::ActiveCallsign& callsign) override;
+        void ActiveCallsignRemoved(const Controller::ActiveCallsign& callsign) override;
         void ControllerFlightPlanDataEvent(Euroscope::EuroScopeCFlightPlanInterface& flightPlan, int dataType) override;
         void OnEvent(const ::ECFMP::Plugin::FlowMeasureActivatedEvent& event) override;
         void OnEvent(const ::ECFMP::Plugin::FlowMeasureExpiredEvent& event) override;

--- a/src/plugin/ecfmp/AircraftFlowMeasureMap.h
+++ b/src/plugin/ecfmp/AircraftFlowMeasureMap.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <string>
+#include <unordered_set>
+#include "ECFMP/SdkEvents.h"
+#include "ECFMP/flowmeasure/FlowMeasure.h"
+#include "AircraftFlowMeasureMapInterface.h"
+#include "euroscope/EuroscopePluginLoopbackInterface.h"
+#include "flightplan/FlightPlanEventHandlerInterface.h"
+
+namespace UKControllerPlugin::Euroscope {
+    class EuroscopePluginLoopbackInterface;
+} // namespace UKControllerPlugin::Euroscope
+
+namespace UKControllerPlugin::ECFMP {
+    class AircraftFlowMeasureMap : public ::ECFMP::EventBus::EventListener<::ECFMP::Plugin::FlowMeasureActivatedEvent>,
+                                   public ::ECFMP::EventBus::EventListener<::ECFMP::Plugin::FlowMeasureExpiredEvent>,
+                                   public ::ECFMP::EventBus::EventListener<::ECFMP::Plugin::FlowMeasureWithdrawnEvent>,
+                                   public Flightplan::FlightPlanEventHandlerInterface,
+                                   public AircraftFlowMeasureMapInterface
+    {
+        public:
+        AircraftFlowMeasureMap(Euroscope::EuroscopePluginLoopbackInterface& plugin);
+        ~AircraftFlowMeasureMap() override;
+        void FlightPlanEvent(
+            UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightPlan,
+            UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface& radarTarget) override;
+        void
+        FlightPlanDisconnectEvent(UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface& flightPlan) override;
+        void ControllerFlightPlanDataEvent(Euroscope::EuroScopeCFlightPlanInterface& flightPlan, int dataType) override;
+        void OnEvent(const ::ECFMP::Plugin::FlowMeasureActivatedEvent& event) override;
+        void OnEvent(const ::ECFMP::Plugin::FlowMeasureExpiredEvent& event) override;
+        void OnEvent(const ::ECFMP::Plugin::FlowMeasureWithdrawnEvent& event) override;
+        auto GetFlowMeasuresForCallsign(const std::string& callsign)
+            -> const std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>& override;
+
+        private:
+        struct Impl;
+        std::unique_ptr<Impl> impl;
+    };
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/AircraftFlowMeasureMapInterface.h
+++ b/src/plugin/ecfmp/AircraftFlowMeasureMapInterface.h
@@ -5,7 +5,7 @@ namespace UKControllerPlugin::ECFMP {
     {
         public:
         virtual ~AircraftFlowMeasureMapInterface() = default;
-        [[nodiscard]] virtual auto GetFlowMeasuresForCallsign(const std::string& callsign)
+        [[nodiscard]] virtual auto GetFlowMeasuresForCallsign(const std::string& callsign) const
             -> const std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>& = 0;
     };
 } // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/AircraftFlowMeasureMapInterface.h
+++ b/src/plugin/ecfmp/AircraftFlowMeasureMapInterface.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace UKControllerPlugin::ECFMP {
+    class AircraftFlowMeasureMapInterface
+    {
+        public:
+        virtual ~AircraftFlowMeasureMapInterface() = default;
+        [[nodiscard]] virtual auto GetFlowMeasuresForCallsign(const std::string& callsign)
+            -> const std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>& = 0;
+    };
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/AircraftFlowMeasureTagItem.cpp
+++ b/src/plugin/ecfmp/AircraftFlowMeasureTagItem.cpp
@@ -1,0 +1,34 @@
+#include "AircraftFlowMeasureTagItem.h"
+#include "AircraftFlowMeasureMapInterface.h"
+#include "euroscope/EuroScopeCFlightPlanInterface.h"
+#include "tag/TagData.h"
+#include <string>
+
+namespace UKControllerPlugin::ECFMP {
+
+    AircraftFlowMeasureTagItem::AircraftFlowMeasureTagItem(
+        std::shared_ptr<const AircraftFlowMeasureMapInterface> flowMeasureMap)
+        : flowMeasureMap(std::move(flowMeasureMap))
+    {
+        assert(this->flowMeasureMap != nullptr && "Flow measure map cannot be null");
+    }
+
+    std::string AircraftFlowMeasureTagItem::GetTagItemDescription(int tagItemId) const
+    {
+        return "Relevant ECFMP Flow Measures";
+    }
+
+    void AircraftFlowMeasureTagItem::SetTagItemData(Tag::TagData& tagData)
+    {
+        const auto flowMeasuresForCallsign =
+            flowMeasureMap->GetFlowMeasuresForCallsign(tagData.GetFlightplan().GetCallsign());
+        if (flowMeasuresForCallsign.empty()) {
+            return;
+        }
+
+        const auto measureCount =
+            flowMeasuresForCallsign.size() > 1 ? "(" + std::to_string(flowMeasuresForCallsign.size()) + ")" : "";
+
+        tagData.SetItemString(measureCount + (*flowMeasuresForCallsign.cbegin())->Identifier());
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/AircraftFlowMeasureTagItem.cpp
+++ b/src/plugin/ecfmp/AircraftFlowMeasureTagItem.cpp
@@ -2,7 +2,6 @@
 #include "AircraftFlowMeasureMapInterface.h"
 #include "euroscope/EuroScopeCFlightPlanInterface.h"
 #include "tag/TagData.h"
-#include <string>
 
 namespace UKControllerPlugin::ECFMP {
 

--- a/src/plugin/ecfmp/AircraftFlowMeasureTagItem.h
+++ b/src/plugin/ecfmp/AircraftFlowMeasureTagItem.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <string>
+#include "tag/TagItemInterface.h"
+
+namespace UKControllerPlugin::ECFMP {
+
+    class AircraftFlowMeasureMapInterface;
+
+    class AircraftFlowMeasureTagItem : public Tag::TagItemInterface
+    {
+        public:
+        AircraftFlowMeasureTagItem(std::shared_ptr<const AircraftFlowMeasureMapInterface> flowMeasureMap);
+        auto GetTagItemDescription(int tagItemId) const -> std::string override;
+        void SetTagItemData(Tag::TagData& tagData) override;
+
+        private:
+        // The map of flow measures
+        std::shared_ptr<const AircraftFlowMeasureMapInterface> flowMeasureMap;
+    };
+
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/AircraftFlowMeasuresDialog.cpp
+++ b/src/plugin/ecfmp/AircraftFlowMeasuresDialog.cpp
@@ -1,0 +1,69 @@
+#include "AircraftFlowMeasuresDialog.h"
+#include "dialog/DialogCallArgument.h"
+
+namespace UKControllerPlugin::ECFMP {
+    /*
+        Public facing window procedure
+    */
+    LRESULT AircraftFlowMeasuresDialog::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+    {
+        if (msg == WM_INITDIALOG) {
+            LogInfo("Aircraft flow measures dialog opened");
+            SetWindowLongPtr(
+                hwnd, GWLP_USERDATA, reinterpret_cast<Dialog::DialogCallArgument*>(lParam)->dialogArgument);
+        } else if (msg == WM_DESTROY) {
+            SetWindowLongPtr(hwnd, GWLP_USERDATA, NULL);
+            LogInfo("Aircraft flow measures dialog closed");
+        }
+
+        AircraftFlowMeasuresDialog* dialog =
+            reinterpret_cast<AircraftFlowMeasuresDialog*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
+        return dialog ? dialog->_WndProc(hwnd, msg, wParam, lParam) : FALSE;
+    }
+
+    /*
+        Private window procedure bound to the objects
+    */
+    LRESULT AircraftFlowMeasuresDialog::_WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+    {
+        switch (msg) {
+        // Initialise
+        case WM_INITDIALOG: {
+            this->InitDialog(hwnd, lParam);
+            return TRUE;
+        }
+        // Dialog Closed
+        case WM_CLOSE: {
+            EndDialog(hwnd, wParam);
+            return TRUE;
+        }
+        // Buttons pressed
+        case WM_COMMAND: {
+            switch (LOWORD(wParam)) {
+            case IDOK: {
+                EndDialog(hwnd, wParam);
+                return TRUE;
+            }
+            default:
+                return FALSE;
+            }
+        }
+        }
+
+        return FALSE;
+    }
+
+    void AircraftFlowMeasuresDialog::InitDialog(HWND hwnd, LPARAM lParam)
+    {
+        auto* data = reinterpret_cast<AircraftFlowMeasuresDialogData*>(
+            reinterpret_cast<Dialog::DialogCallArgument*>(lParam)->contextArgument);
+
+        // Set the the dialog box title
+        std::wstring title = L"ECFMP flow Measures for " + data->callsign;
+        SetWindowText(hwnd, title.c_str());
+
+        // Set the flow measures text
+        std::wstring description = data->flowMeasures;
+        SetDlgItemText(hwnd, IDC_FLOW_MEASURES_INFO, description.c_str());
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/AircraftFlowMeasuresDialog.h
+++ b/src/plugin/ecfmp/AircraftFlowMeasuresDialog.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace UKControllerPlugin::ECFMP {
+
+    struct AircraftFlowMeasuresDialogData
+    {
+        // The aircraft callsign
+        std::wstring callsign;
+
+        // The description of the flow measures
+        std::wstring flowMeasures;
+    };
+
+    class AircraftFlowMeasuresDialog
+    {
+        public:
+        static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+        private:
+        LRESULT _WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+        void InitDialog(HWND hwnd, LPARAM lParam);
+    };
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ControllerFlowMeasureRelevance.cpp
+++ b/src/plugin/ecfmp/ControllerFlowMeasureRelevance.cpp
@@ -1,0 +1,65 @@
+#include "ControllerFlowMeasureRelevance.h"
+#include "controller/ActiveCallsign.h"
+#include "controller/ActiveCallsignCollection.h"
+#include "controller/ControllerPosition.h"
+#include <algorithm>
+
+namespace UKControllerPlugin::ECFMP {
+
+    struct ControllerFlowMeasureRelevance::Impl
+    {
+        [[nodiscard]] auto UserIsScottishController() const noexcept -> bool
+        {
+            const auto& userCallsign = activeCallsigns.GetUserCallsign();
+            const auto normalisedCallsign = userCallsign.GetNormalisedPosition().GetCallsign();
+
+            return normalisedCallsign.substr(0, 3) == "SCO" || normalisedCallsign.substr(0, 3) == "EGP" ||
+                   normalisedCallsign.substr(0, 3) == "STC" || normalisedCallsign.substr(0, 3) == "EGA" ||
+                   normalisedCallsign.substr(0, 3) == "EGQ";
+        }
+
+        [[nodiscard]] auto UserIsLondonController() const noexcept -> bool
+        {
+            const auto& userCallsign = activeCallsigns.GetUserCallsign();
+            const auto normalisedCallsign = userCallsign.GetNormalisedPosition().GetCallsign();
+
+            return (normalisedCallsign.substr(0, 2) == "EG" && normalisedCallsign.substr(0, 3) != "EGP" &&
+                    normalisedCallsign.substr(0, 3) != "EGQ" && normalisedCallsign.substr(0, 3) != "EGA") ||
+                   normalisedCallsign.substr(0, 3) == "LON" || normalisedCallsign.substr(0, 3) == "LTC" ||
+                   normalisedCallsign.substr(0, 3) == "MAN" || normalisedCallsign.substr(0, 5) == "ESSEX" ||
+                   normalisedCallsign.substr(0, 6) == "THAMES" || normalisedCallsign.substr(0, 6) == "SOLENT";
+        }
+
+        // The active callsigns for the controller
+        const Controller::ActiveCallsignCollection& activeCallsigns;
+    };
+
+    ControllerFlowMeasureRelevance::ControllerFlowMeasureRelevance(
+        const Controller::ActiveCallsignCollection& activeCallsigns) noexcept
+        : impl(std::make_unique<Impl>(Impl{activeCallsigns}))
+    {
+    }
+
+    ControllerFlowMeasureRelevance::~ControllerFlowMeasureRelevance() noexcept = default;
+
+    auto ControllerFlowMeasureRelevance::FlowMeasureApplicableToAircraft(
+        const Euroscope::EuroScopeCFlightPlanInterface& flightPlan,
+        const Euroscope::EuroScopeCRadarTargetInterface& radarTarget,
+        const ::ECFMP::FlowMeasure::FlowMeasure& flowMeasure) const noexcept -> bool
+    {
+        // If the user isn't an active callsign, just show everything
+        if (!impl->activeCallsigns.UserHasCallsign()) {
+            return true;
+        }
+
+        // If the user is an active callsign, only show flow measures that are relevant to them
+        return std::any_of(
+            flowMeasure.NotifiedFlightInformationRegions().cbegin(),
+            flowMeasure.NotifiedFlightInformationRegions().cend(),
+            [this](const auto& fir) {
+                return fir->Identifier() == "XXXX" ||
+                       (fir->Identifier() == "EGPX" && impl->UserIsScottishController()) ||
+                       (fir->Identifier() == "EGTT" && impl->UserIsLondonController());
+            });
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ControllerFlowMeasureRelevance.h
+++ b/src/plugin/ecfmp/ControllerFlowMeasureRelevance.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "ECFMPCustomMeasureFilter.h"
+#include "ECFMP/flowmeasure/FlowMeasure.h"
+
+namespace UKControllerPlugin::Controller {
+    class ActiveCallsignCollection;
+} // namespace UKControllerPlugin::Controller
+
+namespace UKControllerPlugin::ECFMP {
+
+    /**
+     * Checks if a flow measure is relevant to the controller.
+     */
+    class ControllerFlowMeasureRelevance : public ECFMPCustomMeasureFilter
+    {
+        public:
+        explicit ControllerFlowMeasureRelevance(const Controller::ActiveCallsignCollection& activeCallsigns) noexcept;
+        ~ControllerFlowMeasureRelevance() noexcept override;
+        auto FlowMeasureApplicableToAircraft(
+            const Euroscope::EuroScopeCFlightPlanInterface& flightPlan,
+            const Euroscope::EuroScopeCRadarTargetInterface& radarTarget,
+            const ::ECFMP::FlowMeasure::FlowMeasure& flowMeasure) const noexcept -> bool override;
+
+        private:
+        struct Impl;
+        std::unique_ptr<Impl> impl;
+    };
+
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
+++ b/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
@@ -1,6 +1,7 @@
 #include "AircraftFlowMeasureMap.h"
 #include "AircraftFlowMeasureTagItem.h"
 #include "AircraftFlowMeasuresDialog.h"
+#include "controller/ActiveCallsignCollection.h"
 #include "ECFMP/SdkEvents.h"
 #include "ECFMPBootstrapProvider.h"
 #include "ECFMPModuleFactory.h"
@@ -21,7 +22,7 @@ namespace UKControllerPlugin::ECFMP {
     void ECFMPBootstrapProvider::BootstrapPlugin(Bootstrap::PersistenceContainer& container)
     {
         // Event to trigger ECFMP event loop every second
-        const auto ecfmpSdk = container.moduleFactories->ECFMP().Sdk(*container.curl);
+        const auto ecfmpSdk = container.moduleFactories->ECFMP().Sdk(*container.curl, *container.activeCallsigns);
         container.timedHandler->RegisterEvent(std::make_shared<TriggerECFMPEventLoop>(ecfmpSdk), 1);
 
         // Tag item to display flow measure for a given aircraft
@@ -38,8 +39,9 @@ namespace UKControllerPlugin::ECFMP {
         ecfmpSdk->EventBus().Subscribe<::ECFMP::Plugin::FlowMeasureExpiredEvent>(
             aircraftFlowMeasureMap, flowMeasureFilter);
 
-        // Register the flow measure filter for flight plan events
+        // Register the flow measure filter for flight plan and active callsign events
         container.flightplanHandler->RegisterHandler(aircraftFlowMeasureMap);
+        container.activeCallsigns->AddHandler(aircraftFlowMeasureMap);
 
         // Create the dialog for displaying flow measures for an aircraft
         auto ecfmpFlowMeasuresDialog = std::make_shared<AircraftFlowMeasuresDialog>();

--- a/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
+++ b/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
@@ -10,6 +10,7 @@
 #include "bootstrap/ModuleFactories.h"
 #include "bootstrap/PersistenceContainer.h"
 #include "dialog/DialogManager.h"
+#include "flightplan/FlightPlanEventHandlerCollection.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "tag/TagFunction.h"
 #include "tag/TagItemCollection.h"
@@ -36,6 +37,9 @@ namespace UKControllerPlugin::ECFMP {
             aircraftFlowMeasureMap, flowMeasureFilter);
         ecfmpSdk->EventBus().Subscribe<::ECFMP::Plugin::FlowMeasureExpiredEvent>(
             aircraftFlowMeasureMap, flowMeasureFilter);
+
+        // Register the flow measure filter for flight plan events
+        container.flightplanHandler->RegisterHandler(aircraftFlowMeasureMap);
 
         // Create the dialog for displaying flow measures for an aircraft
         auto ecfmpFlowMeasuresDialog = std::make_shared<AircraftFlowMeasuresDialog>();

--- a/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
+++ b/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
@@ -1,15 +1,24 @@
+#include "AircraftFlowMeasureMap.h"
+#include "AircraftFlowMeasureTagItem.h"
 #include "ECFMPBootstrapProvider.h"
 #include "ECFMPModuleFactory.h"
 #include "TriggerEcfmpEventLoop.h"
 #include "bootstrap/ModuleFactories.h"
 #include "bootstrap/PersistenceContainer.h"
+#include "tag/TagItemCollection.h"
 #include "timedevent/TimedEventCollection.h"
 
 namespace UKControllerPlugin::ECFMP {
 
     void ECFMPBootstrapProvider::BootstrapPlugin(Bootstrap::PersistenceContainer& container)
     {
-        container.timedHandler->RegisterEvent(
-            std::make_shared<TriggerECFMPEventLoop>(container.moduleFactories->ECFMP().Sdk(*container.curl)), 1);
+        // Event to trigger ECFMP event loop every second
+        const auto ecfmpSdk = container.moduleFactories->ECFMP().Sdk(*container.curl);
+        container.timedHandler->RegisterEvent(std::make_shared<TriggerECFMPEventLoop>(ecfmpSdk), 1);
+
+        // Tag item to display flow measure for a given aircraft
+        const auto aircraftFlowMeasureMap = std::make_shared<AircraftFlowMeasureMap>(*container.plugin);
+        container.tagHandler->RegisterTagItem(
+            131, std::make_shared<AircraftFlowMeasureTagItem>(aircraftFlowMeasureMap));
     }
 } // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
+++ b/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
@@ -1,0 +1,15 @@
+#include "ECFMPBootstrapProvider.h"
+#include "ECFMPModuleFactory.h"
+#include "TriggerEcfmpEventLoop.h"
+#include "bootstrap/ModuleFactories.h"
+#include "bootstrap/PersistenceContainer.h"
+#include "timedevent/TimedEventCollection.h"
+
+namespace UKControllerPlugin::ECFMP {
+
+    void ECFMPBootstrapProvider::BootstrapPlugin(Bootstrap::PersistenceContainer& container)
+    {
+        container.timedHandler->RegisterEvent(
+            std::make_shared<TriggerECFMPEventLoop>(container.moduleFactories->ECFMP().Sdk(*container.curl)), 1);
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
+++ b/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
@@ -1,10 +1,15 @@
 #include "AircraftFlowMeasureMap.h"
 #include "AircraftFlowMeasureTagItem.h"
+#include "AircraftFlowMeasuresDialog.h"
 #include "ECFMPBootstrapProvider.h"
 #include "ECFMPModuleFactory.h"
+#include "ListAircraftFlowMeasures.h"
 #include "TriggerEcfmpEventLoop.h"
 #include "bootstrap/ModuleFactories.h"
 #include "bootstrap/PersistenceContainer.h"
+#include "dialog/DialogManager.h"
+#include "plugin/FunctionCallEventHandler.h"
+#include "tag/TagFunction.h"
 #include "tag/TagItemCollection.h"
 #include "timedevent/TimedEventCollection.h"
 
@@ -20,5 +25,25 @@ namespace UKControllerPlugin::ECFMP {
         const auto aircraftFlowMeasureMap = std::make_shared<AircraftFlowMeasureMap>(*container.plugin);
         container.tagHandler->RegisterTagItem(
             131, std::make_shared<AircraftFlowMeasureTagItem>(aircraftFlowMeasureMap));
+
+        // Create the dialog for displaying flow measures for an aircraft
+        auto ecfmpFlowMeasuresDialog = std::make_shared<AircraftFlowMeasuresDialog>();
+        container.dialogManager->AddDialog(
+            {IDD_FLOW_MEASURE_LIST,
+             "ECFMP Flow Measures",
+             reinterpret_cast<DLGPROC>(ecfmpFlowMeasuresDialog->WndProc), // NOLINT
+             reinterpret_cast<LPARAM>(ecfmpFlowMeasuresDialog.get()),     // NOLINT
+             ecfmpFlowMeasuresDialog});
+
+        // Create the tag function that triggers the flow measure dialog
+        auto listAircraftFlowMeasuresTagFunctionHandler =
+            std::make_shared<ListAircraftFlowMeasures>(aircraftFlowMeasureMap, *container.dialogManager);
+        auto listAircraftFlowMeasuresTagFunction = Tag::TagFunction{
+            9023,
+            "ECFMP List Aircraft Flow Measures",
+            [listAircraftFlowMeasuresTagFunctionHandler](const auto& flightplan, const auto&, auto, const auto&) {
+                listAircraftFlowMeasuresTagFunctionHandler->ListForAircraft(flightplan);
+            }};
+        container.pluginFunctionHandlers->RegisterFunctionCall(listAircraftFlowMeasuresTagFunction);
     }
 } // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
+++ b/src/plugin/ecfmp/ECFMPBootstrapProvider.cpp
@@ -1,8 +1,10 @@
 #include "AircraftFlowMeasureMap.h"
 #include "AircraftFlowMeasureTagItem.h"
 #include "AircraftFlowMeasuresDialog.h"
+#include "ECFMP/SdkEvents.h"
 #include "ECFMPBootstrapProvider.h"
 #include "ECFMPModuleFactory.h"
+#include "HomeFirsFlowMeasureFilter.h"
 #include "ListAircraftFlowMeasures.h"
 #include "TriggerEcfmpEventLoop.h"
 #include "bootstrap/ModuleFactories.h"
@@ -25,6 +27,15 @@ namespace UKControllerPlugin::ECFMP {
         const auto aircraftFlowMeasureMap = std::make_shared<AircraftFlowMeasureMap>(*container.plugin);
         container.tagHandler->RegisterTagItem(
             131, std::make_shared<AircraftFlowMeasureTagItem>(aircraftFlowMeasureMap));
+
+        // Register the flow measure map for ECFMP events
+        auto flowMeasureFilter = std::make_shared<HomeFirsFlowMeasureFilter>();
+        ecfmpSdk->EventBus().Subscribe<::ECFMP::Plugin::FlowMeasureActivatedEvent>(
+            aircraftFlowMeasureMap, flowMeasureFilter);
+        ecfmpSdk->EventBus().Subscribe<::ECFMP::Plugin::FlowMeasureWithdrawnEvent>(
+            aircraftFlowMeasureMap, flowMeasureFilter);
+        ecfmpSdk->EventBus().Subscribe<::ECFMP::Plugin::FlowMeasureExpiredEvent>(
+            aircraftFlowMeasureMap, flowMeasureFilter);
 
         // Create the dialog for displaying flow measures for an aircraft
         auto ecfmpFlowMeasuresDialog = std::make_shared<AircraftFlowMeasuresDialog>();

--- a/src/plugin/ecfmp/ECFMPBootstrapProvider.h
+++ b/src/plugin/ecfmp/ECFMPBootstrapProvider.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "bootstrap/BootstrapProviderInterface.h"
+
+namespace UKControllerPlugin::ECFMP {
+
+    class ECFMPBootstrapProvider : public Bootstrap::BootstrapProviderInterface
+    {
+        public:
+        void BootstrapPlugin(Bootstrap::PersistenceContainer& container) override;
+    };
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPCustomMeasureFilter.h
+++ b/src/plugin/ecfmp/ECFMPCustomMeasureFilter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace UKControllerPlugin::Euroscope {
+    class EuroScopeCFlightPlanInterface;
+    class EuroScopeCRadarTargetInterface;
+} // namespace UKControllerPlugin::Euroscope
+
+namespace UKControllerPlugin::ECFMP {
+    class ECFMPCustomMeasureFilter
+    {
+        public:
+        virtual ~ECFMPCustomMeasureFilter() noexcept = default;
+        [[nodiscard]] virtual auto FlowMeasureApplicableToAircraft(
+            const Euroscope::EuroScopeCFlightPlanInterface& flightPlan,
+            const Euroscope::EuroScopeCRadarTargetInterface& radarTarget,
+            const ::ECFMP::FlowMeasure::FlowMeasure& flowMeasure) const noexcept -> bool = 0;
+    };
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPCustomMeasureFilterWrapper.cpp
+++ b/src/plugin/ecfmp/ECFMPCustomMeasureFilterWrapper.cpp
@@ -1,0 +1,25 @@
+#include "ECFMPCustomMeasureFilter.h"
+#include "ECFMPCustomMeasureFilterWrapper.h"
+#include "euroscope/EuroScopeCFlightPlanWrapper.h"
+#include "euroscope/EuroScopeCRadarTargetWrapper.h"
+
+namespace UKControllerPlugin::ECFMP {
+
+    ECFMPCustomMeasureFilterWrapper::ECFMPCustomMeasureFilterWrapper(
+        std::shared_ptr<ECFMPCustomMeasureFilter> wrappedFilter) noexcept
+        : wrappedFilter(std::move(wrappedFilter))
+    {
+        assert(this->wrappedFilter != nullptr && "Wrapped filter cannot be null");
+    }
+
+    auto ECFMPCustomMeasureFilterWrapper::ApplicableToAircraft(
+        const EuroScopePlugIn::CFlightPlan& flightplan,
+        const EuroScopePlugIn::CRadarTarget& radarTarget,
+        const ::ECFMP::FlowMeasure::FlowMeasure& flowMeasure) const noexcept -> bool
+    {
+        return wrappedFilter->FlowMeasureApplicableToAircraft(
+            Euroscope::EuroScopeCFlightPlanWrapper(flightplan),
+            Euroscope::EuroScopeCRadarTargetWrapper(radarTarget),
+            flowMeasure);
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPCustomMeasureFilterWrapper.h
+++ b/src/plugin/ecfmp/ECFMPCustomMeasureFilterWrapper.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace UKControllerPlugin::ECFMP {
+
+    class ECFMPCustomMeasureFilter;
+
+    /**
+     * Wraps an ECFMPCustomMeasureFilter instance so that we can take the raw EuroScope objects
+     * and turn them into our own interfaces
+     */
+    class ECFMPCustomMeasureFilterWrapper : public ::ECFMP::FlowMeasure::CustomFlowMeasureFilter
+    {
+        public:
+        explicit ECFMPCustomMeasureFilterWrapper(std::shared_ptr<ECFMPCustomMeasureFilter> wrappedFilter) noexcept;
+
+        [[nodiscard]] auto ApplicableToAircraft(
+            const EuroScopePlugIn::CFlightPlan& flightplan,
+            const EuroScopePlugIn::CRadarTarget& radarTarget,
+            const ::ECFMP::FlowMeasure::FlowMeasure& flowMeasure) const noexcept -> bool override;
+
+        private:
+        std::shared_ptr<ECFMPCustomMeasureFilter> wrappedFilter;
+    };
+
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPModuleFactory.cpp
+++ b/src/plugin/ecfmp/ECFMPModuleFactory.cpp
@@ -1,0 +1,39 @@
+#include "ECFMPModuleFactory.h"
+#include "HttpClient.h"
+#include "Logger.h"
+
+namespace UKControllerPlugin::ECFMP {
+
+    struct ECFMPModuleFactory::Impl
+    {
+        [[nodiscard]] auto MakeSdk(Curl::CurlInterface& curl) -> std::shared_ptr<::ECFMP::Plugin::Sdk>
+        {
+            if (!sdk) {
+                sdk = ::ECFMP::Plugin::SdkFactory::Build()
+                          .WithLogger(std::make_unique<Logger>())
+                          .WithHttpClient(std::make_unique<HttpClient>(curl))
+                          .Instance();
+            }
+
+            return sdk;
+        }
+
+        // The ECFMP SDK
+        std::shared_ptr<::ECFMP::Plugin::Sdk> sdk;
+    };
+
+    ECFMPModuleFactory::ECFMPModuleFactory() : impl(std::make_unique<Impl>())
+    {
+        assert(this->impl && "ECFMPModuleFactory::impl is null");
+    }
+
+    ECFMPModuleFactory::~ECFMPModuleFactory()
+    {
+        impl->sdk->Destroy();
+    };
+
+    auto ECFMPModuleFactory::Sdk(Curl::CurlInterface& curl) -> std::shared_ptr<::ECFMP::Plugin::Sdk>
+    {
+        return impl->MakeSdk(curl);
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPModuleFactory.h
+++ b/src/plugin/ecfmp/ECFMPModuleFactory.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace ECFMP::Plugin {
+    class Sdk;
+} // namespace ECFMP::Plugin
+
+namespace UKControllerPlugin::Curl {
+    class CurlInterface;
+} // namespace UKControllerPlugin::Curl
+
+namespace UKControllerPlugin::ECFMP {
+
+    /**
+     * Bootstraps the ECFMP module.
+     */
+    class ECFMPModuleFactory
+    {
+        public:
+        ECFMPModuleFactory();
+        ~ECFMPModuleFactory();
+        [[nodiscard]] auto Sdk(Curl::CurlInterface& curl) -> std::shared_ptr<::ECFMP::Plugin::Sdk>;
+
+        private:
+        struct Impl;
+        std::unique_ptr<Impl> impl;
+    };
+
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ECFMPModuleFactory.h
+++ b/src/plugin/ecfmp/ECFMPModuleFactory.h
@@ -4,9 +4,14 @@ namespace ECFMP::Plugin {
     class Sdk;
 } // namespace ECFMP::Plugin
 
-namespace UKControllerPlugin::Curl {
-    class CurlInterface;
-} // namespace UKControllerPlugin::Curl
+namespace UKControllerPlugin {
+    namespace Controller {
+        class ActiveCallsignCollection;
+    } // namespace Controller
+    namespace Curl {
+        class CurlInterface;
+    } // namespace Curl
+} // namespace UKControllerPlugin
 
 namespace UKControllerPlugin::ECFMP {
 
@@ -18,7 +23,8 @@ namespace UKControllerPlugin::ECFMP {
         public:
         ECFMPModuleFactory();
         ~ECFMPModuleFactory();
-        [[nodiscard]] auto Sdk(Curl::CurlInterface& curl) -> std::shared_ptr<::ECFMP::Plugin::Sdk>;
+        [[nodiscard]] auto Sdk(Curl::CurlInterface& curl, const Controller::ActiveCallsignCollection& callsigns)
+            -> std::shared_ptr<::ECFMP::Plugin::Sdk>;
 
         private:
         struct Impl;

--- a/src/plugin/ecfmp/HomeFirsFlowMeasureFilter.cpp
+++ b/src/plugin/ecfmp/HomeFirsFlowMeasureFilter.cpp
@@ -1,0 +1,37 @@
+#include "HomeFirsFlowMeasureFilter.h"
+
+namespace UKControllerPlugin::ECFMP {
+
+    auto HomeFirsFlowMeasureFilter::ShouldProcess(const ::ECFMP::Plugin::FlowMeasureActivatedEvent& event) -> bool
+    {
+        return IsNotifiedToHomeFirs(*event.flowMeasure);
+    }
+
+    auto HomeFirsFlowMeasureFilter::ShouldProcess(const ::ECFMP::Plugin::FlowMeasureNotifiedEvent& event) -> bool
+    {
+        return IsNotifiedToHomeFirs(*event.flowMeasure);
+    }
+
+    auto HomeFirsFlowMeasureFilter::ShouldProcess(const ::ECFMP::Plugin::FlowMeasureExpiredEvent& event) -> bool
+    {
+        return IsNotifiedToHomeFirs(*event.flowMeasure);
+    }
+
+    auto HomeFirsFlowMeasureFilter::ShouldProcess(const ::ECFMP::Plugin::FlowMeasureWithdrawnEvent& event) -> bool
+    {
+        return IsNotifiedToHomeFirs(*event.flowMeasure);
+    }
+
+    auto HomeFirsFlowMeasureFilter::ShouldProcess(const ::ECFMP::Plugin::FlowMeasureReissuedEvent& event) -> bool
+    {
+        return IsNotifiedToHomeFirs(*event.original);
+    }
+
+    auto HomeFirsFlowMeasureFilter::IsNotifiedToHomeFirs(const ::ECFMP::FlowMeasure::FlowMeasure& measure) -> bool
+    {
+        const auto notifiedRegions = measure.NotifiedFlightInformationRegions();
+        return std::find_if(notifiedRegions.cbegin(), notifiedRegions.cend(), ([](const auto& region) {
+                                return region->Identifier() == "EGTT" || region->Identifier() == "EGPX";
+                            })) != notifiedRegions.cend();
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/HomeFirsFlowMeasureFilter.cpp
+++ b/src/plugin/ecfmp/HomeFirsFlowMeasureFilter.cpp
@@ -1,4 +1,5 @@
 #include "HomeFirsFlowMeasureFilter.h"
+#include <algorithm>
 
 namespace UKControllerPlugin::ECFMP {
 
@@ -30,8 +31,11 @@ namespace UKControllerPlugin::ECFMP {
     auto HomeFirsFlowMeasureFilter::IsNotifiedToHomeFirs(const ::ECFMP::FlowMeasure::FlowMeasure& measure) -> bool
     {
         const auto notifiedRegions = measure.NotifiedFlightInformationRegions();
-        return std::find_if(notifiedRegions.cbegin(), notifiedRegions.cend(), ([](const auto& region) {
-                                return region->Identifier() == "EGTT" || region->Identifier() == "EGPX";
-                            })) != notifiedRegions.cend();
+
+        // XXXX is the identifier used in ECFMP for the global / catch all FIR
+        return std::any_of(notifiedRegions.cbegin(), notifiedRegions.cend(), ([](const auto& region) {
+                               return region->Identifier() == "EGTT" || region->Identifier() == "EGPX" ||
+                                      region->Identifier() == "XXXX";
+                           }));
     }
 } // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/HomeFirsFlowMeasureFilter.h
+++ b/src/plugin/ecfmp/HomeFirsFlowMeasureFilter.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ECFMP/flowmeasure/FlowMeasure.h"
+namespace UKControllerPlugin::ECFMP {
+
+    class HomeFirsFlowMeasureFilter : public ::ECFMP::EventBus::EventFilter<::ECFMP::Plugin::FlowMeasureActivatedEvent>,
+                                      public ::ECFMP::EventBus::EventFilter<::ECFMP::Plugin::FlowMeasureNotifiedEvent>,
+                                      public ::ECFMP::EventBus::EventFilter<::ECFMP::Plugin::FlowMeasureExpiredEvent>,
+                                      public ::ECFMP::EventBus::EventFilter<::ECFMP::Plugin::FlowMeasureWithdrawnEvent>,
+                                      public ::ECFMP::EventBus::EventFilter<::ECFMP::Plugin::FlowMeasureReissuedEvent>
+    {
+        public:
+        [[nodiscard]] auto ShouldProcess(const ::ECFMP::Plugin::FlowMeasureActivatedEvent& event) -> bool override;
+        [[nodiscard]] auto ShouldProcess(const ::ECFMP::Plugin::FlowMeasureNotifiedEvent& event) -> bool override;
+        [[nodiscard]] auto ShouldProcess(const ::ECFMP::Plugin::FlowMeasureExpiredEvent& event) -> bool override;
+        [[nodiscard]] auto ShouldProcess(const ::ECFMP::Plugin::FlowMeasureWithdrawnEvent& event) -> bool override;
+        [[nodiscard]] auto ShouldProcess(const ::ECFMP::Plugin::FlowMeasureReissuedEvent& event) -> bool override;
+
+        private:
+        [[nodiscard]] static auto IsNotifiedToHomeFirs(const ::ECFMP::FlowMeasure::FlowMeasure& measure) -> bool;
+    };
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/HttpClient.cpp
+++ b/src/plugin/ecfmp/HttpClient.cpp
@@ -1,0 +1,22 @@
+#include "HttpClient.h"
+#include "curl/CurlInterface.h"
+#include "curl/CurlRequest.h"
+#include "curl/CurlResponse.h"
+
+namespace UKControllerPlugin::ECFMP {
+
+    HttpClient::HttpClient(Curl::CurlInterface& curl) : curl(curl)
+    {
+    }
+
+    auto HttpClient::Get(const std::string& url) -> ::ECFMP::Http::HttpResponse
+    {
+        const auto response = curl.MakeCurlRequest({url, Curl::CurlRequest::METHOD_GET});
+
+        if (response.IsCurlError()) {
+            return {CURL_ERROR_STATUS_CODE, ""};
+        }
+
+        return {static_cast<long>(response.GetStatusCode()), response.GetResponse()};
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/HttpClient.h
+++ b/src/plugin/ecfmp/HttpClient.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace UKControllerPlugin::Curl {
+    class CurlInterface;
+} // namespace UKControllerPlugin::Curl
+
+namespace UKControllerPlugin::ECFMP {
+
+    /**
+     * An HTTP client instance that can be passed to ECFMP.
+     */
+    class HttpClient : public ::ECFMP::Http::HttpClient
+    {
+        public:
+        HttpClient(Curl::CurlInterface& curl);
+        [[nodiscard]] auto Get(const std::string& url) -> ::ECFMP::Http::HttpResponse override;
+
+        private:
+        static const int CURL_ERROR_STATUS_CODE = 999L;
+
+        // The curl API
+        Curl::CurlInterface& curl;
+    };
+
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ListAircraftFlowMeasures.cpp
+++ b/src/plugin/ecfmp/ListAircraftFlowMeasures.cpp
@@ -1,0 +1,48 @@
+#include "AircraftFlowMeasuresDialog.h"
+#include "AircraftFlowMeasureMapInterface.h"
+#include "ListAircraftFlowMeasures.h"
+#include "dialog/DialogManager.h"
+#include "euroscope/EuroScopeCFlightPlanInterface.h"
+#include "helper/HelperFunctions.h"
+
+namespace UKControllerPlugin::ECFMP {
+    ListAircraftFlowMeasures::ListAircraftFlowMeasures(
+        std::shared_ptr<const AircraftFlowMeasureMapInterface> flowMeasureMap,
+        const Dialog::DialogManager& dialogManager)
+        : flowMeasureMap(std::move(flowMeasureMap)), dialogManager(dialogManager)
+    {
+        assert(this->flowMeasureMap != nullptr && "Flow measure map cannot be null");
+    }
+
+    void ListAircraftFlowMeasures::ListForAircraft(const Euroscope::EuroScopeCFlightPlanInterface& flightplan)
+    {
+        const auto flowMeasuresForCallsign = flowMeasureMap->GetFlowMeasuresForCallsign(flightplan.GetCallsign());
+        if (flowMeasuresForCallsign.empty()) {
+            return;
+        }
+
+        // Write the flow measures to a string
+        std::string flowMeasureString;
+        for (const auto& flowMeasure : flowMeasuresForCallsign) {
+            flowMeasureString += "Measure: " + flowMeasure->Identifier() + "\r\n\r\n";
+            flowMeasureString += flowMeasure->Measure().MeasureDescription() + "\r\n\r\n";
+
+            flowMeasureString += "Applicable To:\r\n\r\n";
+
+            for (const auto& description : flowMeasure->Filters().FilterDescriptions()) {
+                flowMeasureString += description + "\r\n";
+            }
+
+            flowMeasureString += "\r\n";
+            flowMeasureString += "End of measure " + flowMeasure->Identifier() + "\r\n\r\n";
+        }
+
+        // Open dialog
+        AircraftFlowMeasuresDialogData dialogData{
+            .callsign = HelperFunctions::ConvertToWideString(flightplan.GetCallsign()),
+            .flowMeasures =
+                HelperFunctions::ConvertToWideString(flowMeasureString.substr(0, flowMeasureString.size() - 4))};
+
+        dialogManager.OpenDialog(IDD_FLOW_MEASURE_LIST, reinterpret_cast<LPARAM>(&dialogData));
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/ListAircraftFlowMeasures.h
+++ b/src/plugin/ecfmp/ListAircraftFlowMeasures.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace UKControllerPlugin {
+    namespace Dialog {
+        class DialogManager;
+    } // namespace Dialog
+    namespace Euroscope {
+        class EuroScopeCFlightPlanInterface;
+    } // namespace Euroscope
+} // namespace UKControllerPlugin
+
+namespace UKControllerPlugin::ECFMP {
+    class AircraftFlowMeasureMapInterface;
+
+    class ListAircraftFlowMeasures
+    {
+        public:
+        ListAircraftFlowMeasures(
+            std::shared_ptr<const AircraftFlowMeasureMapInterface> flowMeasureMap,
+            const Dialog::DialogManager& dialogManager);
+        void ListForAircraft(const Euroscope::EuroScopeCFlightPlanInterface& flightplan);
+
+        private:
+        // The flow measure map
+        std::shared_ptr<const AircraftFlowMeasureMapInterface> flowMeasureMap;
+
+        // Dialog manager
+        const Dialog::DialogManager& dialogManager;
+    };
+
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/Logger.cpp
+++ b/src/plugin/ecfmp/Logger.cpp
@@ -1,0 +1,23 @@
+#include "Logger.h"
+
+namespace UKControllerPlugin::ECFMP {
+    void Logger::Info(const std::string& message)
+    {
+        LogInfo(message);
+    }
+
+    void Logger::Debug(const std::string& message)
+    {
+        LogDebug(message);
+    }
+
+    void Logger::Warning(const std::string& message)
+    {
+        LogWarning(message);
+    }
+
+    void Logger::Error(const std::string& message)
+    {
+        LogError(message);
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/Logger.h
+++ b/src/plugin/ecfmp/Logger.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace UKControllerPlugin::ECFMP {
+
+    /**
+     * A logger instance that can be passed to ECFMP.
+     */
+    class Logger : public ::ECFMP::Log::Logger
+    {
+        public:
+        void Debug(const std::string& message) override;
+        void Info(const std::string& message) override;
+        void Warning(const std::string& message) override;
+        void Error(const std::string& message) override;
+    };
+
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/TriggerEcfmpEventLoop.cpp
+++ b/src/plugin/ecfmp/TriggerEcfmpEventLoop.cpp
@@ -1,0 +1,16 @@
+#include "TriggerEcfmpEventLoop.h"
+
+#include <utility>
+
+namespace UKControllerPlugin::ECFMP {
+
+    TriggerECFMPEventLoop::TriggerECFMPEventLoop(std::shared_ptr<::ECFMP::Plugin::Sdk> sdk) : sdk(std::move(sdk))
+    {
+        assert(this->sdk && "TriggerECFMPEventLoop::TriggerECFMPEventLoop: sdk is null");
+    }
+
+    void TriggerECFMPEventLoop::TimedEventTrigger()
+    {
+        sdk->OnEuroscopeTimerTick();
+    }
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/ecfmp/TriggerEcfmpEventLoop.h
+++ b/src/plugin/ecfmp/TriggerEcfmpEventLoop.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "timedevent/AbstractTimedEvent.h"
+
+namespace ECFMP::Plugin {
+    class Sdk;
+} // namespace ECFMP::Plugin
+
+namespace UKControllerPlugin::ECFMP {
+
+    class TriggerECFMPEventLoop : public TimedEvent::AbstractTimedEvent
+    {
+        public:
+        TriggerECFMPEventLoop(std::shared_ptr<::ECFMP::Plugin::Sdk> sdk);
+        void TimedEventTrigger() override;
+
+        private:
+        std::shared_ptr<::ECFMP::Plugin::Sdk> sdk;
+    };
+
+} // namespace UKControllerPlugin::ECFMP

--- a/src/plugin/euroscope/EuroScopeCFlightPlanInterface.h
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanInterface.h
@@ -48,7 +48,7 @@ namespace UKControllerPlugin::Euroscope {
         [[nodiscard]] virtual bool IsTrackedByUser() const = 0;
         [[nodiscard]] virtual bool IsValid() const = 0;
         [[nodiscard]] virtual bool IsVfr() const = 0;
-        [[nodiscard]] virtual EuroScopePlugIn::CFlightPlan GetEuroScopeObject() const = 0;
+        [[nodiscard]] virtual EuroScopePlugIn::CFlightPlan& GetEuroScopeObject() const = 0;
         [[nodiscard]] virtual auto GetRemarks() const -> std::string = 0;
         [[nodiscard]] virtual auto GetDepartureRunway() const -> std::string = 0;
     };

--- a/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.cpp
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.cpp
@@ -161,7 +161,7 @@ namespace UKControllerPlugin::Euroscope {
         this->originalData.GetControllerAssignedData().SetSquawk(squawk.c_str());
     }
 
-    auto EuroScopeCFlightPlanWrapper::GetEuroScopeObject() const -> EuroScopePlugIn::CFlightPlan
+    auto EuroScopeCFlightPlanWrapper::GetEuroScopeObject() const -> EuroScopePlugIn::CFlightPlan&
     {
         return this->originalData;
     }

--- a/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.h
+++ b/src/plugin/euroscope/EuroScopeCFlightPlanWrapper.h
@@ -44,12 +44,12 @@ namespace UKControllerPlugin::Euroscope {
         void SetClearedAltitude(int cleared) override;
         void SetHeading(int heading) override;
         void SetSquawk(std::string squawk) override;
-        EuroScopePlugIn::CFlightPlan GetEuroScopeObject() const override;
+        EuroScopePlugIn::CFlightPlan& GetEuroScopeObject() const override;
         [[nodiscard]] auto GetRemarks() const -> std::string override;
 
         private:
         // The original data that we're wrapping.
-        EuroScopePlugIn::CFlightPlan originalData;
+        mutable EuroScopePlugIn::CFlightPlan originalData;
 
         // The value ES passes as cleared altitude when none is set.
         const int euroScopeNoControllerClearedAltitude = 0;

--- a/src/plugin/euroscope/EuroScopeCRadarTargetInterface.h
+++ b/src/plugin/euroscope/EuroScopeCRadarTargetInterface.h
@@ -16,6 +16,7 @@ namespace UKControllerPlugin {
             virtual int GetGroundSpeed(void) const = 0;
             virtual int GetVerticalSpeed(void) const = 0;
             virtual double GetHeading() const = 0;
+            virtual EuroScopePlugIn::CRadarTarget& GetEuroScopeObject() const = 0;
         };
     } // namespace Euroscope
 } // namespace UKControllerPlugin

--- a/src/plugin/euroscope/EuroScopeCRadarTargetWrapper.cpp
+++ b/src/plugin/euroscope/EuroScopeCRadarTargetWrapper.cpp
@@ -43,5 +43,10 @@ namespace UKControllerPlugin {
         {
             return this->originalData.GetTrackHeading();
         }
+
+        auto EuroScopeCRadarTargetWrapper::GetEuroScopeObject() const -> EuroScopePlugIn::CRadarTarget&
+        {
+            return this->originalData;
+        }
     } // namespace Euroscope
 } // namespace UKControllerPlugin

--- a/src/plugin/euroscope/EuroScopeCRadarTargetWrapper.h
+++ b/src/plugin/euroscope/EuroScopeCRadarTargetWrapper.h
@@ -13,9 +13,10 @@ namespace UKControllerPlugin::Euroscope {
         [[nodiscard]] auto GetGroundSpeed() const -> int override;
         [[nodiscard]] auto GetVerticalSpeed() const -> int override;
         [[nodiscard]] auto GetHeading() const -> double override;
+        [[nodiscard]] auto GetEuroScopeObject() const -> EuroScopePlugIn::CRadarTarget& override;
 
         private:
         // The original object from EuroScope
-        EuroScopePlugIn::CRadarTarget originalData;
+        mutable EuroScopePlugIn::CRadarTarget originalData;
     };
 } // namespace UKControllerPlugin::Euroscope

--- a/src/plugin/euroscope/EuroscopePluginLoopbackInterface.h
+++ b/src/plugin/euroscope/EuroscopePluginLoopbackInterface.h
@@ -49,6 +49,11 @@ namespace UKControllerPlugin {
                 std::function<void(
                     std::shared_ptr<EuroScopeCFlightPlanInterface>, std::shared_ptr<EuroScopeCRadarTargetInterface>)>
                     function) = 0;
+            virtual void ApplyFunctionToAllFlightplans(
+                std::function<void(EuroScopeCFlightPlanInterface&, EuroScopeCRadarTargetInterface&)> function) = 0;
+            virtual void ApplyFunctionToAllFlightplans(
+                std::function<void(const EuroScopeCFlightPlanInterface&, const EuroScopeCRadarTargetInterface&)>
+                    function) const = 0;
             virtual void ApplyFunctionToAllControllers(
                 std::function<void(std::shared_ptr<EuroScopeCControllerInterface>)> function) = 0;
             virtual void ShowTextEditPopup(RECT editArea, int callbackId, std::string initialValue) = 0;

--- a/src/plugin/pch/pch.h
+++ b/src/plugin/pch/pch.h
@@ -68,3 +68,4 @@ using std::min;
 #include <vector>
 
 #include "euroscope/EuroScopePlugIn.h"
+#include "ecfmp/include/ECFMP/ECFMP.h"

--- a/src/plugin/plugin/UKPlugin.cpp
+++ b/src/plugin/plugin/UKPlugin.cpp
@@ -552,6 +552,62 @@ namespace UKControllerPlugin {
         } while (strcmp((current = this->FlightPlanSelectNext(current)).GetCallsign(), "") != 0);
     }
 
+    void UKPlugin::ApplyFunctionToAllFlightplans(
+        std::function<void(EuroScopeCFlightPlanInterface&, EuroScopeCRadarTargetInterface&)> function)
+    {
+        EuroScopePlugIn::CFlightPlan current = this->FlightPlanSelectFirst();
+
+        // If there's nothing, stop
+        if (!current.IsValid() || strcmp(current.GetCallsign(), "") == 0) {
+            return;
+        }
+
+        // Loop through all visible flightplans
+        do {
+            if (!current.IsValid()) {
+                continue;
+            }
+
+            EuroScopePlugIn::CRadarTarget rt = this->RadarTargetSelect(current.GetCallsign());
+
+            if (!rt.IsValid()) {
+                continue;
+            }
+
+            auto flightplanWrapper = EuroScopeCFlightPlanWrapper(current);
+            auto radarTargetWrapper = EuroScopeCRadarTargetWrapper(rt);
+            function(flightplanWrapper, radarTargetWrapper);
+
+        } while (strcmp((current = this->FlightPlanSelectNext(current)).GetCallsign(), "") != 0);
+    }
+
+    void UKPlugin::ApplyFunctionToAllFlightplans(
+        std::function<void(const EuroScopeCFlightPlanInterface&, const EuroScopeCRadarTargetInterface&)> function) const
+    {
+        EuroScopePlugIn::CFlightPlan current = this->FlightPlanSelectFirst();
+
+        // If there's nothing, stop
+        if (!current.IsValid() || strcmp(current.GetCallsign(), "") == 0) {
+            return;
+        }
+
+        // Loop through all visible flightplans
+        do {
+            if (!current.IsValid()) {
+                continue;
+            }
+
+            EuroScopePlugIn::CRadarTarget rt = this->RadarTargetSelect(current.GetCallsign());
+
+            if (!rt.IsValid()) {
+                continue;
+            }
+
+            function(EuroScopeCFlightPlanWrapper(current), EuroScopeCRadarTargetWrapper(rt));
+
+        } while (strcmp((current = this->FlightPlanSelectNext(current)).GetCallsign(), "") != 0);
+    }
+
     void UKPlugin::ShowTextEditPopup(RECT editArea, int callbackId, std::string initialValue)
     {
         OpenPopupEdit(editArea, callbackId, initialValue.c_str());

--- a/src/plugin/plugin/UKPlugin.h
+++ b/src/plugin/plugin/UKPlugin.h
@@ -126,6 +126,13 @@ namespace UKControllerPlugin {
             std::function<void(
                 std::shared_ptr<Euroscope::EuroScopeCFlightPlanInterface>,
                 std::shared_ptr<Euroscope::EuroScopeCRadarTargetInterface>)> function) override;
+        void ApplyFunctionToAllFlightplans(
+            std::function<void(Euroscope::EuroScopeCFlightPlanInterface&, Euroscope::EuroScopeCRadarTargetInterface&)>
+                function) override;
+        void ApplyFunctionToAllFlightplans(
+            std::function<
+                void(const Euroscope::EuroScopeCFlightPlanInterface&, const Euroscope::EuroScopeCRadarTargetInterface&)>
+                function) const override;
         void ShowTextEditPopup(RECT editArea, int callbackId, std::string initialValue) override;
         void OnFlightPlanFlightStripPushed(
             EuroScopePlugIn::CFlightPlan flightplan,

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -109,7 +109,7 @@ set(test__dependency
 )
 source_group("test\\dependency" FILES ${test__dependency})
 
-set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp ecfmp/AircraftFlowMeasureMapTest.cpp ecfmp/AircraftFlowMeasureTagItemTest.cpp)
+set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp ecfmp/AircraftFlowMeasureMapTest.cpp ecfmp/AircraftFlowMeasureTagItemTest.cpp ecfmp/ListAircraftFlowMeasuresTest.cpp ecfmp/HomeFirsFlowMeasureFilterTest.cpp)
 source_group("test\\ecfmp" FILES ${test__ecfmp})
 
 set(test__euroscope

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -847,3 +847,9 @@ target_link_libraries(${PROJECT_NAME} PRIVATE "${ADDITIONAL_LIBRARY_DEPENDENCIES
 target_link_directories(${PROJECT_NAME} PRIVATE
     "${CMAKE_SOURCE_DIR}/lib/test"
 )
+
+# Post-build copy the EuroScope binary
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../../lib/EuroScopePlugInDll.dll" "${PROJECT_BINARY_DIR}/bin/EuroScopePlugInDll.dll"
+    COMMENT "Copied EuroScope shared library to ${PROJECT_BINARY_DIR}/bin/EuroScopePlugInDll.dll"
+)

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -109,7 +109,7 @@ set(test__dependency
 )
 source_group("test\\dependency" FILES ${test__dependency})
 
-set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp)
+set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp ecfmp/AircraftFlowMeasureMapTest.cpp)
 source_group("test\\ecfmp" FILES ${test__ecfmp})
 
 set(test__euroscope

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -109,6 +109,9 @@ set(test__dependency
 )
 source_group("test\\dependency" FILES ${test__dependency})
 
+set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp)
+source_group("test\\ecfmp" FILES ${test__ecfmp})
+
 set(test__euroscope
     "euroscope/AsrEventHandlerCollectionTest.cpp"
     "euroscope/CallbackFunctionTest.cpp"
@@ -621,6 +624,7 @@ set(ALL_FILES
     ${test__datablock}
     ${test__departure}
     ${test__dependency}
+    ${test__ecfmp}
     ${test__euroscope}
     ${test__eventhandler}
     ${test__flightinformationservice}
@@ -798,6 +802,7 @@ add_dependencies(${PROJECT_NAME}
     UKControllerPluginUtils
     gmock
     UKControllerPluginTestingUtils
+    ecfmp_sdk
 )
 
 # Link with other targets.

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -109,7 +109,7 @@ set(test__dependency
 )
 source_group("test\\dependency" FILES ${test__dependency})
 
-set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp ecfmp/AircraftFlowMeasureMapTest.cpp ecfmp/AircraftFlowMeasureTagItemTest.cpp ecfmp/ListAircraftFlowMeasuresTest.cpp ecfmp/HomeFirsFlowMeasureFilterTest.cpp)
+set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp ecfmp/AircraftFlowMeasureMapTest.cpp ecfmp/AircraftFlowMeasureTagItemTest.cpp ecfmp/ListAircraftFlowMeasuresTest.cpp ecfmp/HomeFirsFlowMeasureFilterTest.cpp ecfmp/ControllerFlowMeasureRelevanceTest.cpp)
 source_group("test\\ecfmp" FILES ${test__ecfmp})
 
 set(test__euroscope

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -109,7 +109,7 @@ set(test__dependency
 )
 source_group("test\\dependency" FILES ${test__dependency})
 
-set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp ecfmp/AircraftFlowMeasureMapTest.cpp)
+set(test__ecfmp ecfmp/HttpClientTest.cpp ecfmp/TriggerEcfmpEventLoopTest.cpp ecfmp/ECFMPModuleFactoryTest.cpp ecfmp/ECFMPBootstrapProviderTest.cpp ecfmp/AircraftFlowMeasureMapTest.cpp ecfmp/AircraftFlowMeasureTagItemTest.cpp)
 source_group("test\\ecfmp" FILES ${test__ecfmp})
 
 set(test__euroscope

--- a/test/plugin/ecfmp/AircraftFlowMeasureMapTest.cpp
+++ b/test/plugin/ecfmp/AircraftFlowMeasureMapTest.cpp
@@ -1,0 +1,256 @@
+#include "ecfmp/AircraftFlowMeasureMap.h"
+#include "ECFMP/SdkEvents.h"
+#include "mock/FlowMeasureMock.h"
+#include "mock/MockEuroScopeCRadarTargetInterface.h"
+#include "mock/MockEuroscopePluginLoopbackInterface.h"
+#include <euroscope/EuroScopePlugIn.h>
+#include <gmock/gmock-nice-strict.h>
+
+namespace UKControllerPluginTest::ECFMP {
+    class AircraftFlowMeasureMapTest : public testing::Test
+    {
+        public:
+        AircraftFlowMeasureMapTest()
+            : mockFlowMeasure1(std::make_shared<::testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>()),
+              mockFlowMeasure2(std::make_shared<::testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>()),
+              mockFlightplan1(std::make_shared<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>>()),
+              mockRadarTarget1(std::make_shared<testing::NiceMock<Euroscope::MockEuroScopeCRadarTargetInterface>>()),
+              mockFlightplan2(std::make_shared<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>>()),
+              mockRadarTarget2(std::make_shared<testing::NiceMock<Euroscope::MockEuroScopeCRadarTargetInterface>>()),
+              map(mockPlugin)
+        {
+            ON_CALL(*mockFlightplan1, GetCallsign).WillByDefault(testing::Return("BAW123"));
+            ON_CALL(*mockFlightplan2, GetCallsign).WillByDefault(testing::Return("BAW456"));
+
+            ON_CALL(*mockFlightplan1, GetEuroScopeObject).WillByDefault(testing::ReturnRef(euroscopeFlightplan1));
+            ON_CALL(*mockFlightplan2, GetEuroScopeObject).WillByDefault(testing::ReturnRef(euroscopeFlightplan2));
+
+            ON_CALL(*mockRadarTarget1, GetEuroScopeObject).WillByDefault(testing::ReturnRef(euroscopeRadarTarget1));
+            ON_CALL(*mockRadarTarget2, GetEuroScopeObject).WillByDefault(testing::ReturnRef(euroscopeRadarTarget2));
+
+            mockPlugin.AddAllFlightplansItem({mockFlightplan1, mockRadarTarget1});
+            mockPlugin.AddAllFlightplansItem({mockFlightplan2, mockRadarTarget2});
+
+            ON_CALL(*mockFlowMeasure1, Id).WillByDefault(testing::Return(1));
+            ON_CALL(*mockFlowMeasure2, Id).WillByDefault(testing::Return(2));
+        }
+
+        std::shared_ptr<::ECFMP::Mock::FlowMeasure::FlowMeasureMock> mockFlowMeasure1;
+        std::shared_ptr<::ECFMP::Mock::FlowMeasure::FlowMeasureMock> mockFlowMeasure2;
+        EuroScopePlugIn::CFlightPlan euroscopeFlightplan1;
+        EuroScopePlugIn::CFlightPlan euroscopeFlightplan2;
+        EuroScopePlugIn::CRadarTarget euroscopeRadarTarget1;
+        EuroScopePlugIn::CRadarTarget euroscopeRadarTarget2;
+        std::shared_ptr<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>> mockFlightplan1;
+        std::shared_ptr<testing::NiceMock<Euroscope::MockEuroScopeCRadarTargetInterface>> mockRadarTarget1;
+        std::shared_ptr<testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface>> mockFlightplan2;
+        std::shared_ptr<testing::NiceMock<Euroscope::MockEuroScopeCRadarTargetInterface>> mockRadarTarget2;
+        testing::NiceMock<Euroscope::MockEuroscopePluginLoopbackInterface> mockPlugin;
+        UKControllerPlugin::ECFMP::AircraftFlowMeasureMap map;
+    };
+
+    TEST_F(AircraftFlowMeasureMapTest, FlowMeasuresActivatingUpdateAircraftsActiveFlowMeasures)
+    {
+        // Flightplan 1 will be applicable to the measure, flightplan 2, not so
+        EXPECT_CALL(*mockFlowMeasure1, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(false));
+
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure1});
+
+        // Check that flightplan 1 has the measure as applicable, but flightplan does not
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure1, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(0, map.GetFlowMeasuresForCallsign("BAW456").size());
+    }
+
+    TEST_F(AircraftFlowMeasureMapTest, FlowMeasuresWithdrawingRemoveThemFromAircraftsActiveFlowMeasures)
+    {
+        // Flightplan 1 will be applicable to the measure, flightplan 2, not so
+        EXPECT_CALL(*mockFlowMeasure1, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(false));
+
+        EXPECT_CALL(*mockFlowMeasure2, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(true));
+
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure1});
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure2});
+
+        // Check that flightplan 1 has both measures, but flightplan 2 has only the second
+        EXPECT_EQ(2, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure1, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(mockFlowMeasure2, *(++map.GetFlowMeasuresForCallsign("BAW123").begin()));
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+
+        // Withdraw the first measure
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{mockFlowMeasure1});
+
+        // Check that flightplan 1 now has just the second measure, but flightplan 2 has only the second
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+    }
+
+    TEST_F(AircraftFlowMeasureMapTest, FlowMeasuresWithdrawingRemovesAllFromActiveAircraftFlowMeasures)
+    {
+        // Flightplan 1 will be applicable to the measure, flightplan 2, not so
+        EXPECT_CALL(*mockFlowMeasure1, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(false));
+
+        EXPECT_CALL(*mockFlowMeasure2, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(true));
+
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure1});
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure2});
+
+        // Check that flightplan 1 has both measures, but flightplan 2 has only the second
+        EXPECT_EQ(2, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure1, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(mockFlowMeasure2, *(++map.GetFlowMeasuresForCallsign("BAW123").begin()));
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+
+        // Withdraw the measures
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{mockFlowMeasure1});
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{mockFlowMeasure2});
+
+        // Check that no flightplan has any measures
+        EXPECT_EQ(0, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(0, map.GetFlowMeasuresForCallsign("BAW456").size());
+    }
+
+    TEST_F(AircraftFlowMeasureMapTest, FlowMeasuresExpiringRemoveThemFromAircraftsActiveFlowMeasures)
+    {
+        // Flightplan 1 will be applicable to the measure, flightplan 2, not so
+        EXPECT_CALL(*mockFlowMeasure1, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(false));
+
+        EXPECT_CALL(*mockFlowMeasure2, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(true));
+
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure1});
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure2});
+
+        // Check that flightplan 1 has both measures, but flightplan 2 has only the second
+        EXPECT_EQ(2, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure1, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(mockFlowMeasure2, *(++map.GetFlowMeasuresForCallsign("BAW123").begin()));
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+
+        // Withdraw the first measure
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureExpiredEvent{mockFlowMeasure1});
+
+        // Check that flightplan 1 now has just the second measure, but flightplan 2 has only the second
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+    }
+
+    TEST_F(AircraftFlowMeasureMapTest, FlowMeasuresExpiringRemovesAllFromActiveAircraftFlowMeasures)
+    {
+        // Flightplan 1 will be applicable to the measure, flightplan 2, not so
+        EXPECT_CALL(*mockFlowMeasure1, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(false));
+
+        EXPECT_CALL(*mockFlowMeasure2, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(true));
+
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure1});
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure2});
+
+        // Check that flightplan 1 has both measures, but flightplan 2 has only the second
+        EXPECT_EQ(2, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure1, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(mockFlowMeasure2, *(++map.GetFlowMeasuresForCallsign("BAW123").begin()));
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+
+        // Withdraw the measures
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureExpiredEvent{mockFlowMeasure1});
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureExpiredEvent{mockFlowMeasure2});
+
+        // Check that no flightplan has any measures
+        EXPECT_EQ(0, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(0, map.GetFlowMeasuresForCallsign("BAW456").size());
+    }
+
+    TEST_F(AircraftFlowMeasureMapTest, FlightplansDisconnectingRemoveTheirActiveFlowMeasures)
+    {
+        // Flightplan 1 will be applicable to the measure, flightplan 2, not so
+        EXPECT_CALL(*mockFlowMeasure1, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(false));
+
+        EXPECT_CALL(*mockFlowMeasure2, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(true));
+
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure1});
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure2});
+
+        // Check that flightplan 1 has both measures, but flightplan 2 has only the second
+        EXPECT_EQ(2, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure1, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(mockFlowMeasure2, *(++map.GetFlowMeasuresForCallsign("BAW123").begin()));
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+
+        // Flightplan 1 disconnects
+        map.FlightPlanDisconnectEvent(*mockFlightplan1);
+
+        // Check that flightplan 1 has no measures and flightplan 2 is unaffected
+        EXPECT_EQ(0, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+    }
+
+    TEST_F(AircraftFlowMeasureMapTest, FlightplansChangingRecalculateTheFlowMeasures)
+    {
+        // Flightplan 1 will be applicable to the measure, flightplan 2, not so
+        EXPECT_CALL(*mockFlowMeasure1, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(false))
+            .WillOnce(testing::Return(false));
+
+        EXPECT_CALL(*mockFlowMeasure2, ApplicableToAircraft(testing::_, testing::_))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(true))
+            .WillOnce(testing::Return(true));
+
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure1});
+        map.OnEvent(::ECFMP::Plugin::FlowMeasureActivatedEvent{mockFlowMeasure2});
+
+        // Check that flightplan 1 has both measures, but flightplan 2 has only the second
+        EXPECT_EQ(2, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure1, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(mockFlowMeasure2, *(++map.GetFlowMeasuresForCallsign("BAW123").begin()));
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+
+        // Flightplan 1 changes
+        map.FlightPlanEvent(*mockFlightplan1, *mockRadarTarget1);
+
+        // Check that flightplan 1 now only has the second measure flightplan 2 is unaffected
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW123").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW123").begin());
+        EXPECT_EQ(1, map.GetFlowMeasuresForCallsign("BAW456").size());
+        EXPECT_EQ(mockFlowMeasure2, *map.GetFlowMeasuresForCallsign("BAW456").begin());
+    }
+
+    TEST_F(AircraftFlowMeasureMapTest, ItHandlesUnknownCallsignsWhenGettingMeasures)
+    {
+        EXPECT_EQ(0, map.GetFlowMeasuresForCallsign("BAW999").size());
+    }
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/AircraftFlowMeasureTagItemTest.cpp
+++ b/test/plugin/ecfmp/AircraftFlowMeasureTagItemTest.cpp
@@ -1,0 +1,106 @@
+#include "ecfmp/AircraftFlowMeasureTagItem.h"
+#include "ecfmp/AircraftFlowMeasureMapInterface.h"
+#include "mock/FlowMeasureMock.h"
+#include "tag/TagData.h"
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-nice-strict.h>
+
+namespace UKControllerPluginTest::ECFMP {
+
+    class MockFlowMeasureMap : public UKControllerPlugin::ECFMP::AircraftFlowMeasureMapInterface
+    {
+        public:
+        MOCK_METHOD(
+            const std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>&,
+            GetFlowMeasuresForCallsign,
+            (const std::string& callsign),
+            (const, override));
+    };
+
+    class AircraftFlowMeasureTagItemTest : public testing::Test
+    {
+        public:
+        AircraftFlowMeasureTagItemTest()
+            : tagData(
+                  mockFlightplan,
+                  mockRadarTarget,
+                  1,
+                  EuroScopePlugIn::TAG_DATA_CORRELATED,
+                  itemString,
+                  &euroscopeColourCode,
+                  &tagColour,
+                  &fontSize),
+              mockFlowMeasure1(std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>()),
+              mockFlowMeasure2(std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>()),
+              mockFlowMeasure3(std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>()),
+              mockFlowMeasureMap(std::make_shared<testing::NiceMock<const MockFlowMeasureMap>>()),
+              tagItem(mockFlowMeasureMap)
+        {
+            ON_CALL(mockFlightplan, GetCallsign).WillByDefault(testing::Return("BAW123"));
+            ON_CALL(*mockFlowMeasure1, Identifier).WillByDefault(testing::ReturnRef(measure1Identifier));
+            ON_CALL(*mockFlowMeasure2, Identifier).WillByDefault(testing::ReturnRef(measure2Identifier));
+            ON_CALL(*mockFlowMeasure3, Identifier).WillByDefault(testing::ReturnRef(measure3Identifier));
+        }
+
+        std::string measure1Identifier = "EGTT01A";
+        std::string measure2Identifier = "EGTT01B";
+        std::string measure3Identifier = "EGTT01C";
+        double fontSize = 24.1;
+        COLORREF tagColour = RGB(255, 255, 255);
+        int euroscopeColourCode = EuroScopePlugIn::TAG_COLOR_ASSUMED;
+        char itemString[16] = "Foooooo";
+        testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface> mockFlightplan;
+        testing::NiceMock<Euroscope::MockEuroScopeCRadarTargetInterface> mockRadarTarget;
+        UKControllerPlugin::Tag::TagData tagData;
+        std::shared_ptr<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>> mockFlowMeasure1;
+        std::shared_ptr<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>> mockFlowMeasure2;
+        std::shared_ptr<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>> mockFlowMeasure3;
+        std::shared_ptr<testing::NiceMock<const MockFlowMeasureMap>> mockFlowMeasureMap;
+        UKControllerPlugin::ECFMP::AircraftFlowMeasureTagItem tagItem;
+    };
+
+    TEST_F(AircraftFlowMeasureTagItemTest, ItHasADescription)
+    {
+        EXPECT_EQ(tagItem.GetTagItemDescription(0), "Relevant ECFMP Flow Measures");
+    }
+
+    TEST_F(AircraftFlowMeasureTagItemTest, ItSetsTagItemDataNoMeasures)
+    {
+        const auto emptyMeasures = std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>{};
+        ON_CALL(*mockFlowMeasureMap, GetFlowMeasuresForCallsign("BAW123"))
+            .WillByDefault(testing::ReturnRef(emptyMeasures));
+
+        tagItem.SetTagItemData(tagData);
+        EXPECT_EQ("Foooooo", tagData.GetItemString());
+    }
+
+    TEST_F(AircraftFlowMeasureTagItemTest, ItSetsTagItemDataOneMeasure)
+    {
+        const auto measures =
+            std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>{mockFlowMeasure1};
+        ON_CALL(*mockFlowMeasureMap, GetFlowMeasuresForCallsign("BAW123")).WillByDefault(testing::ReturnRef(measures));
+
+        tagItem.SetTagItemData(tagData);
+        EXPECT_EQ("EGTT01A", tagData.GetItemString());
+    }
+
+    TEST_F(AircraftFlowMeasureTagItemTest, ItSetsTagItemDataTwoMeasures)
+    {
+        const auto measures = std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>{
+            mockFlowMeasure1, mockFlowMeasure2};
+        ON_CALL(*mockFlowMeasureMap, GetFlowMeasuresForCallsign("BAW123")).WillByDefault(testing::ReturnRef(measures));
+
+        tagItem.SetTagItemData(tagData);
+        EXPECT_EQ("(2)EGTT01A", tagData.GetItemString());
+    }
+
+    TEST_F(AircraftFlowMeasureTagItemTest, ItSetsTagItemDataManyMeasures)
+    {
+        const auto measures = std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>{
+            mockFlowMeasure1, mockFlowMeasure2, mockFlowMeasure3};
+        ON_CALL(*mockFlowMeasureMap, GetFlowMeasuresForCallsign("BAW123")).WillByDefault(testing::ReturnRef(measures));
+
+        tagItem.SetTagItemData(tagData);
+        EXPECT_EQ("(3)EGTT01A", tagData.GetItemString());
+    }
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ControllerFlowMeasureRelevanceTest.cpp
+++ b/test/plugin/ecfmp/ControllerFlowMeasureRelevanceTest.cpp
@@ -1,0 +1,652 @@
+
+#include "ECFMP/flightinformationregion/FlightInformationRegion.h"
+#include "controller/ActiveCallsign.h"
+#include "controller/ActiveCallsignCollection.h"
+#include "controller/ControllerPosition.h"
+#include "ecfmp/ControllerFlowMeasureRelevance.h"
+#include "mock/FlowMeasureMock.h"
+#include "mock/MockEuroScopeCFlightplanInterface.h"
+#include <gmock/gmock-actions.h>
+
+namespace UKControllerPluginTest::ECFMP {
+
+    struct ControllerFlowMeasureRelevanceTestCase
+    {
+        // Test case name
+        std::string description;
+
+        // Notified fir ICAOs
+        std::vector<std::string> notifiedFirIcaos;
+
+        // User callsign (blank for none)
+        std::string userCallsign;
+
+        // Expected result
+        bool expectedResult;
+    };
+
+    class ControllerFlowMeasureRelevanceTest : public ::testing::TestWithParam<ControllerFlowMeasureRelevanceTestCase>
+    {
+        public:
+        ControllerFlowMeasureRelevanceTest() : controllerFlowMeasureRelevance(activeCallsigns)
+        {
+        }
+
+        testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface> flightPlan;
+        testing::NiceMock<Euroscope::MockEuroScopeCRadarTargetInterface> radarTarget;
+        UKControllerPlugin::Controller::ActiveCallsignCollection activeCallsigns;
+        UKControllerPlugin::ECFMP::ControllerFlowMeasureRelevance controllerFlowMeasureRelevance;
+    };
+
+    TEST_P(ControllerFlowMeasureRelevanceTest, FlowMeasureApplicableToAircraft)
+    {
+        const auto& testCase = GetParam();
+
+        // Set the user callsign
+        UKControllerPlugin::Controller::ControllerPosition position(
+            1, testCase.userCallsign, 121.800, {"EGKK"}, true, false);
+        UKControllerPlugin::Controller::ActiveCallsign callsign(
+            testCase.userCallsign, "Testy McTestface", position, true);
+        if (!testCase.userCallsign.empty()) {
+            activeCallsigns.AddUserCallsign(callsign);
+        }
+
+        // Create the flow measure
+        std::vector<std::shared_ptr<const ::ECFMP::FlightInformationRegion::FlightInformationRegion>> notifiedFirs;
+        for (const auto& notifiedFirIcao : testCase.notifiedFirIcaos) {
+            const auto mockFir = std::make_shared<
+                testing::NiceMock<::ECFMP::Mock::FlightInformationRegion::FlightInformationRegionMock>>();
+            ON_CALL(*mockFir, Identifier).WillByDefault(testing::ReturnRef(notifiedFirIcao));
+            notifiedFirs.push_back(mockFir);
+        }
+
+        testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock> mockFlowMeasure;
+        ON_CALL(mockFlowMeasure, NotifiedFlightInformationRegions).WillByDefault(testing::ReturnRef(notifiedFirs));
+
+        // Check the result
+        EXPECT_EQ(
+            controllerFlowMeasureRelevance.FlowMeasureApplicableToAircraft(flightPlan, radarTarget, mockFlowMeasure),
+            testCase.expectedResult);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(
+        ControllerFlowMeasureRelevanceTest,
+        ControllerFlowMeasureRelevanceTest,
+        testing::Values(
+            // No callsigns
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_user_has_no_callsign_london",
+                {"EGTT", "LFBB"},
+                "",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_user_has_no_callsign_scottish",
+                {"EGPX", "LFBB"},
+                "",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_user_has_no_callsign_global",
+                {"XXXX", "LFBB"},
+                "",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_user_has_no_callsign_other",
+                {"LFBB"},
+                "",
+                true,
+            },
+
+            // Global FIRs
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_london_bandbox_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "LON_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_london_split_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "LON_W_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_scottish_bandbox_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "SCO_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_scottish_split_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "SCO_E_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_ltc_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "LTC_SE_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_man_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "MAN_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_man_split_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "MAN_S_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_stc_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "STC_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_stc_split_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "STC_A_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_eggd_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "EGGD_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egll_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "EGLL_S_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egkk_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "EGKK_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egph_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "EGPH_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_sco_mil_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "EGQP_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egaa_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "EGAA_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_essex_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "ESSEX_APP",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_thames_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "THAMES_APP",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_solent_and_flow_measure_targeting_global",
+                {"XXXX"},
+                "SOLENT_APP",
+                true,
+            },
+
+            // EGTT
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_london_bandbox_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "LON_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_london_split_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "LON_W_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_scottish_bandbox_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "SCO_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_scottish_split_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "SCO_E_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_ltc_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "LTC_SE_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_man_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "MAN_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_man_split_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "MAN_S_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_stc_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "STC_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_stc_split_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "STC_A_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_eggd_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "EGGD_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egll_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "EGLL_S_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egkk_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "EGKK_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_egph_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "EGPH_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_sco_mil_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "EGQP_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_egaa_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "EGAA_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_essex_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "ESSEX_APP",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_thames_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "THAMES_APP",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_solent_and_flow_measure_targeting_london",
+                {"EGTT", "LFBB"},
+                "SOLENT_APP",
+                true,
+            },
+
+            // EGPX
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_london_bandbox_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "LON_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_london_split_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "LON_W_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_scottish_bandbox_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "SCO_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_scottish_split_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "SCO_E_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_ltc_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "LTC_SE_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_man_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "MAN_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_man_split_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "MAN_S_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_stc_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "STC_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_stc_split_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "STC_A_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_eggd_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "EGGD_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_egll_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "EGLL_S_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_egkk_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "EGKK_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egph_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "EGPH_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_sco_mil_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "EGQP_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egaa_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "EGAA_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_essex_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "ESSEX_APP",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_thames_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "THAMES_APP",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_solent_and_flow_measure_targeting_scottish",
+                {"EGPX", "LFBB"},
+                "SOLENT_APP",
+                false,
+            },
+
+            // EGTT and EGPX
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_london_bandbox_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "LON_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_london_split_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "LON_W_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_scottish_bandbox_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "SCO_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_scottish_split_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "SCO_E_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_ltc_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "LTC_SE_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_man_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "MAN_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_man_split_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "MAN_S_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_stc_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "STC_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_stc_split_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "STC_A_CTR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_eggd_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "EGGD_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egll_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "EGLL_S_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egkk_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "EGKK_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egph_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "EGPH_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_sco_mil_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "EGQP_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_egaa_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "EGAA_TWR",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_essex_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "ESSEX_APP",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_thames_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "THAMES_APP",
+                true,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_true_controller_is_solent_and_flow_measure_targeting_both",
+                {"EGTT", "EGPX", "LFBB"},
+                "SOLENT_APP",
+                true,
+            },
+
+            // LFBB
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_london_bandbox_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "LON_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_london_split_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "LON_W_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_scottish_bandbox_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "SCO_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_scottish_split_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "SCO_E_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_ltc_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "LTC_SE_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_man_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "MAN_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_man_split_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "MAN_S_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_stc_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "STC_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_stc_split_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "STC_A_CTR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_eggd_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "EGGD_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_egll_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "EGLL_S_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_egkk_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "EGKK_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_egph_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "EGPH_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_sco_mil_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "EGQP_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_egaa_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "EGAA_TWR",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_essex_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "ESSEX_APP",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_thames_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "THAMES_APP",
+                false,
+            },
+            ControllerFlowMeasureRelevanceTestCase{
+                "returns_false_controller_is_solent_and_flow_measure_targeting_others",
+                {"EDDB", "LOVV", "LFBB"},
+                "SOLENT_APP",
+                false,
+            }),
+        [](const auto& info) { return info.param.description; });
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
+++ b/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
@@ -1,0 +1,22 @@
+#include "ecfmp/ECFMPBootstrapProvider.h"
+#include "test/BootstrapProviderTestCase.h"
+#include "timedevent/TimedEventCollection.h"
+
+namespace UKControllerPluginTest::ECFMP {
+    class ECFMPBootstrapProviderTest : public UKControllerPluginTest::BootstrapProviderTestCase
+    {
+        public:
+        ECFMPBootstrapProviderTest()
+        {
+        }
+
+        UKControllerPlugin::ECFMP::ECFMPBootstrapProvider provider;
+    };
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersForTimedEventsOnBootstrapPlugin)
+    {
+        RunBootstrapPlugin(provider);
+        EXPECT_EQ(1, container.timedHandler->CountHandlers());
+        EXPECT_EQ(1, container.timedHandler->CountHandlersForFrequency(1));
+    }
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
+++ b/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
@@ -3,6 +3,7 @@
 #include "ecfmp/AircraftFlowMeasureMap.h"
 #include "ecfmp/ECFMPBootstrapProvider.h"
 #include "ecfmp/ECFMPModuleFactory.h"
+#include "flightplan/FlightPlanEventHandlerCollection.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "tag/TagItemCollection.h"
 #include "test/BootstrapProviderTestCase.h"
@@ -15,6 +16,8 @@ namespace UKControllerPluginTest::ECFMP {
         ECFMPBootstrapProviderTest()
         {
             container.dialogManager = std::make_unique<UKControllerPlugin::Dialog::DialogManager>(mockDialogProvider);
+            container.flightplanHandler =
+                std::make_unique<UKControllerPlugin::Flightplan::FlightPlanEventHandlerCollection>();
         }
 
         testing::NiceMock<Curl::MockCurlApi> mockCurlApi;
@@ -84,5 +87,11 @@ namespace UKControllerPluginTest::ECFMP {
                                    UKControllerPlugin::ECFMP::AircraftFlowMeasureMap,
                                    ::ECFMP::Plugin::FlowMeasureExpiredEvent>();
         EXPECT_TRUE(hasListener);
+    }
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersTheFlowMeasureMapForFlightplanEvents)
+    {
+        RunBootstrapPlugin(provider);
+        EXPECT_EQ(1, container.flightplanHandler->CountHandlers());
     }
 } // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
+++ b/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
@@ -1,5 +1,6 @@
 #include "ecfmp/ECFMPBootstrapProvider.h"
 #include "test/BootstrapProviderTestCase.h"
+#include "tag/TagItemCollection.h"
 #include "timedevent/TimedEventCollection.h"
 
 namespace UKControllerPluginTest::ECFMP {
@@ -18,5 +19,12 @@ namespace UKControllerPluginTest::ECFMP {
         RunBootstrapPlugin(provider);
         EXPECT_EQ(1, container.timedHandler->CountHandlers());
         EXPECT_EQ(1, container.timedHandler->CountHandlersForFrequency(1));
+    }
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersTagItemForRelevantFlowMeasures)
+    {
+        RunBootstrapPlugin(provider);
+        EXPECT_EQ(1, container.tagHandler->CountHandlers());
+        EXPECT_EQ(1, container.tagHandler->HasHandlerForItemId(131));
     }
 } // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
+++ b/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
@@ -1,6 +1,9 @@
+#include "dialog/DialogManager.h"
 #include "ecfmp/ECFMPBootstrapProvider.h"
-#include "test/BootstrapProviderTestCase.h"
+#include "mock/MockDialogProvider.h"
+#include "plugin/FunctionCallEventHandler.h"
 #include "tag/TagItemCollection.h"
+#include "test/BootstrapProviderTestCase.h"
 #include "timedevent/TimedEventCollection.h"
 
 namespace UKControllerPluginTest::ECFMP {
@@ -9,8 +12,10 @@ namespace UKControllerPluginTest::ECFMP {
         public:
         ECFMPBootstrapProviderTest()
         {
+            container.dialogManager = std::make_unique<UKControllerPlugin::Dialog::DialogManager>(mockDialogProvider);
         }
 
+        testing::NiceMock<Dialog::MockDialogProvider> mockDialogProvider;
         UKControllerPlugin::ECFMP::ECFMPBootstrapProvider provider;
     };
 
@@ -26,5 +31,19 @@ namespace UKControllerPluginTest::ECFMP {
         RunBootstrapPlugin(provider);
         EXPECT_EQ(1, container.tagHandler->CountHandlers());
         EXPECT_EQ(1, container.tagHandler->HasHandlerForItemId(131));
+    }
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersTheFlowMeasuresDialog)
+    {
+        RunBootstrapPlugin(provider);
+        EXPECT_EQ(1, container.dialogManager->CountDialogs());
+        EXPECT_EQ(1, container.dialogManager->HasDialog(IDD_FLOW_MEASURE_LIST));
+    }
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersTheListFlowMeasuresTagFunction)
+    {
+        RunBootstrapPlugin(provider);
+        EXPECT_EQ(1, container.pluginFunctionHandlers->CountTagFunctions());
+        EXPECT_EQ(1, container.pluginFunctionHandlers->HasTagFunction(9023));
     }
 } // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
+++ b/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
@@ -1,4 +1,5 @@
 #include "bootstrap/ModuleFactories.h"
+#include "controller/ActiveCallsignCollection.h"
 #include "dialog/DialogManager.h"
 #include "ecfmp/AircraftFlowMeasureMap.h"
 #include "ecfmp/ECFMPBootstrapProvider.h"
@@ -21,6 +22,7 @@ namespace UKControllerPluginTest::ECFMP {
         }
 
         testing::NiceMock<Curl::MockCurlApi> mockCurlApi;
+        UKControllerPlugin::Controller::ActiveCallsignCollection activeCallsigns;
         testing::NiceMock<Dialog::MockDialogProvider> mockDialogProvider;
         UKControllerPlugin::ECFMP::ECFMPBootstrapProvider provider;
     };
@@ -57,7 +59,7 @@ namespace UKControllerPluginTest::ECFMP {
     {
         RunBootstrapPlugin(provider);
         auto hasListener = container.moduleFactories->ECFMP()
-                               .Sdk(mockCurlApi)
+                               .Sdk(mockCurlApi, activeCallsigns)
                                ->EventBus()
                                .HasListenerOfType<
                                    UKControllerPlugin::ECFMP::AircraftFlowMeasureMap,
@@ -69,7 +71,7 @@ namespace UKControllerPluginTest::ECFMP {
     {
         RunBootstrapPlugin(provider);
         auto hasListener = container.moduleFactories->ECFMP()
-                               .Sdk(mockCurlApi)
+                               .Sdk(mockCurlApi, activeCallsigns)
                                ->EventBus()
                                .HasListenerOfType<
                                    UKControllerPlugin::ECFMP::AircraftFlowMeasureMap,
@@ -81,7 +83,7 @@ namespace UKControllerPluginTest::ECFMP {
     {
         RunBootstrapPlugin(provider);
         auto hasListener = container.moduleFactories->ECFMP()
-                               .Sdk(mockCurlApi)
+                               .Sdk(mockCurlApi, activeCallsigns)
                                ->EventBus()
                                .HasListenerOfType<
                                    UKControllerPlugin::ECFMP::AircraftFlowMeasureMap,
@@ -93,5 +95,11 @@ namespace UKControllerPluginTest::ECFMP {
     {
         RunBootstrapPlugin(provider);
         EXPECT_EQ(1, container.flightplanHandler->CountHandlers());
+    }
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersTheFlowMeasureMapForActiveCallsignEvents)
+    {
+        RunBootstrapPlugin(provider);
+        EXPECT_EQ(1, container.activeCallsigns->CountHandlers());
     }
 } // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
+++ b/test/plugin/ecfmp/ECFMPBootstrapProviderTest.cpp
@@ -1,6 +1,8 @@
+#include "bootstrap/ModuleFactories.h"
 #include "dialog/DialogManager.h"
+#include "ecfmp/AircraftFlowMeasureMap.h"
 #include "ecfmp/ECFMPBootstrapProvider.h"
-#include "mock/MockDialogProvider.h"
+#include "ecfmp/ECFMPModuleFactory.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "tag/TagItemCollection.h"
 #include "test/BootstrapProviderTestCase.h"
@@ -15,6 +17,7 @@ namespace UKControllerPluginTest::ECFMP {
             container.dialogManager = std::make_unique<UKControllerPlugin::Dialog::DialogManager>(mockDialogProvider);
         }
 
+        testing::NiceMock<Curl::MockCurlApi> mockCurlApi;
         testing::NiceMock<Dialog::MockDialogProvider> mockDialogProvider;
         UKControllerPlugin::ECFMP::ECFMPBootstrapProvider provider;
     };
@@ -45,5 +48,41 @@ namespace UKControllerPluginTest::ECFMP {
         RunBootstrapPlugin(provider);
         EXPECT_EQ(1, container.pluginFunctionHandlers->CountTagFunctions());
         EXPECT_EQ(1, container.pluginFunctionHandlers->HasTagFunction(9023));
+    }
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersTheFlowMeasureMapForECFMPActivatedEvents)
+    {
+        RunBootstrapPlugin(provider);
+        auto hasListener = container.moduleFactories->ECFMP()
+                               .Sdk(mockCurlApi)
+                               ->EventBus()
+                               .HasListenerOfType<
+                                   UKControllerPlugin::ECFMP::AircraftFlowMeasureMap,
+                                   ::ECFMP::Plugin::FlowMeasureActivatedEvent>();
+        EXPECT_TRUE(hasListener);
+    }
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersTheFlowMeasureMapForECFMPWithdrawnEvents)
+    {
+        RunBootstrapPlugin(provider);
+        auto hasListener = container.moduleFactories->ECFMP()
+                               .Sdk(mockCurlApi)
+                               ->EventBus()
+                               .HasListenerOfType<
+                                   UKControllerPlugin::ECFMP::AircraftFlowMeasureMap,
+                                   ::ECFMP::Plugin::FlowMeasureWithdrawnEvent>();
+        EXPECT_TRUE(hasListener);
+    }
+
+    TEST_F(ECFMPBootstrapProviderTest, ItRegistersTheFlowMeasureMapForECFMPExpiredEvents)
+    {
+        RunBootstrapPlugin(provider);
+        auto hasListener = container.moduleFactories->ECFMP()
+                               .Sdk(mockCurlApi)
+                               ->EventBus()
+                               .HasListenerOfType<
+                                   UKControllerPlugin::ECFMP::AircraftFlowMeasureMap,
+                                   ::ECFMP::Plugin::FlowMeasureExpiredEvent>();
+        EXPECT_TRUE(hasListener);
     }
 } // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ECFMPModuleFactoryTest.cpp
+++ b/test/plugin/ecfmp/ECFMPModuleFactoryTest.cpp
@@ -1,3 +1,4 @@
+#include "controller/ActiveCallsignCollection.h"
 #include "ecfmp/ECFMPModuleFactory.h"
 #include "mock/MockCurlApi.h"
 
@@ -10,19 +11,20 @@ namespace UKControllerPluginTest::ECFMP {
         }
 
         testing::NiceMock<Curl::MockCurlApi> mockCurl;
+        UKControllerPlugin::Controller::ActiveCallsignCollection callsigns;
         UKControllerPlugin::ECFMP::ECFMPModuleFactory factory;
     };
 
     TEST_F(ECFMPModuleFactoryTest, ItCreatesTheECFMPSDK)
     {
-        const auto sdk = factory.Sdk(mockCurl);
+        const auto sdk = factory.Sdk(mockCurl, callsigns);
         EXPECT_EQ(0, sdk->FlowMeasures()->Count());
     }
 
     TEST_F(ECFMPModuleFactoryTest, ItReturnsTheSdkAsASingleton)
     {
-        const auto sdk1 = factory.Sdk(mockCurl);
-        const auto sdk2 = factory.Sdk(mockCurl);
+        const auto sdk1 = factory.Sdk(mockCurl, callsigns);
+        const auto sdk2 = factory.Sdk(mockCurl, callsigns);
         EXPECT_EQ(sdk1, sdk2);
     }
 } // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ECFMPModuleFactoryTest.cpp
+++ b/test/plugin/ecfmp/ECFMPModuleFactoryTest.cpp
@@ -1,0 +1,28 @@
+#include "ecfmp/ECFMPModuleFactory.h"
+#include "mock/MockCurlApi.h"
+
+namespace UKControllerPluginTest::ECFMP {
+    class ECFMPModuleFactoryTest : public testing::Test
+    {
+        public:
+        ECFMPModuleFactoryTest()
+        {
+        }
+
+        testing::NiceMock<Curl::MockCurlApi> mockCurl;
+        UKControllerPlugin::ECFMP::ECFMPModuleFactory factory;
+    };
+
+    TEST_F(ECFMPModuleFactoryTest, ItCreatesTheECFMPSDK)
+    {
+        const auto sdk = factory.Sdk(mockCurl);
+        EXPECT_EQ(0, sdk->FlowMeasures()->Count());
+    }
+
+    TEST_F(ECFMPModuleFactoryTest, ItReturnsTheSdkAsASingleton)
+    {
+        const auto sdk1 = factory.Sdk(mockCurl);
+        const auto sdk2 = factory.Sdk(mockCurl);
+        EXPECT_EQ(sdk1, sdk2);
+    }
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/HomeFirsFlowMeasureFilterTest.cpp
+++ b/test/plugin/ecfmp/HomeFirsFlowMeasureFilterTest.cpp
@@ -52,13 +52,19 @@ namespace UKControllerPluginTest::ECFMP {
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureActivatedEvent{measure}));
     }
 
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnActivatedEventIfIsGlobal)
+    {
+        const auto measure = GetMeasure({"LFFF", "XXXX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureActivatedEvent{measure}));
+    }
+
     TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnActivatedEventIfIsScottishAndLondon)
     {
         const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureActivatedEvent{measure}));
     }
 
-    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnActivatedEventIfIsNotScottishOrLondon)
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnActivatedEventIfIsNotScottishOrLondonOrGlobal)
     {
         const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
         EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureActivatedEvent{measure}));
@@ -76,13 +82,19 @@ namespace UKControllerPluginTest::ECFMP {
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{measure}));
     }
 
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnWithdrawnEventIfIsGlobal)
+    {
+        const auto measure = GetMeasure({"LFFF", "XXXX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{measure}));
+    }
+
     TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnWithdrawnEventIfIsScottishAndLondon)
     {
         const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{measure}));
     }
 
-    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnWithdrawnEventIfIsNotScottishOrLondon)
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnWithdrawnEventIfIsNotScottishOrLondonOrGlobal)
     {
         const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
         EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{measure}));
@@ -100,13 +112,19 @@ namespace UKControllerPluginTest::ECFMP {
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureExpiredEvent{measure}));
     }
 
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnExpiredEventIfIsGlobal)
+    {
+        const auto measure = GetMeasure({"LFFF", "XXXX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureExpiredEvent{measure}));
+    }
+
     TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnExpiredEventIfIsScottishAndLondon)
     {
         const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureExpiredEvent{measure}));
     }
 
-    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnExpiredEventIfIsNotScottishOrLondon)
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnExpiredEventIfIsNotScottishOrLondonOrGlobal)
     {
         const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
         EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureExpiredEvent{measure}));
@@ -124,13 +142,19 @@ namespace UKControllerPluginTest::ECFMP {
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureNotifiedEvent{measure}));
     }
 
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnNotifiedEventIfIsGlobal)
+    {
+        const auto measure = GetMeasure({"LFFF", "XXXX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureNotifiedEvent{measure}));
+    }
+
     TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnNotifiedEventIfIsScottishAndLondon)
     {
         const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureNotifiedEvent{measure}));
     }
 
-    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnNotifiedEventIfIsNotScottishOrLondon)
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnNotifiedEventIfIsNotScottishOrLondonOrGlobal)
     {
         const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
         EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureNotifiedEvent{measure}));
@@ -148,13 +172,19 @@ namespace UKControllerPluginTest::ECFMP {
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureReissuedEvent{measure}));
     }
 
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnReissuedEventIfIsGlobal)
+    {
+        const auto measure = GetMeasure({"LFFF", "XXXX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureReissuedEvent{measure}));
+    }
+
     TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnReissuedEventIfIsScottishAndLondon)
     {
         const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
         EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureReissuedEvent{measure}));
     }
 
-    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnReissuedEventIfIsNotScottishOrLondon)
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnReissuedEventIfIsNotScottishOrLondonOrGlobal)
     {
         const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
         EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureReissuedEvent{measure}));

--- a/test/plugin/ecfmp/HomeFirsFlowMeasureFilterTest.cpp
+++ b/test/plugin/ecfmp/HomeFirsFlowMeasureFilterTest.cpp
@@ -1,0 +1,162 @@
+#include "ecfmp/HomeFirsFlowMeasureFilter.h"
+#include "ECFMP/SdkEvents.h"
+#include "ECFMP/flightinformationregion/FlightInformationRegion.h"
+
+namespace UKControllerPluginTest::ECFMP {
+    class HomeFirsFlowMeasureFilterTest : public testing::Test
+    {
+        public:
+        [[nodiscard]] auto GetMeasure(const std::vector<std::string>& notifiedFirs)
+            -> std::shared_ptr<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>
+        {
+            firIcaos = notifiedFirs;
+            auto measure = std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>();
+            firs = GetRegions(firIcaos);
+
+            ON_CALL(*measure, NotifiedFlightInformationRegions).WillByDefault(testing::ReturnRef(firs));
+
+            return measure;
+        }
+
+        UKControllerPlugin::ECFMP::HomeFirsFlowMeasureFilter filter;
+
+        private:
+        [[nodiscard]] static auto GetRegions(const std::vector<std::string>& icaoCodes)
+            -> std::vector<std::shared_ptr<const ::ECFMP::FlightInformationRegion::FlightInformationRegion>>
+        {
+            std::vector<std::shared_ptr<const ::ECFMP::FlightInformationRegion::FlightInformationRegion>> regions;
+
+            for (const auto& icaoCode : icaoCodes) {
+                auto mock = std::make_shared<
+                    ::testing::NiceMock<::ECFMP::Mock::FlightInformationRegion::FlightInformationRegionMock>>();
+                ON_CALL(*mock, Identifier).WillByDefault(testing::ReturnRef(icaoCode));
+                regions.push_back(mock);
+            }
+
+            return regions;
+        }
+
+        std::vector<std::string> firIcaos;
+        std::vector<std::shared_ptr<const ::ECFMP::FlightInformationRegion::FlightInformationRegion>> firs;
+    };
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnActivatedEventIfIsLondon)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGTT"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureActivatedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnActivatedEventIfIsScottish)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureActivatedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnActivatedEventIfIsScottishAndLondon)
+    {
+        const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureActivatedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnActivatedEventIfIsNotScottishOrLondon)
+    {
+        const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
+        EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureActivatedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnWithdrawnEventIfIsLondon)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGTT"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnWithdrawnEventIfIsScottish)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnWithdrawnEventIfIsScottishAndLondon)
+    {
+        const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnWithdrawnEventIfIsNotScottishOrLondon)
+    {
+        const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
+        EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureWithdrawnEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnExpiredEventIfIsLondon)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGTT"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureExpiredEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnExpiredEventIfIsScottish)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureExpiredEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnExpiredEventIfIsScottishAndLondon)
+    {
+        const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureExpiredEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnExpiredEventIfIsNotScottishOrLondon)
+    {
+        const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
+        EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureExpiredEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnNotifiedEventIfIsLondon)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGTT"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureNotifiedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnNotifiedEventIfIsScottish)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureNotifiedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnNotifiedEventIfIsScottishAndLondon)
+    {
+        const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureNotifiedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnNotifiedEventIfIsNotScottishOrLondon)
+    {
+        const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
+        EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureNotifiedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnReissuedEventIfIsLondon)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGTT"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureReissuedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnReissuedEventIfIsScottish)
+    {
+        const auto measure = GetMeasure({"LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureReissuedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsTrueOnReissuedEventIfIsScottishAndLondon)
+    {
+        const auto measure = GetMeasure({"EGTT", "LFFF", "EGPX"});
+        EXPECT_TRUE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureReissuedEvent{measure}));
+    }
+
+    TEST_F(HomeFirsFlowMeasureFilterTest, ShouldProcessReturnsFalseOnReissuedEventIfIsNotScottishOrLondon)
+    {
+        const auto measure = GetMeasure({"EDDM", "LFFF", "EURW"});
+        EXPECT_FALSE(filter.ShouldProcess(::ECFMP::Plugin::FlowMeasureReissuedEvent{measure}));
+    }
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/HttpClientTest.cpp
+++ b/test/plugin/ecfmp/HttpClientTest.cpp
@@ -1,0 +1,33 @@
+#include "curl/CurlResponse.h"
+#include "ecfmp/HttpClient.h"
+
+namespace UKControllerPluginTest::ECFMP {
+    class HttpClientTest : public testing::Test
+    {
+        public:
+        HttpClientTest() : client(mockCurlApi)
+        {
+        }
+
+        testing::NiceMock<Curl::MockCurlApi> mockCurlApi;
+        UKControllerPlugin::ECFMP::HttpClient client;
+    };
+
+    TEST_F(HttpClientTest, GetReturnsCurlErrorStatusWhenCurlRequestFails)
+    {
+        EXPECT_CALL(mockCurlApi, MakeCurlRequest(testing::_))
+            .WillOnce(testing::Return(UKControllerPlugin::Curl::CurlResponse{"", true, 0L}));
+        const auto response = client.Get("http://www.example.com");
+        EXPECT_EQ(999, response.statusCode);
+        EXPECT_EQ("", response.body);
+    }
+
+    TEST_F(HttpClientTest, GetReturnsCurlResponse)
+    {
+        EXPECT_CALL(mockCurlApi, MakeCurlRequest(testing::_))
+            .WillOnce(testing::Return(UKControllerPlugin::Curl::CurlResponse{"response body", false, 418L}));
+        const auto response = client.Get("http://www.example.com");
+        EXPECT_EQ("response body", response.body);
+        EXPECT_EQ(418L, response.statusCode);
+    }
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/ListAircraftFlowMeasuresTest.cpp
+++ b/test/plugin/ecfmp/ListAircraftFlowMeasuresTest.cpp
@@ -1,0 +1,128 @@
+#include "dialog/DialogCallArgument.h"
+#include "ecfmp/AircraftFlowMeasureMapInterface.h"
+#include "ecfmp/AircraftFlowMeasuresDialog.h"
+#include "ecfmp/ListAircraftFlowMeasures.h"
+#include "dialog/DialogManager.h"
+#include "mock/FlowMeasureFiltersMock.h"
+#include "mock/FlowMeasureMock.h"
+#include "mock/MeasureMock.h"
+#include "mock/MockEuroScopeCFlightplanInterface.h"
+#include <gmock/gmock-nice-strict.h>
+
+namespace UKControllerPluginTest::ECFMP {
+
+    class MockListAircraftFlowMeasureMap : public UKControllerPlugin::ECFMP::AircraftFlowMeasureMapInterface
+    {
+        public:
+        MOCK_METHOD(
+            const std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>&,
+            GetFlowMeasuresForCallsign,
+            (const std::string& callsign),
+            (const, override));
+    };
+
+    auto MatchesExpectedFlowMeasureString(const UKControllerPlugin::Dialog::DialogCallArgument* const arg) -> int
+    {
+        const auto castedArg = reinterpret_cast<const UKControllerPlugin::ECFMP::AircraftFlowMeasuresDialogData* const>(
+            reinterpret_cast<const UKControllerPlugin::Dialog::DialogCallArgument* const>(arg)->contextArgument);
+
+        std::wstring expected;
+        expected += L"Measure: EGTT01A\r\n\r\n";
+        expected += L"Minimum Departure Interval: 5 Minutes\r\n\r\n";
+        expected += L"Applicable To:\r\n\r\n";
+        expected += L"Departing: EGKK\r\n";
+        expected += L"Arriving: EGLL\r\n\r\n";
+        expected += L"End of measure EGTT01A\r\n\r\n";
+        expected += L"Measure: EGTT01B\r\n\r\n";
+        expected += L"Minimum Departure Interval: 3 Minutes\r\n\r\n";
+        expected += L"Applicable To:\r\n\r\n";
+        expected += L"Departing: EGCC\r\n";
+        expected += L"Arriving: EGPH\r\n\r\n";
+        expected += L"End of measure EGTT01B";
+
+        return L"BAW123" == castedArg->callsign && expected == castedArg->flowMeasures ? 1 : 0;
+    }
+
+    class ListAircraftFlowMeasuresTest : public testing::Test
+    {
+        public:
+        ListAircraftFlowMeasuresTest()
+            : dialogManager(dialogProvider),
+              flowMeasureMap(std::make_shared<testing::NiceMock<MockListAircraftFlowMeasureMap>>()),
+              listAircraftFlowMeasures(flowMeasureMap, dialogManager)
+        {
+            dialogManager.AddDialog(dialogData);
+            ON_CALL(mockFlightplan, GetCallsign).WillByDefault(testing::Return("BAW123"));
+        }
+
+        testing::NiceMock<Euroscope::MockEuroScopeCFlightPlanInterface> mockFlightplan;
+        UKControllerPlugin::Dialog::DialogData dialogData = {IDD_FLOW_MEASURE_LIST, "", nullptr, NULL, nullptr};
+        testing::NiceMock<Dialog::MockDialogProvider> dialogProvider;
+        UKControllerPlugin::Dialog::DialogManager dialogManager;
+        std::shared_ptr<MockListAircraftFlowMeasureMap> flowMeasureMap;
+        UKControllerPlugin::ECFMP::ListAircraftFlowMeasures listAircraftFlowMeasures;
+    };
+
+    TEST_F(ListAircraftFlowMeasuresTest, ItDoesNothingIfNoFlowMeasures)
+    {
+        auto measures = std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>{};
+        EXPECT_CALL(*flowMeasureMap, GetFlowMeasuresForCallsign("BAW123")).WillOnce(testing::ReturnRef(measures));
+
+        EXPECT_CALL(dialogProvider, OpenDialog).Times(0);
+
+        listAircraftFlowMeasures.ListForAircraft(mockFlightplan);
+    }
+
+    TEST_F(ListAircraftFlowMeasuresTest, ItOpensDialogForFlowMeasures)
+    {
+        // Mock measure 1
+        auto mockMeasure1 = std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>();
+        std::string mockMeasure1Identifier = "EGTT01A";
+        ON_CALL(*mockMeasure1, Identifier).WillByDefault(testing::ReturnRef(mockMeasure1Identifier));
+
+        // Measure 1 measure
+        auto measure1Measure = std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::MeasureMock>>();
+        ON_CALL(*measure1Measure, MeasureDescription)
+            .WillByDefault(testing::Return("Minimum Departure Interval: 5 Minutes"));
+
+        ON_CALL(*mockMeasure1, Measure).WillByDefault(testing::ReturnRef(*measure1Measure));
+
+        // Measure 1 filters
+        auto measure1Filters =
+            std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureFiltersMock>>();
+
+        auto measure1FilterDescriptions = std::vector<std::string>{"Departing: EGKK", "Arriving: EGLL"};
+        ON_CALL(*measure1Filters, FilterDescriptions).WillByDefault(testing::Return(measure1FilterDescriptions));
+
+        ON_CALL(*mockMeasure1, Filters).WillByDefault(testing::ReturnRef(*measure1Filters));
+
+        // Mock measure 2
+        auto mockMeasure2 = std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureMock>>();
+        std::string mockMeasure2Identifier = "EGTT01B";
+        ON_CALL(*mockMeasure2, Identifier).WillByDefault(testing::ReturnRef(mockMeasure2Identifier));
+
+        // Measure 2 measure
+        auto measure2Measure = std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::MeasureMock>>();
+        ON_CALL(*measure2Measure, MeasureDescription)
+            .WillByDefault(testing::Return("Minimum Departure Interval: 3 Minutes"));
+        ON_CALL(*mockMeasure2, Measure).WillByDefault(testing::ReturnRef(*measure2Measure));
+
+        // Measure 2 filters
+        auto measure2Filters =
+            std::make_shared<testing::NiceMock<::ECFMP::Mock::FlowMeasure::FlowMeasureFiltersMock>>();
+
+        auto measure2FilterDescriptions = std::vector<std::string>{"Departing: EGCC", "Arriving: EGPH"};
+        ON_CALL(*measure2Filters, FilterDescriptions).WillByDefault(testing::Return(measure2FilterDescriptions));
+
+        ON_CALL(*mockMeasure2, Filters).WillByDefault(testing::ReturnRef(*measure2Filters));
+
+        // Return measures from mocks
+        auto measures =
+            std::unordered_set<std::shared_ptr<const ::ECFMP::FlowMeasure::FlowMeasure>>{mockMeasure1, mockMeasure2};
+        EXPECT_CALL(*flowMeasureMap, GetFlowMeasuresForCallsign("BAW123")).WillOnce(testing::ReturnRef(measures));
+
+        EXPECT_CALL(dialogProvider, OpenDialog(dialogData, testing::Truly(MatchesExpectedFlowMeasureString))).Times(1);
+
+        listAircraftFlowMeasures.ListForAircraft(mockFlightplan);
+    }
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/ecfmp/TriggerEcfmpEventLoopTest.cpp
+++ b/test/plugin/ecfmp/TriggerEcfmpEventLoopTest.cpp
@@ -1,0 +1,21 @@
+#include "ecfmp/TriggerEcfmpEventLoop.h"
+
+namespace UKControllerPluginTest::ECFMP {
+    class TriggerECFMPEventLoopTest : public testing::Test
+    {
+        public:
+        TriggerECFMPEventLoopTest()
+            : ecfmp(std::make_shared<::testing::NiceMock<::ECFMP::Mock::Plugin::SdkMock>>()), trigger(ecfmp)
+        {
+        }
+
+        std::shared_ptr<testing::NiceMock<::ECFMP::Mock::Plugin::SdkMock>> ecfmp;
+        UKControllerPlugin::ECFMP::TriggerECFMPEventLoop trigger;
+    };
+
+    TEST_F(TriggerECFMPEventLoopTest, ItTriggersTheECFMPEventLoop)
+    {
+        EXPECT_CALL(*ecfmp, OnEuroscopeTimerTick()).Times(1);
+        trigger.TimedEventTrigger();
+    }
+} // namespace UKControllerPluginTest::ECFMP

--- a/test/plugin/mock/MockEuroScopeCFlightplanInterface.h
+++ b/test/plugin/mock/MockEuroScopeCFlightplanInterface.h
@@ -46,7 +46,7 @@ namespace UKControllerPluginTest {
             MOCK_METHOD1(SetClearedAltitude, void(int));
             MOCK_METHOD1(SetHeading, void(int));
             MOCK_METHOD1(SetSquawk, void(std::string));
-            MOCK_CONST_METHOD0(GetEuroScopeObject, EuroScopePlugIn::CFlightPlan(void));
+            MOCK_CONST_METHOD0(GetEuroScopeObject, EuroScopePlugIn::CFlightPlan&(void));
         };
     } // namespace Euroscope
 } // namespace UKControllerPluginTest

--- a/test/plugin/mock/MockEuroScopeCRadarTargetInterface.h
+++ b/test/plugin/mock/MockEuroScopeCRadarTargetInterface.h
@@ -15,6 +15,7 @@ namespace UKControllerPluginTest {
             MOCK_CONST_METHOD0(GetPosition, const EuroScopePlugIn::CPosition(void));
             MOCK_CONST_METHOD0(GetVerticalSpeed, int(void));
             MOCK_METHOD(double, GetHeading, (), (const, override));
+            MOCK_METHOD(EuroScopePlugIn::CRadarTarget&, GetEuroScopeObject, (), (const, override));
         };
     } // namespace Euroscope
 } // namespace UKControllerPluginTest

--- a/test/plugin/mock/MockEuroscopePluginLoopbackInterface.cpp
+++ b/test/plugin/mock/MockEuroscopePluginLoopbackInterface.cpp
@@ -29,6 +29,34 @@ namespace UKControllerPluginTest::Euroscope {
         }
     };
 
+    void MockEuroscopePluginLoopbackInterface::ApplyFunctionToAllFlightplans(
+        std::function<void(
+            UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface&,
+            UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface&)> function)
+    {
+        if (this->expectFlightplanLoopNoFire) {
+            throw std::logic_error("Was not expecting the flightplan loop");
+        }
+
+        for (auto it = this->allFpRtPairs.cbegin(); it != this->allFpRtPairs.cend(); ++it) {
+            function(*it->fp, *it->rt);
+        }
+    };
+
+    void MockEuroscopePluginLoopbackInterface::ApplyFunctionToAllFlightplans(
+        std::function<void(
+            const UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface&,
+            const UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface&)> function) const
+    {
+        if (this->expectFlightplanLoopNoFire) {
+            throw std::logic_error("Was not expecting the flightplan loop");
+        }
+
+        for (auto it = this->allFpRtPairs.cbegin(); it != this->allFpRtPairs.cend(); ++it) {
+            function(*it->fp, *it->rt);
+        }
+    };
+
     void MockEuroscopePluginLoopbackInterface::ApplyFunctionToAllControllers(
         std::function<void(std::shared_ptr<UKControllerPlugin::Euroscope::EuroScopeCControllerInterface>)> function)
     {

--- a/test/plugin/mock/MockEuroscopePluginLoopbackInterface.h
+++ b/test/plugin/mock/MockEuroscopePluginLoopbackInterface.h
@@ -60,6 +60,14 @@ namespace UKControllerPluginTest {
                 std::function<void(
                     std::shared_ptr<UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface>,
                     std::shared_ptr<UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface>)> function) override;
+            void ApplyFunctionToAllFlightplans(
+                std::function<void(
+                    UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface&,
+                    UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface&)> function) override;
+            void ApplyFunctionToAllFlightplans(
+                std::function<void(
+                    const UKControllerPlugin::Euroscope::EuroScopeCFlightPlanInterface&,
+                    const UKControllerPlugin::Euroscope::EuroScopeCRadarTargetInterface&)> function) const override;
             void ApplyFunctionToAllControllers(
                 std::function<void(std::shared_ptr<UKControllerPlugin::Euroscope::EuroScopeCControllerInterface>)>
                     function) override;

--- a/test/plugin/pch/pch.h
+++ b/test/plugin/pch/pch.h
@@ -44,6 +44,10 @@
 // Euroscope
 #include "euroscope/EuroScopePlugIn.h"
 
+// ECFMP
+#include "ecfmp/include/ECFMP/ECFMP.h"
+#include "ecfmp/include/mock/ecfmp-sdk-mock.h"
+
 // Testingutils mocks
 #include "../../testingutils/mock/MockApiInterface.h"
 #include "../../testingutils/mock/MockApiSettingsProvider.h"

--- a/test/plugin/releases/DepartureReleaseRequestTest.cpp
+++ b/test/plugin/releases/DepartureReleaseRequestTest.cpp
@@ -6,7 +6,7 @@ using UKControllerPlugin::Releases::DepartureReleaseRequest;
 using UKControllerPlugin::Time::SetTestNow;
 using UKControllerPlugin::Time::TimeNow;
 
-namespace UKControllerPluginTes::Releases {
+namespace UKControllerPluginTest::Releases {
 
     class DepartureReleaseRequestTest : public Test
     {
@@ -191,4 +191,4 @@ namespace UKControllerPluginTes::Releases {
     {
         EXPECT_EQ(TimeNow(), request->CreatedAt());
     }
-} // namespace UKControllerPluginTes::Releases
+} // namespace UKControllerPluginTest::Releases

--- a/test/plugin/test/BootstrapProviderTestCase.cpp
+++ b/test/plugin/test/BootstrapProviderTestCase.cpp
@@ -1,6 +1,7 @@
 #include "BootstrapProviderTestCase.h"
-#include "bootstrap/ModuleBootstrap.h"
 #include "aircraft/CallsignSelectionListFactory.h"
+#include "bootstrap/ModuleBootstrap.h"
+#include "controller/ActiveCallsignCollection.h"
 #include "list/PopupListFactory.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "plugin/UKPlugin.h"
@@ -44,6 +45,7 @@ namespace UKControllerPluginTest {
             std::make_unique<CallsignSelectionListFactory>(*container.popupListFactory);
         container.tagHandler = std::make_unique<TagItemCollection>();
         container.timedHandler = std::make_unique<TimedEventCollection>();
+        container.activeCallsigns = std::make_unique<UKControllerPlugin::Controller::ActiveCallsignCollection>();
         return container;
     }
 } // namespace UKControllerPluginTest

--- a/test/plugin/test/BootstrapProviderTestCase.cpp
+++ b/test/plugin/test/BootstrapProviderTestCase.cpp
@@ -5,12 +5,14 @@
 #include "plugin/FunctionCallEventHandler.h"
 #include "plugin/UKPlugin.h"
 #include "tag/TagItemCollection.h"
+#include "timedevent/TimedEventCollection.h"
 
 using UKControllerPlugin::Aircraft::CallsignSelectionListFactory;
 using UKControllerPlugin::Bootstrap::ModuleBootstrap;
 using UKControllerPlugin::List::PopupListFactory;
 using UKControllerPlugin::Plugin::FunctionCallEventHandler;
 using UKControllerPlugin::Tag::TagItemCollection;
+using UKControllerPlugin::TimedEvent::TimedEventCollection;
 
 namespace UKControllerPluginTest {
 
@@ -41,6 +43,7 @@ namespace UKControllerPluginTest {
         container.callsignSelectionListFactory =
             std::make_unique<CallsignSelectionListFactory>(*container.popupListFactory);
         container.tagHandler = std::make_unique<TagItemCollection>();
+        container.timedHandler = std::make_unique<TimedEventCollection>();
         return container;
     }
 } // namespace UKControllerPluginTest


### PR DESCRIPTION
- Builds the ECFMP SDK with the project
- Adds a tag item that displays the current relevant flow measure from ECFMP.
- Adds a tag function to display full details of the flow measures.
- Flow measures are relevant to an aircraft if the SDK says so, plus if the controller position is in the notified FIR for the measure.