### PR TITLE
Stands auto request

### DIFF
--- a/src/plugin/stands/StandModule.cpp
+++ b/src/plugin/stands/StandModule.cpp
@@ -40,6 +40,7 @@ namespace UKControllerPlugin::Stands {
             *container.taskRunner,
             *container.plugin,
             *container.integrationModuleContainer->outboundMessageHandler,
+            container.airfieldOwnership,
             stands,
             standSelectedCallbackId);
 

--- a/src/utils/api/ApiCurlRequestFactory.cpp
+++ b/src/utils/api/ApiCurlRequestFactory.cpp
@@ -16,6 +16,10 @@ namespace UKControllerPluginUtils::Api {
     auto ApiCurlRequestFactory::BuildCurlRequest(const ApiRequestData& data) const -> CurlRequest
     {
         CurlRequest request(urlBuilder.BuildUrl(data), data.Method());
+        if (!data.Body().empty()) {
+            request.SetBody(data.Body().dump());
+        }
+
         headerApplicator.ApplyHeaders(request);
         return request;
     }

--- a/src/utils/api/CurlApiRequestPerformer.cpp
+++ b/src/utils/api/CurlApiRequestPerformer.cpp
@@ -20,8 +20,16 @@ namespace UKControllerPluginUtils::Api {
 
     auto CurlApiRequestPerformer::Perform(const ApiRequestData& data) -> Response
     {
+        const auto request = requestFactory.BuildCurlRequest(data);
+        LogDebug(
+            "CurlApiRequestPerformer: Performing cURL request with method " + std::string(data.Method()) + " to " +
+            data.Uri() + " with body " + data.Body().dump());
+
         auto curlResponse = curl.MakeCurlRequest(requestFactory.BuildCurlRequest(data));
         if (!ResponseSuccessful(curlResponse)) {
+            LogDebug(
+                "CurlApiRequestPerformer: Failed cURL request, status was: " +
+                std::to_string(curlResponse.GetStatusCode()) + " response body was " + curlResponse.GetResponse());
             throw ApiRequestException(data.Uri(), static_cast<HttpStatusCode>(curlResponse.GetStatusCode()), false);
         }
 

--- a/test/plugin/stands/StandModuleTest.cpp
+++ b/test/plugin/stands/StandModuleTest.cpp
@@ -5,6 +5,7 @@
 #include "integration/InboundIntegrationMessageHandler.h"
 #include "integration/IntegrationPersistenceContainer.h"
 #include "integration/IntegrationServer.h"
+#include "ownership/AirfieldServiceProviderCollection.h"
 #include "plugin/FunctionCallEventHandler.h"
 #include "push/PushEventProcessorCollection.h"
 #include "stands/StandModule.h"
@@ -41,6 +42,8 @@ namespace UKControllerPluginTest::Stands {
                 std::make_unique<IntegrationPersistenceContainer>(nullptr, nullptr, nullptr, nullptr);
             container.integrationModuleContainer->inboundMessageHandler =
                 std::make_shared<InboundIntegrationMessageHandler>(nullptr);
+            container.airfieldOwnership =
+                std::make_shared<UKControllerPlugin::Ownership::AirfieldServiceProviderCollection>();
 
             nlohmann::json gatwick = nlohmann::json::array();
             gatwick.push_back({

--- a/test/testingutils/test/ApiExpectation.cpp
+++ b/test/testingutils/test/ApiExpectation.cpp
@@ -77,6 +77,12 @@ namespace UKControllerPluginTest {
         return *this;
     }
 
+    ApiResponseExpectation& ApiExpectation::WillReturnCreated()
+    {
+        this->responseCode = HttpStatusCode::Created;
+        return *this;
+    }
+
     ApiResponseExpectation& ApiExpectation::WillReturnOk()
     {
         this->responseCode = HttpStatusCode::Ok;

--- a/test/testingutils/test/ApiExpectation.h
+++ b/test/testingutils/test/ApiExpectation.h
@@ -35,6 +35,7 @@ namespace UKControllerPluginTest {
         auto Delete() -> ApiUriExpectation& override;
         auto WithBody(const nlohmann::json& body) -> ApiResponseExpectation& override;
         auto WithoutBody() -> ApiResponseExpectation& override;
+        auto WillReturnCreated() -> ApiResponseExpectation& override;
         auto WillReturnOk() -> ApiResponseExpectation& override;
         auto WillReturnServerError() -> ApiResponseExpectation& override;
         auto WillReturnForbidden() -> ApiResponseExpectation& override;

--- a/test/testingutils/test/ApiResponseExpectation.h
+++ b/test/testingutils/test/ApiResponseExpectation.h
@@ -7,6 +7,7 @@ namespace UKControllerPluginTest {
     class ApiResponseExpectation
     {
         public:
+        virtual auto WillReturnCreated() -> ApiResponseExpectation& = 0;
         virtual auto WillReturnOk() -> ApiResponseExpectation& = 0;
         virtual auto WillReturnServerError() -> ApiResponseExpectation& = 0;
         virtual auto WillReturnForbidden() -> ApiResponseExpectation& = 0;

--- a/test/utils/api/ApiCurlRequestFactoryTest.cpp
+++ b/test/utils/api/ApiCurlRequestFactoryTest.cpp
@@ -38,4 +38,19 @@ namespace UKControllerPluginUtilsTest::Api {
 
         EXPECT_EQ(expectedRequest, request);
     }
+
+    TEST_F(ApiCurlRequestFactoryTest, ItBuildsRequestsWithABody)
+    {
+        const auto body = nlohmann::json{{"test", "test"}};
+        auto request = requestFactory.BuildCurlRequest(
+            ApiRequestData("test", UKControllerPluginUtils::Http::HttpMethod::Post(), body));
+
+        CurlRequest expectedRequest("https://ukcp.vatsim.uk/api/test", CurlRequest::METHOD_POST);
+        expectedRequest.AddHeader("Authorization", "Bearer key");
+        expectedRequest.AddHeader("Accept", "application/json");
+        expectedRequest.AddHeader("Content-Type", "application/json");
+        expectedRequest.SetBody(body.dump());
+
+        EXPECT_EQ(expectedRequest, request);
+    }
 } // namespace UKControllerPluginUtilsTest::Api


### PR DESCRIPTION
Adds functionality to request that the API automatically assign a stand to a given aircraft. Works for both departure (based on the lat/lon) and arrivals.