### PR TITLE
fix: make close button close wake calculator

### DIFF
--- a/src/plugin/wake/WakeCalculatorDisplay.cpp
+++ b/src/plugin/wake/WakeCalculatorDisplay.cpp
@@ -91,6 +91,11 @@ namespace UKControllerPlugin::Wake {
             this->contentCollapsed = !this->contentCollapsed;
             return;
         }
+
+        if (objectDescription == "closeButton") {
+            this->visible = false;
+            return;
+        }
     }
 
     void WakeCalculatorDisplay::Move(RECT position, std::string objectDescription)

--- a/test/plugin/wake/WakeCalculatorDisplayTest.cpp
+++ b/test/plugin/wake/WakeCalculatorDisplayTest.cpp
@@ -54,6 +54,16 @@ namespace UKControllerPluginTest::Wake {
         EXPECT_FALSE(display.IsCollapsed());
     }
 
+    TEST_F(WakeCalculatorDisplayTest, ItCanBeClosedByClickButton)
+    {
+        if (!display.IsVisible()) {
+            display.Toggle();
+        }
+        EXPECT_TRUE(display.IsVisible());
+        display.LeftClick(radarScreen, 1, "closeButton", {1, 2}, {});
+        EXPECT_FALSE(display.IsVisible());
+    }
+
     TEST_F(WakeCalculatorDisplayTest, ItHasADefaultPosition)
     {
         const auto position = display.Position();


### PR DESCRIPTION
Makes the close button on the titlebar close the wake calculator.

I can't build this, so I have no idea if it works; sorry.