### PR TITLE
fix: Match OP button height with other buttons

### DIFF
--- a/src/plugin/radarscreen/ScreenControls.h
+++ b/src/plugin/radarscreen/ScreenControls.h
@@ -55,10 +55,10 @@ namespace UKControllerPlugin::RadarScreen {
         const int toggleboxIdEuroscope;
 
         // Height for each control
-        const int controlHeight = 25;
+        const int controlHeight = 22;
 
         // Width for each control
-        const int controlWidth = 25;
+        const int controlWidth = 22;
 
         // Title for the options
         const std::string menuName = "UKCP Options";

--- a/test/plugin/radarscreen/ScreenControlsTest.cpp
+++ b/test/plugin/radarscreen/ScreenControlsTest.cpp
@@ -42,7 +42,7 @@ namespace UKControllerPluginTest::RadarScreen {
         StrictMock<MockEuroscopeRadarScreenLoopbackInterface> mockRadar;
 
         RECT radarArea = {0, 0, 1024, 768};
-        RECT menuRect = {radarArea.right - 25, radarArea.bottom - 25, radarArea.right, radarArea.bottom};
+        RECT menuRect = {radarArea.right - 22, radarArea.bottom - 22, radarArea.right, radarArea.bottom};
 
         EXPECT_CALL(mockRadar, GetRadarViewport()).Times(1).WillOnce(Return(radarArea));
 
@@ -80,7 +80,7 @@ namespace UKControllerPluginTest::RadarScreen {
         StrictMock<MockEuroscopeRadarScreenLoopbackInterface> mockRadar;
 
         RECT radarArea = {0, 0, 1024, 768};
-        RECT menuRect = {radarArea.right - 25, radarArea.bottom - 25, radarArea.right, radarArea.bottom};
+        RECT menuRect = {radarArea.right - 22, radarArea.bottom - 22, radarArea.right, radarArea.bottom};
 
         EXPECT_CALL(mockRadar, GetRadarViewport()).Times(1).WillOnce(Return(radarArea));
 


### PR DESCRIPTION
fixes #559

@luke11brown we happy?

<img width="394" height="65" alt="image" src="https://github.com/user-attachments/assets/50bc8b88-303b-47c9-8fec-87417049ecb1" />
