### PR TITLE
Move Build to Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/alpha')
     needs: [build, format]
     concurrency:
@@ -231,19 +231,19 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: UKControllerPluginCore.dll
-          path: ".\\build\\bin\\UKControllerPluginCore.dll"
+          path: "./build/bin/UKControllerPluginCore.dll"
 
       - name: Download Updater Binary
         uses: actions/download-artifact@v7
         with:
           name: UKControllerPluginUpdater.dll
-          path: ".\\build\\bin\\UKControllerPluginUpdater.dll"
+          path: "./build/bin/UKControllerPluginUpdater.dll"
 
       - name: Download Loader Binary
         uses: actions/download-artifact@v7
         with:
           name: UKControllerPlugin.dll
-          path: ".\\build\\bin\\UKControllerPlugin.dll"
+          path: "./build/bin/UKControllerPlugin.dll"
 
       - name: Create Release
         env:


### PR DESCRIPTION
## Changes

### Build Workflow Update

**Move release job to Ubuntu**

- Changed the `release` job runner from `windows-latest` to `ubuntu-latest`
- Updated artifact download paths from Windows-style backslashes to Unix-style forward slashes

### Modified Files

- `.github/workflows/build.yml`

### Detailed Changes

```diff
@@ -185,7 +185,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/alpha')
     needs: [build, format]
     concurrency:
@@ -231,19 +231,19 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: UKControllerPluginCore.dll
-          path: ".\\build\\bin\\UKControllerPluginCore.dll"
+          path: "./build/bin/UKControllerPluginCore.dll"
 
       - name: Download Updater Binary
         uses: actions/download-artifact@v7
         with:
           name: UKControllerPluginUpdater.dll
-          path: ".\\build\\bin\\UKControllerPluginUpdater.dll"
+          path: "./build/bin/UKControllerPluginUpdater.dll"
 
       - name: Download Loader Binary
         uses: actions/download-artifact@v7
         with:
           name: UKControllerPlugin.dll
-          path: ".\\build\\bin\\UKControllerPlugin.dll"
+          path: "./build/bin/UKControllerPlugin.dll"