### PR TITLE
Update the inbuilt release window

### DIFF
--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -835,7 +835,9 @@ set(src__releases
     releases/EnrouteRelease.cpp releases/EnrouteReleaseType.cpp
     releases/RejectDepartureReleaseDialog.cpp releases/RejectDepartureReleaseDialog.h
     releases/ReleaseApprovalRemarksUserMessage.cpp releases/ReleaseApprovalRemarksUserMessage.h
-    releases/ReleaseRejectionRemarksUserMessage.cpp releases/ReleaseRejectionRemarksUserMessage.h releases/DepartureReleaseRequestedEvent.h releases/SendReleaseRequestedChatAreaMessage.cpp releases/SendReleaseRequestedChatAreaMessage.h releases/DepartureReleaseRelevanceChecker.h releases/ReleaseIsTargetedAtUser.cpp releases/ReleaseIsTargetedAtUser.h handoff/DefaultDepartureHandoffResolver.cpp handoff/DefaultDepartureHandoffResolver.h)
+    releases/ReleaseRejectionRemarksUserMessage.cpp releases/ReleaseRejectionRemarksUserMessage.h
+    releases/ReleasePendingReminderUserMessage.cpp releases/ReleasePendingReminderUserMessage.h
+    releases/DepartureReleaseRequestedEvent.h releases/SendReleaseRequestedChatAreaMessage.cpp releases/SendReleaseRequestedChatAreaMessage.h releases/DepartureReleaseRelevanceChecker.h releases/ReleaseIsTargetedAtUser.cpp releases/ReleaseIsTargetedAtUser.h handoff/DefaultDepartureHandoffResolver.cpp handoff/DefaultDepartureHandoffResolver.h)
 source_group("src\\releases" FILES ${src__releases})
 
 set(src__runway

--- a/src/plugin/releases/DepartureReleaseEventHandler.cpp
+++ b/src/plugin/releases/DepartureReleaseEventHandler.cpp
@@ -5,6 +5,7 @@
 #include "DepartureReleaseRequestedEvent.h"
 #include "DepartureReleaseRequestView.h"
 #include "ReleaseApprovalRemarksUserMessage.h"
+#include "ReleasePendingReminderUserMessage.h"
 #include "ReleaseRejectionRemarksUserMessage.h"
 #include "api/ApiException.h"
 #include "api/ApiInterface.h"
@@ -511,6 +512,42 @@ namespace UKControllerPlugin::Releases {
                    request->RequestingController();
     }
 
+    auto DepartureReleaseEventHandler::ReleaseNeedsPendingReminder(
+        const std::shared_ptr<DepartureReleaseRequest>& releaseRequest) const -> bool
+    {
+        if (!releaseRequest || !this->activeCallsigns.UserHasCallsign() ||
+            releaseRequest->PendingDecisionReminderSent() || !releaseRequest->RequiresDecision()) {
+            return false;
+        }
+
+        if (this->activeCallsigns.GetUserCallsign().GetNormalisedPosition().GetId() !=
+            releaseRequest->TargetController()) {
+            return false;
+        }
+
+        return releaseRequest->CreatedAt() + std::chrono::seconds(PENDING_RELEASE_REMINDER_SECONDS) <= Time::TimeNow();
+    }
+
+    void DepartureReleaseEventHandler::SendPendingReleaseReminders()
+    {
+        for (const auto& release : *this->releaseRequests) {
+            auto releaseRequest = this->releaseRequests->Get(release.Id());
+            if (!this->ReleaseNeedsPendingReminder(releaseRequest)) {
+                continue;
+            }
+
+            auto requestingController = this->controllers.FetchPositionById(releaseRequest->RequestingController());
+            if (!requestingController) {
+                releaseRequest->MarkPendingDecisionReminderSent();
+                continue;
+            }
+
+            this->messager.SendMessageToUser(
+                ReleasePendingReminderUserMessage(releaseRequest->Callsign(), requestingController->GetCallsign()));
+            releaseRequest->MarkPendingDecisionReminderSent();
+        }
+    }
+
     /**
      * Create a new departure release request.
      */
@@ -645,6 +682,7 @@ namespace UKControllerPlugin::Releases {
     void DepartureReleaseEventHandler::TimedEventTrigger()
     {
         std::lock_guard queueLock(this->releaseMapGuard);
+        this->SendPendingReleaseReminders();
         this->releaseRequests->RemoveWhere([this](const std::shared_ptr<DepartureReleaseRequest>& release) {
             return this->ReleaseShouldBeRemoved(release);
         });
@@ -709,7 +747,7 @@ namespace UKControllerPlugin::Releases {
         this->plugin.AddItemToPopupList(menuItem);
         menuItem.firstValue = "Reject";
         this->plugin.AddItemToPopupList(menuItem);
-        menuItem.firstValue = "Acknowledge";
+        menuItem.firstValue = "Standby";
         this->plugin.AddItemToPopupList(menuItem);
     }
 
@@ -748,7 +786,12 @@ namespace UKControllerPlugin::Releases {
             return;
         }
 
-        // Release has been acknowledged
+        // Release has been put on standby
+        if (context != "Standby" && context != "Acknowledge") {
+            LogWarning("Unknown departure release decision context: " + context);
+            return;
+        }
+
         this->taskRunner.QueueAsynchronousTask([this, release]() {
             try {
                 this->api.AcknowledgeDepartureReleaseRequest(release->Id(), release->TargetController());

--- a/src/plugin/releases/DepartureReleaseEventHandler.cpp
+++ b/src/plugin/releases/DepartureReleaseEventHandler.cpp
@@ -95,8 +95,8 @@ namespace UKControllerPlugin::Releases {
     /*
      * An acknowledged message needs an id that we know about.
      */
-    auto DepartureReleaseEventHandler::DepartureReleaseAcknowledgedMessageValid(const nlohmann::json& data) const
-        -> bool
+    auto
+    DepartureReleaseEventHandler::DepartureReleaseAcknowledgedMessageValid(const nlohmann::json& data) const -> bool
     {
         return data.is_object() && data.contains("id") && data.at("id").is_number_integer() &&
                this->releaseRequests->Get(data.at("id").get<int>()) != nullptr;
@@ -132,9 +132,8 @@ namespace UKControllerPlugin::Releases {
     /*
      * Whether releases should be removed from the lists.
      */
-    auto
-    DepartureReleaseEventHandler::ReleaseShouldBeRemoved(const std::shared_ptr<DepartureReleaseRequest>& releaseRequest)
-        -> bool
+    auto DepartureReleaseEventHandler::ReleaseShouldBeRemoved(
+        const std::shared_ptr<DepartureReleaseRequest>& releaseRequest) -> bool
     {
         if (releaseRequest->Approved()) {
             return releaseRequest->ReleaseExpiryTime() +
@@ -503,9 +502,8 @@ namespace UKControllerPlugin::Releases {
                 : requestingControllerCallsign);
     }
 
-    auto
-    DepartureReleaseEventHandler::UserRequestedRelease(const std::shared_ptr<DepartureReleaseRequest>& request) const
-        -> bool
+    auto DepartureReleaseEventHandler::UserRequestedRelease(
+        const std::shared_ptr<DepartureReleaseRequest>& request) const -> bool
     {
         return this->activeCallsigns.UserHasCallsign() &&
                this->activeCallsigns.GetUserCallsign().GetNormalisedPosition().GetId() ==
@@ -747,7 +745,7 @@ namespace UKControllerPlugin::Releases {
         this->plugin.AddItemToPopupList(menuItem);
         menuItem.firstValue = "Reject";
         this->plugin.AddItemToPopupList(menuItem);
-        menuItem.firstValue = "Standby";
+        menuItem.firstValue = "Acknowledge";
         this->plugin.AddItemToPopupList(menuItem);
     }
 
@@ -786,12 +784,7 @@ namespace UKControllerPlugin::Releases {
             return;
         }
 
-        // Release has been put on standby
-        if (context != "Standby" && context != "Acknowledge") {
-            LogWarning("Unknown departure release decision context: " + context);
-            return;
-        }
-
+        // Release has been acknowledged
         this->taskRunner.QueueAsynchronousTask([this, release]() {
             try {
                 this->api.AcknowledgeDepartureReleaseRequest(release->Id(), release->TargetController());

--- a/src/plugin/releases/DepartureReleaseEventHandler.h
+++ b/src/plugin/releases/DepartureReleaseEventHandler.h
@@ -57,8 +57,8 @@ namespace UKControllerPlugin {
                 int releaseDecisionCallbackId,
                 int releaseCancellationCallbackId);
             void ProcessPushEvent(const Push::PushEvent& message) override;
-            [[nodiscard]] auto GetPushEventSubscriptions() const -> std::set<Push::PushEventSubscription> override;
-            void PluginEventsSynced() override{};
+            [[nodiscard]] std::set<Push::PushEventSubscription> GetPushEventSubscriptions() const override;
+            void PluginEventsSynced() override {};
             void AddReleaseRequest(const std::shared_ptr<DepartureReleaseRequest>& request);
             auto GetReleaseRequest(int id) -> std::shared_ptr<DepartureReleaseRequest>;
             void TimedEventTrigger() override;
@@ -80,15 +80,14 @@ namespace UKControllerPlugin {
                 std::chrono::system_clock::time_point releasedAt,
                 int expiresInSeconds,
                 std::string remarks);
-            [[nodiscard]] auto GetTagItemDescription(int tagItemId) const -> std::string override;
+            [[nodiscard]] std::string GetTagItemDescription(int tagItemId) const override;
             void SetTagItemData(Tag::TagData& tagData) override;
             void ShowStatusDisplay(
                 Euroscope::EuroScopeCFlightPlanInterface& flightplan,
                 Euroscope::EuroScopeCRadarTargetInterface& radarTarget,
                 const std::string& context,
                 const POINT& mousePos);
-            [[nodiscard]] auto GetReleasesToDisplay() const
-                -> const std::set<std::shared_ptr<DepartureReleaseRequest>>&;
+            [[nodiscard]] const std::set<std::shared_ptr<DepartureReleaseRequest>>& GetReleasesToDisplay() const;
             auto GetReleasesRequiringUsersDecision()
                 -> std::set<std::shared_ptr<DepartureReleaseRequest>, CompareDepartureReleases>;
             void SelectReleaseRequestToCancel(
@@ -111,16 +110,18 @@ namespace UKControllerPlugin {
             [[nodiscard]] auto DepartureReleaseApprovedMessageValid(const nlohmann::json& data) const -> bool;
             [[nodiscard]] auto DepartureReleaseCancelMessageValid(const nlohmann::json& data) const -> bool;
             static auto ReleaseShouldBeRemoved(const std::shared_ptr<DepartureReleaseRequest>& releaseRequest) -> bool;
-            [[nodiscard]] auto
-            ControllerCanMakeReleaseDecision(const std::shared_ptr<DepartureReleaseRequest>& releaseRequest) const
-                -> bool;
-            auto FindReleaseRequiringDecisionForCallsign(std::string callsign)
-                -> std::shared_ptr<DepartureReleaseRequest>;
+            [[nodiscard]] bool
+            ControllerCanMakeReleaseDecision(const std::shared_ptr<DepartureReleaseRequest>& releaseRequest) const;
+            auto
+            FindReleaseRequiringDecisionForCallsign(std::string callsign) -> std::shared_ptr<DepartureReleaseRequest>;
             void SetReleaseStatusIndicatorTagData(Tag::TagData& tagData);
             void SetReleaseCountdownTagData(Tag::TagData& tagData);
             void SetRequestingControllerTagData(Tag::TagData& tagData);
-            [[nodiscard]] auto UserRequestedRelease(const std::shared_ptr<DepartureReleaseRequest>& request) const
-                -> bool;
+            [[nodiscard]] auto
+            UserRequestedRelease(const std::shared_ptr<DepartureReleaseRequest>& request) const -> bool;
+            void SendPendingReleaseReminders();
+            [[nodiscard]] auto
+            ReleaseNeedsPendingReminder(const std::shared_ptr<DepartureReleaseRequest>& releaseRequest) const -> bool;
 
             // A guard on the map to allow async operations
             std::mutex releaseMapGuard;
@@ -137,6 +138,7 @@ namespace UKControllerPlugin {
 
             static const int RELEASE_EXPIRY_SECONDS = 300;
             static const int RELEASE_DECISION_MADE_DELETE_AFTER_SECONDS = 90;
+            static const int PENDING_RELEASE_REMINDER_SECONDS = 60;
 
             // Release requests in progress
             const std::shared_ptr<DepartureReleaseRequestCollection> releaseRequests;

--- a/src/plugin/releases/DepartureReleaseRequest.cpp
+++ b/src/plugin/releases/DepartureReleaseRequest.cpp
@@ -81,6 +81,16 @@ namespace UKControllerPlugin::Releases {
         return this->releasedAtTime != this->noTime;
     }
 
+    void DepartureReleaseRequest::MarkPendingDecisionReminderSent()
+    {
+        this->pendingDecisionReminderSent = true;
+    }
+
+    bool DepartureReleaseRequest::PendingDecisionReminderSent() const
+    {
+        return this->pendingDecisionReminderSent;
+    }
+
     auto DepartureReleaseRequest::RequestExpired() const -> bool
     {
         return this->requestExpiresAt < Time::TimeNow();

--- a/src/plugin/releases/DepartureReleaseRequest.h
+++ b/src/plugin/releases/DepartureReleaseRequest.h
@@ -30,6 +30,8 @@ namespace UKControllerPlugin::Releases {
         bool Acknowledged() const;
         bool Rejected() const;
         bool Approved() const;
+        void MarkPendingDecisionReminderSent();
+        [[nodiscard]] bool PendingDecisionReminderSent() const;
         bool RequestExpired() const;
         bool ApprovalExpired() const;
         bool AwaitingReleasedTime() const;
@@ -81,5 +83,8 @@ namespace UKControllerPlugin::Releases {
 
         // Remarks relating to the release being approved or rejected
         std::string remarks;
+
+        // Whether the target controller has already been reminded this release is pending
+        bool pendingDecisionReminderSent = false;
     };
 } // namespace UKControllerPlugin::Releases

--- a/src/plugin/releases/ReleasePendingReminderUserMessage.cpp
+++ b/src/plugin/releases/ReleasePendingReminderUserMessage.cpp
@@ -20,8 +20,7 @@ namespace UKControllerPlugin::Releases {
 
     auto ReleasePendingReminderUserMessage::MessageString() const -> std::string
     {
-        return "Departure release for " + this->callsign + " from " + this->requestingController +
-               " is still pending (standby).";
+        return "Departure release for " + this->callsign + " from " + this->requestingController + " is still pending.";
     }
 
     auto ReleasePendingReminderUserMessage::MessageShowHandler() const -> bool

--- a/src/plugin/releases/ReleasePendingReminderUserMessage.cpp
+++ b/src/plugin/releases/ReleasePendingReminderUserMessage.cpp
@@ -1,0 +1,51 @@
+#include "ReleasePendingReminderUserMessage.h"
+
+namespace UKControllerPlugin::Releases {
+
+    ReleasePendingReminderUserMessage::ReleasePendingReminderUserMessage(
+        std::string callsign, std::string requestingController)
+        : callsign(std::move(callsign)), requestingController(std::move(requestingController))
+    {
+    }
+
+    auto ReleasePendingReminderUserMessage::MessageHandler() const -> std::string
+    {
+        return "DEPARTURE_RELEASE";
+    }
+
+    auto ReleasePendingReminderUserMessage::MessageSender() const -> std::string
+    {
+        return "UKCP";
+    }
+
+    auto ReleasePendingReminderUserMessage::MessageString() const -> std::string
+    {
+        return "Departure release for " + this->callsign + " from " + this->requestingController +
+               " is still pending (standby).";
+    }
+
+    auto ReleasePendingReminderUserMessage::MessageShowHandler() const -> bool
+    {
+        return true;
+    }
+
+    auto ReleasePendingReminderUserMessage::MessageMarkUnread() const -> bool
+    {
+        return true;
+    }
+
+    auto ReleasePendingReminderUserMessage::MessageOverrideBusy() const -> bool
+    {
+        return true;
+    }
+
+    auto ReleasePendingReminderUserMessage::MessageFlashHandler() const -> bool
+    {
+        return true;
+    }
+
+    auto ReleasePendingReminderUserMessage::MessageRequiresConfirm() const -> bool
+    {
+        return true;
+    }
+} // namespace UKControllerPlugin::Releases

--- a/src/plugin/releases/ReleasePendingReminderUserMessage.h
+++ b/src/plugin/releases/ReleasePendingReminderUserMessage.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "message/MessageSerializableInterface.h"
+
+namespace UKControllerPlugin::Releases {
+
+    class ReleasePendingReminderUserMessage : public Message::MessageSerializableInterface
+    {
+        public:
+        ReleasePendingReminderUserMessage(std::string callsign, std::string requestingController);
+        auto MessageHandler() const -> std::string override;
+        auto MessageSender() const -> std::string override;
+        auto MessageString() const -> std::string override;
+        auto MessageShowHandler() const -> bool override;
+        auto MessageMarkUnread() const -> bool override;
+        auto MessageOverrideBusy() const -> bool override;
+        auto MessageFlashHandler() const -> bool override;
+        auto MessageRequiresConfirm() const -> bool override;
+
+        private:
+        const std::string callsign;
+        const std::string requestingController;
+    };
+} // namespace UKControllerPlugin::Releases

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -517,6 +517,7 @@ set(test__releases
     "releases/EnrouteReleaseTypesSerializerTest.cpp"
     "releases/ReleaseModuleTest.cpp"
     releases/ReleaseApprovalRemarksUserMessageTest.cpp
+    releases/ReleasePendingReminderUserMessageTest.cpp
     releases/ReleaseRejectionRemarksUserMessageTest.cpp releases/ReleaseIsTargetedAtUserTest.cpp releases/SendReleaseRequestedChatAreaMessageTest.cpp handoff/DefaultDepartureHandoffResolverTest.cpp)
 source_group("test\\releases" FILES ${test__releases})
 

--- a/test/plugin/releases/DepartureReleaseEventHandlerTest.cpp
+++ b/test/plugin/releases/DepartureReleaseEventHandlerTest.cpp
@@ -1113,6 +1113,79 @@ namespace UKControllerPluginTest::Releases {
         EXPECT_EQ(relevantRelease, handler.GetReleaseRequest(4));
     }
 
+    TEST_F(DepartureReleaseEventHandlerTest, ItDoesntSendPendingReminderIfRequestIsLessThanOneMinuteOld)
+    {
+        this->activeCallsigns.AddUserCallsign(*this->controller1Callsign);
+
+        auto now = std::chrono::system_clock::now();
+        UKControllerPlugin::Time::SetTestNow(now - std::chrono::seconds(59));
+        auto relevantRelease =
+            std::make_shared<DepartureReleaseRequest>(4, "BAW999", 3, 2, TimeNow() + std::chrono::minutes(5));
+        UKControllerPlugin::Time::SetTestNow(now);
+
+        this->handler.AddReleaseRequest(relevantRelease);
+        EXPECT_CALL(this->mockPlugin, ChatAreaMessage).Times(0);
+
+        this->handler.TimedEventTrigger();
+    }
+
+    TEST_F(DepartureReleaseEventHandlerTest, ItDoesntSendPendingReminderIfUserIsNotTargetController)
+    {
+        this->activeCallsigns.AddUserCallsign(*this->controller2Callsign);
+
+        auto now = std::chrono::system_clock::now();
+        UKControllerPlugin::Time::SetTestNow(now - std::chrono::seconds(61));
+        auto relevantRelease =
+            std::make_shared<DepartureReleaseRequest>(4, "BAW999", 3, 2, TimeNow() + std::chrono::minutes(5));
+        UKControllerPlugin::Time::SetTestNow(now);
+
+        this->handler.AddReleaseRequest(relevantRelease);
+        EXPECT_CALL(this->mockPlugin, ChatAreaMessage).Times(0);
+
+        this->handler.TimedEventTrigger();
+    }
+
+    TEST_F(DepartureReleaseEventHandlerTest, ItSendsPendingReminderIfRequestOlderThanOneMinute)
+    {
+        this->activeCallsigns.AddUserCallsign(*this->controller1Callsign);
+
+        auto now = std::chrono::system_clock::now();
+        UKControllerPlugin::Time::SetTestNow(now - std::chrono::seconds(61));
+        auto relevantRelease =
+            std::make_shared<DepartureReleaseRequest>(4, "BAW999", 3, 2, TimeNow() + std::chrono::minutes(5));
+        UKControllerPlugin::Time::SetTestNow(now);
+
+        this->handler.AddReleaseRequest(relevantRelease);
+
+        EXPECT_CALL(
+            this->mockPlugin,
+            ChatAreaMessage(_, _, "Departure release for BAW999 from EGFF_TWR is still pending.", _, _, _, _, _))
+            .Times(1);
+
+        this->handler.TimedEventTrigger();
+    }
+
+    TEST_F(DepartureReleaseEventHandlerTest, ItOnlySendsPendingReminderOncePerRelease)
+    {
+        this->activeCallsigns.AddUserCallsign(*this->controller1Callsign);
+
+        auto now = std::chrono::system_clock::now();
+        UKControllerPlugin::Time::SetTestNow(now - std::chrono::seconds(61));
+        auto relevantRelease =
+            std::make_shared<DepartureReleaseRequest>(4, "BAW999", 3, 2, TimeNow() + std::chrono::minutes(5));
+        UKControllerPlugin::Time::SetTestNow(now);
+
+        this->handler.AddReleaseRequest(relevantRelease);
+
+        EXPECT_CALL(
+            this->mockPlugin,
+            ChatAreaMessage(_, _, "Departure release for BAW999 from EGFF_TWR is still pending.", _, _, _, _, _))
+            .Times(1);
+
+        this->handler.TimedEventTrigger();
+        this->handler.TimedEventTrigger();
+    }
+
     TEST_F(DepartureReleaseEventHandlerTest, ItRemovesPendingReleasesThatHaveExpired)
     {
         std::shared_ptr<DepartureReleaseRequest> relevantRelease =

--- a/test/plugin/releases/DepartureReleaseRequestTest.cpp
+++ b/test/plugin/releases/DepartureReleaseRequestTest.cpp
@@ -71,6 +71,11 @@ namespace UKControllerPluginTest::Releases {
         EXPECT_TRUE(request->Remarks().empty());
     }
 
+    TEST_F(DepartureReleaseRequestTest, ItStartsWithNoPendingDecisionReminder)
+    {
+        EXPECT_FALSE(request->PendingDecisionReminderSent());
+    }
+
     TEST_F(DepartureReleaseRequestTest, ItCanBeAcknowledged)
     {
         request->Acknowledge();
@@ -81,6 +86,12 @@ namespace UKControllerPluginTest::Releases {
     {
         request->Acknowledge();
         EXPECT_TRUE(std::chrono::system_clock::now() - request->AcknowledgedAtTime() < std::chrono::seconds(5));
+    }
+
+    TEST_F(DepartureReleaseRequestTest, PendingDecisionReminderCanBeMarkedAsSent)
+    {
+        request->MarkPendingDecisionReminderSent();
+        EXPECT_TRUE(request->PendingDecisionReminderSent());
     }
 
     TEST_F(DepartureReleaseRequestTest, ItCanBeRejected)

--- a/test/plugin/releases/ReleasePendingReminderUserMessageTest.cpp
+++ b/test/plugin/releases/ReleasePendingReminderUserMessageTest.cpp
@@ -1,0 +1,54 @@
+#include "releases/ReleasePendingReminderUserMessage.h"
+
+using UKControllerPlugin::Releases::ReleasePendingReminderUserMessage;
+
+namespace UKControllerPluginTest::Releases {
+
+    class ReleasePendingReminderUserMessageTest : public testing::Test
+    {
+        public:
+        ReleasePendingReminderUserMessageTest() : message("BAW123", "LON_S_CTR") {};
+
+        ReleasePendingReminderUserMessage message;
+    };
+
+    TEST_F(ReleasePendingReminderUserMessageTest, ItUsesAHandler)
+    {
+        EXPECT_TRUE("DEPARTURE_RELEASE" == this->message.MessageHandler());
+    }
+
+    TEST_F(ReleasePendingReminderUserMessageTest, ItHasASender)
+    {
+        EXPECT_TRUE("UKCP" == this->message.MessageSender());
+    }
+
+    TEST_F(ReleasePendingReminderUserMessageTest, ItFormatsAMessage)
+    {
+        EXPECT_EQ("Departure release for BAW123 from LON_S_CTR is still pending.", this->message.MessageString());
+    }
+
+    TEST_F(ReleasePendingReminderUserMessageTest, ItShowsHandler)
+    {
+        EXPECT_TRUE(this->message.MessageShowHandler());
+    }
+
+    TEST_F(ReleasePendingReminderUserMessageTest, ItMarksMessageAsUnread)
+    {
+        EXPECT_TRUE(this->message.MessageMarkUnread());
+    }
+
+    TEST_F(ReleasePendingReminderUserMessageTest, ItOverridesBusy)
+    {
+        EXPECT_TRUE(this->message.MessageOverrideBusy());
+    }
+
+    TEST_F(ReleasePendingReminderUserMessageTest, ItFlashesTheHandler)
+    {
+        EXPECT_TRUE(this->message.MessageFlashHandler());
+    }
+
+    TEST_F(ReleasePendingReminderUserMessageTest, ItRequiresConfirm)
+    {
+        EXPECT_TRUE(this->message.MessageRequiresConfirm());
+    }
+} // namespace UKControllerPluginTest::Releases


### PR DESCRIPTION
Fixes #600 

Turns out there already is away to acknowldge a release request I think.

This add, for now, a message to remind controllers after 1 min if they have not responded.

Wrote some unit tests, but not tested. Need to work something out for that 😆 